### PR TITLE
[codex] add parity coverage and sidebar fixes

### DIFF
--- a/.changeset/recent-kumo-parity.md
+++ b/.changeset/recent-kumo-parity.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Port recent upstream Kumo banner, filtering, token, workflow, and peer dependency parity updates.

--- a/.changeset/sidebar-timeseries-parity.md
+++ b/.changeset/sidebar-timeseries-parity.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Port recent upstream parity updates for TimeseriesChart tooltips, Sidebar modernization, status color docs, and scoped clickable cursor affordances.

--- a/.changeset/silver-toys-walk.md
+++ b/.changeset/silver-toys-walk.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Add Svelte Vitest infrastructure and close Sidebar parity gaps for collapsed tooltips and mobile dialog behavior.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     permissions:
       id-token: write
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk') && !contains(github.event.comment.body, '/bigbonk')
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       id-token: write
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -42,15 +42,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Lil Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@8c7a8314f4f4865e2e41e5718dfabc4ab7a2274b # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5"
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: kumo
           mentions: "/bonk"
-          opencode_version: "1.4.6"
+          opencode_version: "1.15.11"
           permissions: write
           

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -80,4 +80,4 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm test:tools
+      - run: pnpm test

--- a/PARITY_OMISSIONS.md
+++ b/PARITY_OMISSIONS.md
@@ -1,0 +1,35 @@
+# Kumo Svelte Parity Omissions
+
+Last audited against `cloudflare/kumo` on 2026-05-30 for upstream commits on or after 2026-05-25.
+
+## Feature Omissions
+
+### TimeseriesChart native tooltip parity
+
+Upstream added a native tooltip model in `18f5e42` and docs fixes in `1eac3aa`. The Svelte `TimeseriesChart` still uses ECharts HTML tooltip formatting and does not expose the upstream `tooltipMode`, `tooltipMaxItems`, `tooltipBoundary`, or `tooltipFollowCursor` props. The Svelte docs also omit the upstream Tooltip Cursor Tracking and Tooltip Boundary demos.
+
+### Sidebar modernization
+
+Upstream `3db8294` substantially modernized Sidebar with contained provider behavior, peeking state, sliding view APIs, keyboard resize affordances, and updated demos. The Svelte Sidebar remains the older compact implementation and its docs still describe outdated concepts such as `GroupContent` and `Sidebar.Input`.
+
+### Status token docs and Badge color demo
+
+Upstream `9d4a2ff` refreshed semantic status token docs, added a `StatusBannerDemo`, added a semantic text contrast note, and removed the green badge from the color demo. The Svelte token values used by components have been updated where directly needed, but the colors page and badge demo still need the full docs/demo parity pass.
+
+### Clickable cursor scoping
+
+Upstream `351fac9` added base clickable affordances scoped to elements with Kumo-owned `data-kumo-component` or `data-kumo-part` attributes. The Svelte components do not currently emit that data-attribute contract, so the cursor rule was not ported yet.
+
+## Non-Applicable Upstream Changes
+
+### Opencode lockfile
+
+Upstream changed `.opencode/package-lock.json` as part of the Bonk/opencode bump. This repo does not have an `.opencode/` setup, so there is no local file to update unless that setup is adopted.
+
+### Upstream package versions and changelogs
+
+Upstream changelogs record `@cloudflare/kumo` `2.4.0` / `2.4.1` and docs `1.5.5` / `1.5.6`. `kumo-svelte` is independently versioned, so those version entries should not be copied directly.
+
+### Temporary backport workflows
+
+Upstream added and removed temporary backport release dispatch workflows on 2026-05-29. There is no net workflow parity target for this repo.

--- a/PARITY_OMISSIONS.md
+++ b/PARITY_OMISSIONS.md
@@ -27,7 +27,7 @@ Known Svelte difference:
 
 ### Sidebar
 
-Status: substantially ported, with one deliberate Svelte simplification remaining.
+Status: ported as closely as Svelte/bits-ui allows.
 
 Ported:
 
@@ -39,16 +39,14 @@ Ported:
 - Collapsible content remains mounted and now uses `aria-controls`, `role="region"`, `aria-hidden`, `inert`, and grid-row animation.
 - Sliding views remain mounted and inactive views are marked `aria-hidden` / `inert`.
 - Menu button and menu sub-button auto-wrapping now avoids nested `<li>` markup when consumers explicitly use `Sidebar.MenuItem` or `Sidebar.MenuSubItem`.
+- Collapsed `Sidebar.MenuButton` tooltips use the local Tooltip component and only expose tooltip content when the sidebar is collapsed and not peekable.
+- Mobile sidebar rendering now uses a dialog portal/overlay/content path for focus-trap, escape, modal, and portal semantics.
 - Resize handle tracks resizing state during pointer drag and supports keyboard resizing.
 - Docs now describe the current compound API and include peeking and sliding views demos.
 
-Remaining omission:
-
-- Collapsed `Sidebar.MenuButton` tooltips still use the native `title` attribute instead of the upstream Tooltip component behavior. This is functional but not at full visual/interaction parity.
-
 Known Svelte differences:
 
-- Mobile behavior is implemented as a Svelte sheet/backdrop path rather than the upstream React Dialog composition. It now covers the core mobile open/close behavior, but it does not yet provide the same focus-trap semantics as a dialog primitive.
+- Mobile behavior uses bits-ui Dialog primitives rather than upstream Base UI Dialog primitives.
 - Sliding views preserve mounted inactive panels and inert state, but they use Svelte-friendly per-panel transforms instead of upstream's indexed React child transform model.
 
 ### Status Token Docs And Badge Demo
@@ -66,16 +64,18 @@ No known remaining omissions for the upstream 2026-05-25 status docs and badge d
 
 ### Clickable Cursor Scoping
 
-Status: broadly ported; only lower-priority specialty controls remain to audit.
+Status: ported.
 
 Ported:
 
 - `styles.css` scopes pointer cursors to Kumo-owned interactive elements with `data-kumo-component` or `data-kumo-part`, excluding disabled states.
 - Data ownership attributes now cover the previously identified core components: Button, Link, Select trigger/options, AutocompleteItem, Combobox item/trigger/clear/chip controls, CollapsibleTrigger, PopoverTrigger fallback button, Toast close button, Sidebar controls, Checkbox, Radio, Switch, DropdownMenu items, Dialog triggers, Tabs triggers, MenuBar options, Breadcrumb links, TableOfContents items, and SensitiveInput masked/toggle/copy controls.
+- Date picker internals use the same `.rdp-*` cursor styling approach as upstream.
+- Pagination controls are covered by Kumo Button data attributes; native selects keep browser-native cursor behavior.
 
-Remaining omission:
+Known Svelte difference:
 
-- Date picker internals and pagination controls should still receive a dedicated follow-up audit for complete data-attribute coverage.
+- Pagination page-size and page-number native selects do not use upstream's React Select composition. This is a Svelte implementation difference rather than a cursor-scoping omission.
 
 ## Non-Applicable Upstream Changes
 
@@ -95,5 +95,8 @@ Upstream added and removed temporary backport release dispatch workflows on 2026
 
 After this parity pass:
 
+- `git -C /private/tmp/cloudflare-kumo-current fetch origin main` passed on 2026-05-31; `HEAD`, `origin/main`, and `FETCH_HEAD` are all `5ceace9`.
+- No upstream `main` commits exist after the previous 2026-05-30 audit. The newer Wizard work is only on `origin/feat/wizard-component`, not `main`.
+- `pnpm --filter kumo-svelte test` passed with 23 tests.
 - `pnpm --filter kumo-svelte check` passed with 0 errors and 0 warnings.
 - `pnpm --filter kumo-svelte build` passed.

--- a/PARITY_OMISSIONS.md
+++ b/PARITY_OMISSIONS.md
@@ -1,8 +1,8 @@
 # Kumo Svelte Parity Audit
 
-Last audited: 2026-05-30
+Last audited: 2026-05-31
 
-Compared against `cloudflare/kumo` at `/private/tmp/cloudflare-kumo-current` for upstream changes on or after 2026-05-25. This audit reflects the current `codex/may-30` worktree after the second parity pass.
+Compared against `cloudflare/kumo` at `/private/tmp/cloudflare-kumo-current` for upstream changes on or after 2026-05-25. This audit reflects the current `codex/may-30` worktree after the second parity pass and the follow-up docs/test parity gap cleanup.
 
 ## Current Parity Status
 
@@ -76,6 +76,22 @@ Ported:
 Known Svelte difference:
 
 - Pagination page-size and page-number native selects do not use upstream's React Select composition. This is a Svelte implementation difference rather than a cursor-scoping omission.
+
+### Docs Demo Coverage And Import Validation
+
+Status: follow-up gaps partially closed.
+
+Ported:
+
+- CodeHighlighted docs now include language variant and alias demos in addition to the existing TypeScript and copy-button examples.
+- Link docs now include a `plain` variant demo alongside inline/current/external examples.
+- Import validation now includes a deep import test for representative built component paths: `code-highlighted`, `link`, `select`, and `tooltip`.
+- Contributing docs now point at local `kumo-svelte` paths instead of upstream React package and docs-site paths.
+
+Remaining bounded follow-up:
+
+- Select and Tooltip have broad demo coverage, including grouped, disabled, long-list, label-tooltip, delay, multiple, follow-cursor, and boundary demos. No new edge demos were added in this pass because the straightforward high-value cases already existed.
+- No browser-test infrastructure was added. The existing Vitest import test layer covers the requested deep import validation without introducing new dependencies.
 
 ## Non-Applicable Upstream Changes
 

--- a/PARITY_OMISSIONS.md
+++ b/PARITY_OMISSIONS.md
@@ -1,35 +1,95 @@
-# Kumo Svelte Parity Omissions
+# Kumo Svelte Parity Audit
 
-Last audited against `cloudflare/kumo` on 2026-05-30 for upstream commits on or after 2026-05-25.
+Last audited: 2026-05-30
 
-## Feature Omissions
+Compared against `cloudflare/kumo` at `/private/tmp/cloudflare-kumo-current` for upstream changes on or after 2026-05-25. The local implementation baseline for this audit is commit `e9b87d8` on `codex/may-30`.
 
-### TimeseriesChart native tooltip parity
+## Current Parity Status
 
-Upstream added a native tooltip model in `18f5e42` and docs fixes in `1eac3aa`. The Svelte `TimeseriesChart` still uses ECharts HTML tooltip formatting and does not expose the upstream `tooltipMode`, `tooltipMaxItems`, `tooltipBoundary`, or `tooltipFollowCursor` props. The Svelte docs also omit the upstream Tooltip Cursor Tracking and Tooltip Boundary demos.
+### TimeseriesChart
 
-### Sidebar modernization
+Status: mostly ported, with one positioning caveat.
 
-Upstream `3db8294` substantially modernized Sidebar with contained provider behavior, peeking state, sliding view APIs, keyboard resize affordances, and updated demos. The Svelte Sidebar remains the older compact implementation and its docs still describe outdated concepts such as `GroupContent` and `Sidebar.Input`.
+Ported:
 
-### Status token docs and Badge color demo
+- Native tooltip rendering now replaces ECharts HTML tooltip content.
+- `tooltipMode`, `tooltipMaxItems`, `tooltipBoundary`, and `tooltipFollowCursor` are exposed on `TimeseriesChart`.
+- Tooltip rows are derived from nearest timestamp values, sorted by value, and support single-series mode.
+- Time range brush cursor cleanup is handled when the selection effect is torn down.
+- Docs now include Tooltip Cursor Tracking and Tooltip Boundary examples.
+- Props metadata includes the new tooltip props.
 
-Upstream `9d4a2ff` refreshed semantic status token docs, added a `StatusBannerDemo`, added a semantic text contrast note, and removed the green badge from the color demo. The Svelte token values used by components have been updated where directly needed, but the colors page and badge demo still need the full docs/demo parity pass.
+Remaining omission:
 
-### Clickable cursor scoping
+- Upstream uses Base UI positioning for `tooltipBoundary`, including actual `Element` / `Element[]` boundaries and portal-style collision behavior. The Svelte port clamps to the chart container when a boundary is provided, so element-specific boundary semantics are approximate.
 
-Upstream `351fac9` added base clickable affordances scoped to elements with Kumo-owned `data-kumo-component` or `data-kumo-part` attributes. The Svelte components do not currently emit that data-attribute contract, so the cursor rule was not ported yet.
+### Sidebar
+
+Status: modern API surface ported, advanced behavior still incomplete.
+
+Ported:
+
+- Compound exports now include `Provider`, `Header`, `Content`, `Footer`, `Group`, `GroupLabel`, `Menu`, `MenuItem`, `MenuButton`, `MenuBadge`, `MenuSub`, `MenuSubItem`, `MenuSubButton`, `Separator`, `Trigger`, `Rail`, `ResizeHandle`, `MenuChevron`, `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`, `SlidingViews`, and `SlidingView`.
+- Provider supports contained layouts, peeking, animation duration, resizable widths, side, variant, and collapsible mode props.
+- Root Sidebar supports collapsed/icon rail width, peeking width, variants, side, and provider state data attributes.
+- Resize handle supports pointer drag and keyboard resizing.
+- Docs now describe the current compound API instead of stale `Sidebar.Input` / `GroupContent` concepts.
+- Docs now include peeking and sliding views demos.
+- Registry output includes the expanded Sidebar component surface.
+
+Remaining omissions:
+
+- Mobile sheet/dialog behavior from upstream is not implemented. The Svelte Sidebar currently renders the desktop aside path at all breakpoints.
+- `collapsible="none"` still needs a stricter non-collapsible path that ignores collapsed width calculations.
+- Footer content is still inside the peek hover/focus zone instead of being separated from the peeking content area.
+- Collapsible content should keep inactive content mounted and add stronger `aria-controls`, `role="region"`, `aria-hidden`, and `inert` semantics.
+- Sliding views should preserve inactive panels with inert/aria-hidden state instead of rendering only the active panel.
+- Menu button auto-wrapping should avoid nested list markup when consumers explicitly use `Sidebar.MenuItem` or `Sidebar.MenuSubItem`.
+- Collapsed menu tooltips currently use the native `title` attribute rather than the upstream tooltip component behavior.
+
+### Status Token Docs And Badge Demo
+
+Status: ported.
+
+Ported:
+
+- Colors docs now include the rendered status banner example.
+- Status token copy now calls out paired semantic status text and tinted backgrounds.
+- `StatusBannerDemo` exists in the Svelte docs snippets.
+- The green badge has been removed from the color variant demo to match upstream.
+
+No known remaining omissions for the upstream 2026-05-25 status docs and badge demo changes.
+
+### Clickable Cursor Scoping
+
+Status: base behavior ported, coverage still partial.
+
+Ported:
+
+- `styles.css` now scopes pointer cursors to Kumo-owned interactive elements with `data-kumo-component` or `data-kumo-part`, excluding disabled states.
+- High-priority interactive components now emit Kumo ownership data attributes, including Button, Link, Select trigger/options, AutocompleteItem, ComboboxItem, CollapsibleTrigger, PopoverTrigger fallback button, Toast close button, and new Sidebar controls.
+
+Remaining omission:
+
+- A full component-by-component data attribute rollout remains incomplete. Components that should still be audited include checkbox, radio, switch, dropdown/menu items, pagination controls, date picker internals, and any other owned interactive controls relying only on local cursor utility classes.
 
 ## Non-Applicable Upstream Changes
 
-### Opencode lockfile
+### Opencode Lockfile
 
 Upstream changed `.opencode/package-lock.json` as part of the Bonk/opencode bump. This repo does not have an `.opencode/` setup, so there is no local file to update unless that setup is adopted.
 
-### Upstream package versions and changelogs
+### Upstream Package Versions And Changelogs
 
 Upstream changelogs record `@cloudflare/kumo` `2.4.0` / `2.4.1` and docs `1.5.5` / `1.5.6`. `kumo-svelte` is independently versioned, so those version entries should not be copied directly.
 
-### Temporary backport workflows
+### Temporary Backport Workflows
 
 Upstream added and removed temporary backport release dispatch workflows on 2026-05-29. There is no net workflow parity target for this repo.
+
+## Verification
+
+After the implementation commit:
+
+- `pnpm --filter kumo-svelte check` passed with 0 errors and 0 warnings.
+- `pnpm --filter kumo-svelte build` passed.

--- a/PARITY_OMISSIONS.md
+++ b/PARITY_OMISSIONS.md
@@ -2,50 +2,54 @@
 
 Last audited: 2026-05-30
 
-Compared against `cloudflare/kumo` at `/private/tmp/cloudflare-kumo-current` for upstream changes on or after 2026-05-25. The local implementation baseline for this audit is commit `e9b87d8` on `codex/may-30`.
+Compared against `cloudflare/kumo` at `/private/tmp/cloudflare-kumo-current` for upstream changes on or after 2026-05-25. This audit reflects the current `codex/may-30` worktree after the second parity pass.
 
 ## Current Parity Status
 
 ### TimeseriesChart
 
-Status: mostly ported, with one positioning caveat.
+Status: ported as closely as Svelte/bits-ui allows.
 
 Ported:
 
-- Native tooltip rendering now replaces ECharts HTML tooltip content.
+- Native tooltip rendering replaces ECharts HTML tooltip content.
 - `tooltipMode`, `tooltipMaxItems`, `tooltipBoundary`, and `tooltipFollowCursor` are exposed on `TimeseriesChart`.
 - Tooltip rows are derived from nearest timestamp values, sorted by value, and support single-series mode.
 - Time range brush cursor cleanup is handled when the selection effect is torn down.
-- Docs now include Tooltip Cursor Tracking and Tooltip Boundary examples.
-- Props metadata includes the new tooltip props.
+- Tooltip placement now uses `bits-ui` floating tooltip positioning with `customAnchor`, collision handling, fixed strategy, and `updatePositionStrategy="always"`.
+- `Element` and `Element[]` tooltip boundaries are passed through as collision boundaries; the upstream `"clipping-ancestors"` value maps to bits-ui default clipping behavior.
+- The Tooltip Boundary demo now passes an actual bound wrapper element.
+- Docs and props metadata include the new tooltip props and examples.
 
-Remaining omission:
+Known Svelte difference:
 
-- Upstream uses Base UI positioning for `tooltipBoundary`, including actual `Element` / `Element[]` boundaries and portal-style collision behavior. The Svelte port clamps to the chart container when a boundary is provided, so element-specific boundary semantics are approximate.
+- Upstream uses Base UI; the Svelte port uses bits-ui. The public behavior is aligned, but internals and exact collision edge cases may differ by floating-positioning implementation.
 
 ### Sidebar
 
-Status: modern API surface ported, advanced behavior still incomplete.
+Status: substantially ported, with one deliberate Svelte simplification remaining.
 
 Ported:
 
-- Compound exports now include `Provider`, `Header`, `Content`, `Footer`, `Group`, `GroupLabel`, `Menu`, `MenuItem`, `MenuButton`, `MenuBadge`, `MenuSub`, `MenuSubItem`, `MenuSubButton`, `Separator`, `Trigger`, `Rail`, `ResizeHandle`, `MenuChevron`, `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`, `SlidingViews`, and `SlidingView`.
-- Provider supports contained layouts, peeking, animation duration, resizable widths, side, variant, and collapsible mode props.
-- Root Sidebar supports collapsed/icon rail width, peeking width, variants, side, and provider state data attributes.
-- Resize handle supports pointer drag and keyboard resizing.
-- Docs now describe the current compound API instead of stale `Sidebar.Input` / `GroupContent` concepts.
-- Docs now include peeking and sliding views demos.
-- Registry output includes the expanded Sidebar component surface.
+- Compound exports include the modern Sidebar surface: `Provider`, `Header`, `Content`, `Footer`, `Group`, `GroupLabel`, `Menu`, `MenuItem`, `MenuButton`, `MenuBadge`, `MenuSub`, `MenuSubItem`, `MenuSubButton`, `Separator`, `Trigger`, `Rail`, `ResizeHandle`, `MenuChevron`, `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`, `SlidingViews`, and `SlidingView`.
+- Provider supports contained layouts, peeking, animation duration, resizable widths, side, variant, collapsible mode, mobile state, mobile open state, and resize state.
+- Root Sidebar supports collapsed/icon rail width, peeking width, side-aware mobile sheet rendering, variants, and provider state data attributes.
+- `collapsible="none"` now remains visually expanded instead of using collapsed width calculations.
+- Peeking is scoped to content instead of wrapping all sidebar children, so footer content no longer starts peeking.
+- Collapsible content remains mounted and now uses `aria-controls`, `role="region"`, `aria-hidden`, `inert`, and grid-row animation.
+- Sliding views remain mounted and inactive views are marked `aria-hidden` / `inert`.
+- Menu button and menu sub-button auto-wrapping now avoids nested `<li>` markup when consumers explicitly use `Sidebar.MenuItem` or `Sidebar.MenuSubItem`.
+- Resize handle tracks resizing state during pointer drag and supports keyboard resizing.
+- Docs now describe the current compound API and include peeking and sliding views demos.
 
-Remaining omissions:
+Remaining omission:
 
-- Mobile sheet/dialog behavior from upstream is not implemented. The Svelte Sidebar currently renders the desktop aside path at all breakpoints.
-- `collapsible="none"` still needs a stricter non-collapsible path that ignores collapsed width calculations.
-- Footer content is still inside the peek hover/focus zone instead of being separated from the peeking content area.
-- Collapsible content should keep inactive content mounted and add stronger `aria-controls`, `role="region"`, `aria-hidden`, and `inert` semantics.
-- Sliding views should preserve inactive panels with inert/aria-hidden state instead of rendering only the active panel.
-- Menu button auto-wrapping should avoid nested list markup when consumers explicitly use `Sidebar.MenuItem` or `Sidebar.MenuSubItem`.
-- Collapsed menu tooltips currently use the native `title` attribute rather than the upstream tooltip component behavior.
+- Collapsed `Sidebar.MenuButton` tooltips still use the native `title` attribute instead of the upstream Tooltip component behavior. This is functional but not at full visual/interaction parity.
+
+Known Svelte differences:
+
+- Mobile behavior is implemented as a Svelte sheet/backdrop path rather than the upstream React Dialog composition. It now covers the core mobile open/close behavior, but it does not yet provide the same focus-trap semantics as a dialog primitive.
+- Sliding views preserve mounted inactive panels and inert state, but they use Svelte-friendly per-panel transforms instead of upstream's indexed React child transform model.
 
 ### Status Token Docs And Badge Demo
 
@@ -53,8 +57,8 @@ Status: ported.
 
 Ported:
 
-- Colors docs now include the rendered status banner example.
-- Status token copy now calls out paired semantic status text and tinted backgrounds.
+- Colors docs include the rendered status banner example.
+- Status token copy calls out paired semantic status text and tinted backgrounds.
 - `StatusBannerDemo` exists in the Svelte docs snippets.
 - The green badge has been removed from the color variant demo to match upstream.
 
@@ -62,16 +66,16 @@ No known remaining omissions for the upstream 2026-05-25 status docs and badge d
 
 ### Clickable Cursor Scoping
 
-Status: base behavior ported, coverage still partial.
+Status: broadly ported; only lower-priority specialty controls remain to audit.
 
 Ported:
 
-- `styles.css` now scopes pointer cursors to Kumo-owned interactive elements with `data-kumo-component` or `data-kumo-part`, excluding disabled states.
-- High-priority interactive components now emit Kumo ownership data attributes, including Button, Link, Select trigger/options, AutocompleteItem, ComboboxItem, CollapsibleTrigger, PopoverTrigger fallback button, Toast close button, and new Sidebar controls.
+- `styles.css` scopes pointer cursors to Kumo-owned interactive elements with `data-kumo-component` or `data-kumo-part`, excluding disabled states.
+- Data ownership attributes now cover the previously identified core components: Button, Link, Select trigger/options, AutocompleteItem, Combobox item/trigger/clear/chip controls, CollapsibleTrigger, PopoverTrigger fallback button, Toast close button, Sidebar controls, Checkbox, Radio, Switch, DropdownMenu items, Dialog triggers, Tabs triggers, MenuBar options, Breadcrumb links, TableOfContents items, and SensitiveInput masked/toggle/copy controls.
 
 Remaining omission:
 
-- A full component-by-component data attribute rollout remains incomplete. Components that should still be audited include checkbox, radio, switch, dropdown/menu items, pagination controls, date picker internals, and any other owned interactive controls relying only on local cursor utility classes.
+- Date picker internals and pagination controls should still receive a dedicated follow-up audit for complete data-attribute coverage.
 
 ## Non-Applicable Upstream Changes
 
@@ -89,7 +93,7 @@ Upstream added and removed temporary backport release dispatch workflows on 2026
 
 ## Verification
 
-After the implementation commit:
+After this parity pass:
 
 - `pnpm --filter kumo-svelte check` passed with 0 errors and 0 warnings.
 - `pnpm --filter kumo-svelte build` passed.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "publish:beta": "bash ci/versioning/publish-beta.sh",
     "release": "pnpm build:all && changeset publish",
     "release:beta": "changeset publish --no-git-tag --tag beta",
+    "test": "pnpm --filter kumo-svelte test && pnpm test:tools",
     "typecheck": "pnpm --filter kumo-svelte typecheck",
     "version": "changeset version",
     "version:beta": "bash ci/versioning/version-beta.sh",

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -4084,6 +4084,7 @@
         }
       },
       "colors": [
+        "bg-kumo-base",
         "bg-kumo-brand",
         "bg-kumo-hairline",
         "bg-kumo-line",

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.6",
+  "version": "0.1.7",
   "components": {
     "Autocomplete": {
       "name": "Autocomplete",
@@ -340,6 +340,7 @@
         "bg-kumo-danger-tint",
         "bg-kumo-fill",
         "bg-kumo-info-tint",
+        "bg-kumo-success",
         "bg-kumo-success-tint",
         "bg-kumo-warning-tint",
         "border-kumo-brand",
@@ -412,14 +413,13 @@
         }
       },
       "colors": [
+        "bg-kumo-banner-info",
+        "bg-kumo-banner-warning",
+        "bg-kumo-contrast",
         "bg-kumo-danger-tint",
-        "bg-kumo-info-tint",
-        "bg-kumo-warning-tint",
-        "border-kumo-danger",
-        "border-kumo-info",
-        "border-kumo-warning",
         "text-kumo-danger",
         "text-kumo-info",
+        "text-kumo-subtle",
         "text-kumo-warning"
       ]
     },

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -4035,7 +4035,7 @@
       "name": "Sidebar",
       "type": "component",
       "category": "Navigation",
-      "description": "A composable sidebar navigation component with collapsible groups, icon-only mode, and responsive mobile support.",
+      "description": "A composable sidebar navigation component with contained layouts, peeking, sliding views, resizing, icon-only mode, and responsive mobile support.",
       "importPath": "kumo-svelte/components/sidebar",
       "sourceFile": "components/sidebar",
       "props": {
@@ -4084,11 +4084,16 @@
         }
       },
       "colors": [
-        "bg-kumo-fill",
-        "bg-kumo-surface",
+        "bg-kumo-brand",
+        "bg-kumo-hairline",
+        "bg-kumo-line",
+        "bg-kumo-recessed",
         "bg-kumo-tint",
         "border-kumo-line",
-        "text-kumo-default"
+        "ring-kumo-brand",
+        "text-kumo-default",
+        "text-kumo-strong",
+        "text-kumo-subtle"
       ],
       "subComponents": {
         "Input": {
@@ -4268,6 +4273,24 @@
               "type": "(width: number) => void",
               "optional": true,
               "description": "Callback when width changes during resize."
+            },
+            "contained": {
+              "type": "boolean",
+              "optional": true,
+              "default": "false",
+              "description": "Keeps the provider scoped to its parent container instead of using full viewport height."
+            },
+            "peekable": {
+              "type": "boolean",
+              "optional": true,
+              "default": "false",
+              "description": "Allows collapsed sidebars to temporarily reveal full content while hovered or focused."
+            },
+            "animationDuration": {
+              "type": "number",
+              "optional": true,
+              "default": "250",
+              "description": "Transition duration in milliseconds for width and peek animations."
             },
             "children": {
               "type": "Snippet",

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -2592,6 +2592,8 @@
       },
       "colors": [
         "bg-kumo-base",
+        "bg-kumo-fill",
+        "bg-kumo-hairline",
         "ring-kumo-line",
         "text-kumo-inactive"
       ],

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -9,16 +9,6 @@
       "importPath": "kumo-svelte/components/autocomplete",
       "sourceFile": "components/autocomplete",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
         "items": {
           "type": "unknown[]",
           "optional": false,
@@ -30,21 +20,31 @@
           "optional": true,
           "description": "Controlled input value."
         },
-        "defaultValue": {
-          "type": "string | number | string[]",
-          "optional": true,
-          "description": "Uncontrolled default input value."
-        },
         "open": {
           "type": "boolean",
           "optional": true,
           "default": "false",
           "description": "Controlled open state."
         },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
         "label": {
           "type": "string | Snippet",
           "optional": true,
           "description": "Visible label content."
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Marks the field as required."
         },
         "labelTooltip": {
           "type": "string | Snippet",
@@ -61,10 +61,10 @@
           "optional": true,
           "description": "Validation error message or matcher."
         },
-        "required": {
-          "type": "boolean",
+        "defaultValue": {
+          "type": "string | number | string[]",
           "optional": true,
-          "description": "Marks the field as required."
+          "description": "Uncontrolled default input value."
         },
         "onValueChange": {
           "type": "(value: string | number | string[]) => void",
@@ -200,11 +200,6 @@
               "optional": true,
               "description": "Additional classes merged onto the root element."
             },
-            "placeholder": {
-              "type": "string",
-              "optional": true,
-              "description": "Placeholder text."
-            },
             "size": {
               "type": "enum",
               "optional": true,
@@ -216,6 +211,11 @@
               ],
               "default": "base",
               "description": "Size of the autocomplete input. Matches Input component sizes."
+            },
+            "placeholder": {
+              "type": "string",
+              "optional": true,
+              "description": "Placeholder text."
             }
           }
         },
@@ -525,32 +525,6 @@
       "importPath": "kumo-svelte/components/button",
       "sourceFile": "components/button",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "icon": {
-          "type": "Component",
-          "optional": true,
-          "description": "Icon rendered by the component."
-        },
-        "loading": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Loading state."
-        },
-        "title": {
-          "type": "string",
-          "optional": true,
-          "description": "Tooltip content shown when hovering the button."
-        },
         "shape": {
           "type": "enum",
           "optional": true,
@@ -587,6 +561,32 @@
           ],
           "default": "secondary",
           "description": "Visual variant."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
+        "icon": {
+          "type": "Component",
+          "optional": true,
+          "description": "Icon rendered by the component."
+        },
+        "loading": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Loading state."
+        },
+        "title": {
+          "type": "string",
+          "optional": true,
+          "description": "Tooltip content shown when hovering the button."
         },
         "disabled": {
           "type": "boolean",
@@ -703,34 +703,6 @@
       "importPath": "kumo-svelte/components/checkbox",
       "sourceFile": "components/checkbox",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "checked": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Checked state."
-        },
-        "indeterminate": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Indeterminate checked state."
-        },
-        "disabled": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Disables the component."
-        },
         "variant": {
           "type": "enum",
           "optional": true,
@@ -757,15 +729,38 @@
           "default": "true",
           "description": "Renders the control before label content."
         },
-        "required": {
+        "checked": {
           "type": "boolean",
           "optional": true,
-          "description": "Marks the field as required."
+          "default": "false",
+          "description": "Checked state."
+        },
+        "indeterminate": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Indeterminate checked state."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Disables the component."
         },
         "name": {
           "type": "string",
           "optional": true,
           "description": "Form field name."
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Marks the field as required."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
         },
         "value": {
           "type": "string",
@@ -796,6 +791,11 @@
           "type": "(indeterminate: boolean) => void",
           "optional": true,
           "description": "Called when indeterminate changes."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
         }
       },
       "colors": [
@@ -815,25 +815,20 @@
         "Group": {
           "description": "Checkbox.Group",
           "props": {
-            "children": {
-              "type": "Snippet",
-              "optional": true,
-              "description": "Child snippet rendered by the component."
-            },
             "legend": {
               "type": "string",
               "optional": true,
               "description": "legend prop."
             },
-            "description": {
-              "type": "string | Snippet",
-              "optional": true,
-              "description": "Supporting description text."
-            },
             "error": {
               "type": "string",
               "optional": true,
               "description": "Validation error message or matcher."
+            },
+            "description": {
+              "type": "string | Snippet",
+              "optional": true,
+              "description": "Supporting description text."
             },
             "value": {
               "type": "string[]",
@@ -847,16 +842,6 @@
               "default": "false",
               "description": "Disables the component."
             },
-            "required": {
-              "type": "boolean",
-              "optional": true,
-              "description": "Marks the field as required."
-            },
-            "name": {
-              "type": "string",
-              "optional": true,
-              "description": "Form field name."
-            },
             "controlFirst": {
               "type": "boolean",
               "optional": true,
@@ -868,10 +853,25 @@
               "optional": true,
               "description": "Additional classes merged onto the root element."
             },
+            "required": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Marks the field as required."
+            },
+            "name": {
+              "type": "string",
+              "optional": true,
+              "description": "Form field name."
+            },
             "onValueChange": {
               "type": "(value: string[]) => void",
               "optional": true,
               "description": "Called when the value changes."
+            },
+            "children": {
+              "type": "Snippet",
+              "optional": true,
+              "description": "Child snippet rendered by the component."
             }
           }
         },
@@ -963,10 +963,16 @@
       "importPath": "kumo-svelte/components/clipboard-text",
       "sourceFile": "components/clipboard-text",
       "props": {
-        "class": {
-          "type": "string",
+        "size": {
+          "type": "enum",
           "optional": true,
-          "description": "Additional classes merged onto the root element."
+          "values": [
+            "sm",
+            "base",
+            "lg"
+          ],
+          "default": "lg",
+          "description": "Size preset."
         },
         "text": {
           "type": "string",
@@ -979,21 +985,10 @@
           "optional": true,
           "description": "Alternate text copied to the clipboard."
         },
-        "size": {
-          "type": "enum",
+        "class": {
+          "type": "string",
           "optional": true,
-          "values": [
-            "sm",
-            "base",
-            "lg"
-          ],
-          "default": "lg",
-          "description": "Size preset."
-        },
-        "onCopy": {
-          "type": "() => void",
-          "optional": true,
-          "description": "Called after copying succeeds."
+          "description": "Additional classes merged onto the root element."
         },
         "tooltip": {
           "type": "{ text?: string; copiedText?: string; side?: TooltipSide; }",
@@ -1004,6 +999,11 @@
           "type": "{ copyAction?: string; }",
           "optional": true,
           "description": "Accessible labels for internationalization."
+        },
+        "onCopy": {
+          "type": "() => void",
+          "optional": true,
+          "description": "Called after copying succeeds."
         }
       },
       "colors": [
@@ -1307,16 +1307,6 @@
         "Root": {
           "description": "Collapsible.Root",
           "props": {
-            "children": {
-              "type": "Snippet",
-              "optional": true,
-              "description": "Child snippet rendered by the component."
-            },
-            "class": {
-              "type": "string",
-              "optional": true,
-              "description": "Additional classes merged onto the root element."
-            },
             "open": {
               "type": "boolean",
               "optional": true,
@@ -1328,21 +1318,31 @@
               "default": "false",
               "description": "Initial uncontrolled open state."
             },
+            "onOpenChange": {
+              "type": "(open: boolean) => void",
+              "optional": true,
+              "description": "Called when open state changes."
+            },
             "disabled": {
               "type": "boolean",
               "optional": true,
               "default": "false",
               "description": "Disables the component."
             },
-            "onOpenChange": {
-              "type": "(open: boolean) => void",
-              "optional": true,
-              "description": "Called when open state changes."
-            },
             "onOpenChangeComplete": {
               "type": "(open: boolean) => void",
               "optional": true,
               "description": "Called after the open-state transition completes."
+            },
+            "children": {
+              "type": "Snippet",
+              "optional": true,
+              "description": "Child snippet rendered by the component."
+            },
+            "class": {
+              "type": "string",
+              "optional": true,
+              "description": "Additional classes merged onto the root element."
             }
           }
         },
@@ -1388,33 +1388,6 @@
       "importPath": "kumo-svelte/components/combobox",
       "sourceFile": "components/combobox",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "items": {
-          "type": "unknown[]",
-          "optional": false,
-          "required": true,
-          "description": "Array of items to display in the dropdown."
-        },
-        "value": {
-          "type": "unknown",
-          "optional": true,
-          "description": "Controlled value."
-        },
-        "multiple": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Enables multiple selection."
-        },
         "size": {
           "type": "enum",
           "optional": true,
@@ -1427,10 +1400,36 @@
           "default": "base",
           "description": "Size preset."
         },
+        "items": {
+          "type": "unknown[]",
+          "optional": false,
+          "required": true,
+          "description": "Array of items to display in the dropdown."
+        },
+        "value": {
+          "type": "unknown",
+          "optional": true,
+          "description": "Controlled value."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
         "label": {
           "type": "string | Snippet",
           "optional": true,
           "description": "Visible label content."
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Marks the field as required."
         },
         "labelTooltip": {
           "type": "string | Snippet",
@@ -1447,15 +1446,16 @@
           "optional": true,
           "description": "Validation error message or matcher."
         },
-        "required": {
-          "type": "boolean",
-          "optional": true,
-          "description": "Marks the field as required."
-        },
         "onValueChange": {
           "type": "(value: unknown) => void",
           "optional": true,
           "description": "Called when the value changes."
+        },
+        "multiple": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Enables multiple selection."
         },
         "onOpenChange": {
           "type": "(open: boolean) => void",
@@ -2021,6 +2021,23 @@
       "importPath": "kumo-svelte/components/dialog",
       "sourceFile": "components/dialog",
       "props": {
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the dialog content."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": false,
+          "required": true,
+          "description": "Dialog content, typically title, description, close, and action buttons."
+        },
+        "container": {
+          "type": "HTMLElement | string",
+          "optional": true,
+          "default": "document.body",
+          "description": "Portal container for custom roots or Shadow DOM."
+        },
         "size": {
           "type": "enum",
           "optional": true,
@@ -2033,27 +2050,10 @@
           "default": "base",
           "description": "Dialog width preset."
         },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the dialog content."
-        },
-        "children": {
-          "type": "Snippet",
-          "optional": false,
-          "required": true,
-          "description": "Dialog content, typically title, description, close, and action buttons."
-        },
         "style": {
           "type": "string",
           "optional": true,
           "description": "Inline styles for the dialog content."
-        },
-        "container": {
-          "type": "HTMLElement | string",
-          "optional": true,
-          "default": "document.body",
-          "description": "Portal container for custom roots or Shadow DOM."
         }
       },
       "colors": [
@@ -2263,32 +2263,15 @@
         "Item": {
           "description": "DropdownMenu.Item",
           "props": {
-            "children": {
-              "type": "Snippet",
-              "optional": true,
-              "description": "Child snippet rendered by the component."
-            },
-            "class": {
+            "href": {
               "type": "string",
               "optional": true,
-              "description": "Additional classes merged onto the root element."
-            },
-            "inset": {
-              "type": "boolean",
-              "optional": true,
-              "default": "false",
-              "description": "Indents the item content."
+              "description": "Deprecated destination URL for legacy link items."
             },
             "icon": {
               "type": "Component",
               "optional": true,
               "description": "Icon rendered by the component."
-            },
-            "selected": {
-              "type": "boolean",
-              "optional": true,
-              "default": "false",
-              "description": "Shows a trailing selected check indicator."
             },
             "variant": {
               "type": "enum",
@@ -2300,21 +2283,23 @@
               "default": "default",
               "description": "Visual variant."
             },
-            "href": {
-              "type": "string",
+            "selected": {
+              "type": "boolean",
               "optional": true,
-              "description": "Deprecated destination URL for legacy link items."
+              "default": "false",
+              "description": "Shows a trailing selected check indicator."
+            },
+            "inset": {
+              "type": "boolean",
+              "optional": true,
+              "default": "false",
+              "description": "Indents the item content."
             },
             "disabled": {
               "type": "boolean",
               "optional": true,
               "description": "Disables the component."
-            }
-          }
-        },
-        "RadioItem": {
-          "description": "DropdownMenu.RadioItem",
-          "props": {
+            },
             "children": {
               "type": "Snippet",
               "optional": true,
@@ -2324,6 +2309,22 @@
               "type": "string",
               "optional": true,
               "description": "Additional classes merged onto the root element."
+            }
+          }
+        },
+        "RadioItem": {
+          "description": "DropdownMenu.RadioItem",
+          "props": {
+            "value": {
+              "type": "string",
+              "optional": false,
+              "required": true,
+              "description": "Controlled value."
+            },
+            "icon": {
+              "type": "Component",
+              "optional": true,
+              "description": "Icon rendered by the component."
             },
             "inset": {
               "type": "boolean",
@@ -2331,16 +2332,15 @@
               "default": "false",
               "description": "Indents the item content."
             },
-            "icon": {
-              "type": "Component",
+            "children": {
+              "type": "Snippet",
               "optional": true,
-              "description": "Icon rendered by the component."
+              "description": "Child snippet rendered by the component."
             },
-            "value": {
+            "class": {
               "type": "string",
-              "optional": false,
-              "required": true,
-              "description": "Controlled value."
+              "optional": true,
+              "description": "Additional classes merged onto the root element."
             }
           }
         },
@@ -2420,6 +2420,17 @@
         "SubTrigger": {
           "description": "DropdownMenu.SubTrigger",
           "props": {
+            "icon": {
+              "type": "Component",
+              "optional": true,
+              "description": "Icon rendered by the component."
+            },
+            "inset": {
+              "type": "boolean",
+              "optional": true,
+              "default": "false",
+              "description": "Indents the item content."
+            },
             "children": {
               "type": "Snippet",
               "optional": true,
@@ -2429,17 +2440,6 @@
               "type": "string",
               "optional": true,
               "description": "Additional classes merged onto the root element."
-            },
-            "inset": {
-              "type": "boolean",
-              "optional": true,
-              "default": "false",
-              "description": "Indents the item content."
-            },
-            "icon": {
-              "type": "Component",
-              "optional": true,
-              "description": "Icon rendered by the component."
             }
           }
         },
@@ -2495,16 +2495,6 @@
           "default": "base",
           "description": "Size preset."
         },
-        "contents": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Custom empty-state content."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
         "icon": {
           "type": "Snippet",
           "optional": true,
@@ -2525,6 +2515,16 @@
           "type": "string",
           "optional": true,
           "description": "Shell command displayed in a copyable code block."
+        },
+        "contents": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Custom empty-state content."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
         }
       },
       "colors": [
@@ -2693,6 +2693,21 @@
       "importPath": "kumo-svelte/components/grid",
       "sourceFile": "components/grid",
       "props": {
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Grid items to render."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
+        "mobileDivider": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Show dividers between grid items on mobile. Only applies with the 4up variant."
+        },
         "gap": {
           "type": "enum",
           "optional": true,
@@ -2720,21 +2735,6 @@
             "1-2-4up"
           ],
           "description": "Responsive column layout variant."
-        },
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Grid items to render."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "mobileDivider": {
-          "type": "boolean",
-          "optional": true,
-          "description": "Show dividers between grid items on mobile. Only applies with the 4up variant."
         }
       },
       "colors": [
@@ -2766,10 +2766,25 @@
       "importPath": "kumo-svelte/components/input",
       "sourceFile": "components/input",
       "props": {
-        "class": {
-          "type": "string",
+        "label": {
+          "type": "string | Snippet",
           "optional": true,
-          "description": "Additional classes merged onto the root element."
+          "description": "Visible label content."
+        },
+        "labelTooltip": {
+          "type": "string | Snippet",
+          "optional": true,
+          "description": "Optional help content for the label."
+        },
+        "description": {
+          "type": "string | Snippet",
+          "optional": true,
+          "description": "Supporting description text."
+        },
+        "error": {
+          "type": "FieldError",
+          "optional": true,
+          "description": "Validation error message or matcher."
         },
         "size": {
           "type": "enum",
@@ -2793,25 +2808,10 @@
           "default": "default",
           "description": "Visual variant."
         },
-        "label": {
-          "type": "string | Snippet",
+        "class": {
+          "type": "string",
           "optional": true,
-          "description": "Visible label content."
-        },
-        "labelTooltip": {
-          "type": "string | Snippet",
-          "optional": true,
-          "description": "Optional help content for the label."
-        },
-        "description": {
-          "type": "string | Snippet",
-          "optional": true,
-          "description": "Supporting description text."
-        },
-        "error": {
-          "type": "FieldError",
-          "optional": true,
-          "description": "Validation error message or matcher."
+          "description": "Additional classes merged onto the root element."
         },
         "passwordManagerIgnore": {
           "type": "boolean",
@@ -2923,49 +2923,10 @@
       "importPath": "kumo-svelte/components/input-group",
       "sourceFile": "components/input-group",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "size": {
-          "type": "enum",
-          "optional": true,
-          "values": [
-            "xs",
-            "sm",
-            "base",
-            "lg"
-          ],
-          "default": "base",
-          "description": "Size preset."
-        },
-        "focusMode": {
-          "type": "InputGroupFocusMode",
-          "optional": true,
-          "default": "container",
-          "description": "focusMode prop."
-        },
-        "disabled": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Disables the component."
-        },
         "label": {
           "type": "string | Snippet",
           "optional": true,
           "description": "Visible label content."
-        },
-        "labelTooltip": {
-          "type": "string | Snippet",
-          "optional": true,
-          "description": "Optional help content for the label."
         },
         "description": {
           "type": "string",
@@ -2982,15 +2943,55 @@
           "optional": true,
           "description": "Marks the field as required."
         },
+        "labelTooltip": {
+          "type": "string | Snippet",
+          "optional": true,
+          "description": "Optional help content for the label."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
         "id": {
           "type": "string",
           "optional": true,
           "description": "Element id."
+        },
+        "size": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "xs",
+            "sm",
+            "base",
+            "lg"
+          ],
+          "default": "base",
+          "description": "Size preset."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Disables the component."
+        },
+        "focusMode": {
+          "type": "InputGroupFocusMode",
+          "optional": true,
+          "default": "container",
+          "description": "focusMode prop."
         }
       },
       "colors": [
         "bg-kumo-control",
         "bg-kumo-overlay",
+        "border-kumo-focus",
         "border-kumo-line",
         "ring-kumo-danger",
         "ring-kumo-focus",
@@ -3017,16 +3018,6 @@
           "required": true,
           "description": "The label content."
         },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "htmlFor": {
-          "type": "string",
-          "optional": true,
-          "description": "The id of the form element this label is associated with."
-        },
         "showOptional": {
           "type": "boolean",
           "optional": true,
@@ -3037,6 +3028,16 @@
           "type": "string | Snippet",
           "optional": true,
           "description": "Tooltip content displayed next to the label."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
+        "htmlFor": {
+          "type": "string",
+          "optional": true,
+          "description": "The id of the form element this label is associated with."
         },
         "asContent": {
           "type": "boolean",
@@ -3113,15 +3114,15 @@
           "optional": true,
           "description": "Deprecated routing destination. Use href instead."
         },
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Content rendered inside the link."
-        },
         "class": {
           "type": "string",
           "optional": true,
           "description": "Additional classes merged onto the root element."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Content rendered inside the link."
         }
       },
       "colors": [
@@ -3203,29 +3204,6 @@
       "importPath": "kumo-svelte/components/meter",
       "sourceFile": "components/meter",
       "props": {
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "value": {
-          "type": "number",
-          "optional": true,
-          "default": "0",
-          "description": "Controlled value."
-        },
-        "min": {
-          "type": "number",
-          "optional": true,
-          "default": "0",
-          "description": "Minimum value."
-        },
-        "max": {
-          "type": "number",
-          "optional": true,
-          "default": "100",
-          "description": "Maximum value."
-        },
         "customValue": {
           "type": "string",
           "optional": true,
@@ -3252,6 +3230,29 @@
           "type": "string",
           "optional": true,
           "description": "Class for the meter indicator."
+        },
+        "value": {
+          "type": "number",
+          "optional": true,
+          "default": "0",
+          "description": "Controlled value."
+        },
+        "max": {
+          "type": "number",
+          "optional": true,
+          "default": "100",
+          "description": "Maximum value."
+        },
+        "min": {
+          "type": "number",
+          "optional": true,
+          "default": "0",
+          "description": "Minimum value."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
         }
       },
       "colors": [
@@ -3268,26 +3269,16 @@
       "importPath": "kumo-svelte/components/pagination",
       "sourceFile": "components/pagination",
       "props": {
-        "children": {
-          "type": "Snippet",
+        "setPage": {
+          "type": "(page: number) => void",
           "optional": true,
-          "description": "Compound component children for custom layouts."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
+          "description": "Callback fired when the current page changes. In Svelte, bind:page can be used instead."
         },
         "page": {
           "type": "number",
           "optional": true,
           "default": "1",
           "description": "Current page number (1-indexed)."
-        },
-        "setPage": {
-          "type": "(page: number) => void",
-          "optional": true,
-          "description": "Callback fired when the current page changes. In Svelte, bind:page can be used instead."
         },
         "perPage": {
           "type": "number",
@@ -3298,6 +3289,21 @@
           "type": "number",
           "optional": true,
           "description": "Total number of items across all pages."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
+        "labels": {
+          "type": "PaginationLabels",
+          "optional": true,
+          "description": "Labels for internationalization of aria-labels."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Compound component children for custom layouts."
         },
         "controls": {
           "type": "enum",
@@ -3313,20 +3319,11 @@
           "type": "(props: { page?: number; perPage?: number; totalCount?: number; pageShowingRange: string }) => unknown",
           "optional": true,
           "description": "Deprecated legacy render function for the info text. Prefer Pagination.Info children."
-        },
-        "labels": {
-          "type": "PaginationLabels",
-          "optional": true,
-          "description": "Labels for internationalization of aria-labels."
         }
       },
       "colors": [
-        "bg-kumo-base",
         "border-kumo-hairline",
-        "ring-kumo-focus",
         "ring-kumo-hairline",
-        "ring-kumo-line",
-        "text-kumo-default",
         "text-kumo-subtle"
       ],
       "subComponents": {
@@ -3590,15 +3587,15 @@
         "Group": {
           "description": "Radio.Group",
           "props": {
-            "children": {
-              "type": "Snippet",
-              "optional": true,
-              "description": "Child snippet rendered by the component."
-            },
             "legend": {
               "type": "string",
               "optional": true,
               "description": "legend prop."
+            },
+            "children": {
+              "type": "Snippet",
+              "optional": true,
+              "description": "Child snippet rendered by the component."
             },
             "orientation": {
               "type": "enum",
@@ -3635,21 +3632,11 @@
               "optional": true,
               "description": "Controlled value."
             },
-            "defaultValue": {
-              "type": "string",
-              "optional": true,
-              "description": "Initial uncontrolled value."
-            },
             "disabled": {
               "type": "boolean",
               "optional": true,
               "default": "false",
               "description": "Disables the component."
-            },
-            "required": {
-              "type": "boolean",
-              "optional": true,
-              "description": "Marks the field as required."
             },
             "controlPosition": {
               "type": "enum",
@@ -3669,6 +3656,16 @@
               "type": "string",
               "optional": true,
               "description": "Additional classes merged onto the root element."
+            },
+            "defaultValue": {
+              "type": "string",
+              "optional": true,
+              "description": "Initial uncontrolled value."
+            },
+            "required": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Marks the field as required."
             },
             "onValueChange": {
               "type": "(value: string) => void",
@@ -3764,51 +3761,6 @@
           "optional": true,
           "description": "Additional classes merged onto the root element."
         },
-        "options": {
-          "type": "Option[]",
-          "optional": true,
-          "default": "[]",
-          "description": "Options rendered by the component."
-        },
-        "items": {
-          "type": "Record<string, SelectItemValue> | { label: Snippet | string; value: Value }[]",
-          "optional": true,
-          "description": "Items rendered by the component."
-        },
-        "value": {
-          "type": "Value",
-          "optional": true,
-          "description": "Controlled value."
-        },
-        "defaultValue": {
-          "type": "Value",
-          "optional": true,
-          "description": "Initial uncontrolled value."
-        },
-        "placeholder": {
-          "type": "string",
-          "optional": true,
-          "default": "Select...",
-          "description": "Placeholder text."
-        },
-        "disabled": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Disables the component."
-        },
-        "loading": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Loading state."
-        },
-        "multiple": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Enables multiple selection."
-        },
         "size": {
           "type": "enum",
           "optional": true,
@@ -3832,10 +3784,44 @@
           "default": "false",
           "description": "hideLabel prop."
         },
+        "placeholder": {
+          "type": "string",
+          "optional": true,
+          "default": "Select...",
+          "description": "Placeholder text."
+        },
+        "loading": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Loading state."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Disables the component."
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Marks the field as required."
+        },
         "labelTooltip": {
           "type": "string | Snippet",
           "optional": true,
           "description": "Optional help content for the label."
+        },
+        "value": {
+          "type": "Value",
+          "optional": true,
+          "description": "Controlled value."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
         },
         "description": {
           "type": "string | Snippet",
@@ -3847,26 +3833,37 @@
           "optional": true,
           "description": "Validation error message or matcher."
         },
-        "name": {
-          "type": "string",
+        "defaultValue": {
+          "type": "Value",
           "optional": true,
-          "description": "Form field name."
-        },
-        "required": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Marks the field as required."
-        },
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
+          "description": "Initial uncontrolled value."
         },
         "renderValue": {
           "type": "(value: Value) => unknown",
           "optional": true,
           "description": "Custom selected-value renderer."
+        },
+        "items": {
+          "type": "Record<string, SelectItemValue> | { label: Snippet | string; value: Value }[]",
+          "optional": true,
+          "description": "Items rendered by the component."
+        },
+        "options": {
+          "type": "Option[]",
+          "optional": true,
+          "default": "[]",
+          "description": "Options rendered by the component."
+        },
+        "multiple": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Enables multiple selection."
+        },
+        "name": {
+          "type": "string",
+          "optional": true,
+          "description": "Form field name."
         },
         "container": {
           "type": "HTMLElement | string",
@@ -3894,26 +3891,43 @@
       "importPath": "kumo-svelte/components/sensitive-input",
       "sourceFile": "components/sensitive-input",
       "props": {
+        "autoComplete": {
+          "type": "string",
+          "optional": true,
+          "default": "off",
+          "description": "Autocomplete attribute."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Disables the component."
+        },
+        "readOnly": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Makes the input read-only."
+        },
+        "required": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Marks the field as required."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
+        },
+        "id": {
+          "type": "string",
+          "optional": true,
+          "description": "Element id."
+        },
         "value": {
           "type": "string",
           "optional": true,
           "description": "Controlled value."
-        },
-        "defaultValue": {
-          "type": "string",
-          "optional": true,
-          "default": "",
-          "description": "Initial uncontrolled value."
-        },
-        "onValueChange": {
-          "type": "(value: string) => void",
-          "optional": true,
-          "description": "Called when the value changes."
-        },
-        "onCopy": {
-          "type": "() => void",
-          "optional": true,
-          "description": "Called after copying succeeds."
         },
         "size": {
           "type": "enum",
@@ -3957,27 +3971,21 @@
           "optional": true,
           "description": "Validation error message or matcher."
         },
-        "class": {
+        "defaultValue": {
           "type": "string",
           "optional": true,
-          "description": "Additional classes merged onto the root element."
+          "default": "",
+          "description": "Initial uncontrolled value."
         },
-        "id": {
-          "type": "string",
+        "onValueChange": {
+          "type": "(value: string) => void",
           "optional": true,
-          "description": "Element id."
+          "description": "Called when the value changes."
         },
-        "disabled": {
-          "type": "boolean",
+        "onCopy": {
+          "type": "() => void",
           "optional": true,
-          "default": "false",
-          "description": "Disables the component."
-        },
-        "readOnly": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Makes the input read-only."
+          "description": "Called after copying succeeds."
         },
         "readonly": {
           "type": "boolean",
@@ -3985,20 +3993,9 @@
           "default": "false",
           "description": "Makes the input read-only."
         },
-        "required": {
-          "type": "boolean",
-          "optional": true,
-          "description": "Marks the field as required."
-        },
         "autocomplete": {
           "type": "string",
           "optional": true,
-          "description": "Autocomplete attribute."
-        },
-        "autoComplete": {
-          "type": "string",
-          "optional": true,
-          "default": "off",
           "description": "Autocomplete attribute."
         },
         "oninput": {
@@ -4041,17 +4038,6 @@
       "importPath": "kumo-svelte/components/sidebar",
       "sourceFile": "components/sidebar",
       "props": {
-        "children": {
-          "type": "Snippet",
-          "optional": false,
-          "required": true,
-          "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
-        },
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes for the sidebar element."
-        },
         "variant": {
           "type": "enum",
           "optional": true,
@@ -4083,6 +4069,17 @@
           ],
           "default": "icon",
           "description": "Collapse behavior inherited from Provider."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": false,
+          "required": true,
+          "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes for the sidebar element."
         }
       },
       "colors": [
@@ -4375,34 +4372,6 @@
       "importPath": "kumo-svelte/components/switch",
       "sourceFile": "components/switch",
       "props": {
-        "class": {
-          "type": "string",
-          "optional": true,
-          "description": "Additional classes merged onto the root element."
-        },
-        "checked": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Checked state."
-        },
-        "disabled": {
-          "type": "boolean",
-          "optional": true,
-          "default": "false",
-          "description": "Disables the component."
-        },
-        "size": {
-          "type": "enum",
-          "optional": true,
-          "values": [
-            "sm",
-            "base",
-            "lg"
-          ],
-          "default": "base",
-          "description": "Size preset."
-        },
         "variant": {
           "type": "enum",
           "optional": true,
@@ -4434,10 +4403,38 @@
           "default": "true",
           "description": "Renders the control before label content."
         },
+        "size": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "sm",
+            "base",
+            "lg"
+          ],
+          "default": "base",
+          "description": "Size preset."
+        },
+        "checked": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Checked state."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Disables the component."
+        },
         "transitioning": {
           "type": "boolean",
           "optional": true,
           "description": "transitioning prop."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the root element."
         },
         "id": {
           "type": "string",
@@ -4449,11 +4446,6 @@
           "optional": true,
           "description": "Accessible label."
         },
-        "children": {
-          "type": "Snippet",
-          "optional": true,
-          "description": "Child snippet rendered by the component."
-        },
         "onchange": {
           "type": "(checked: boolean) => void",
           "optional": true,
@@ -4463,6 +4455,11 @@
           "type": "(checked: boolean) => void",
           "optional": true,
           "description": "Called when checked changes."
+        },
+        "children": {
+          "type": "Snippet",
+          "optional": true,
+          "description": "Child snippet rendered by the component."
         }
       },
       "colors": [
@@ -4479,25 +4476,25 @@
         "Group": {
           "description": "Switch.Group",
           "props": {
-            "children": {
-              "type": "Snippet",
-              "optional": true,
-              "description": "Child snippet rendered by the component."
-            },
             "legend": {
               "type": "string",
               "optional": true,
               "description": "legend prop."
             },
-            "description": {
-              "type": "string",
+            "children": {
+              "type": "Snippet",
               "optional": true,
-              "description": "Supporting description text."
+              "description": "Child snippet rendered by the component."
             },
             "error": {
               "type": "string",
               "optional": true,
               "description": "Validation error message or matcher."
+            },
+            "description": {
+              "type": "string",
+              "optional": true,
+              "description": "Supporting description text."
             },
             "disabled": {
               "type": "boolean",
@@ -5183,10 +5180,22 @@
       "importPath": "kumo-svelte/components/tooltip",
       "sourceFile": "components/tooltip",
       "props": {
-        "trigger": {
-          "type": "Snippet<[Record<string, unknown>]>",
+        "side": {
+          "type": "enum",
           "optional": true,
-          "description": "trigger prop."
+          "values": [
+            "top",
+            "right",
+            "bottom",
+            "left"
+          ],
+          "default": "top",
+          "description": "Preferred floating side."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the tooltip popup."
         },
         "children": {
           "type": "Snippet",
@@ -5199,10 +5208,10 @@
           "required": true,
           "description": "Content to display inside the tooltip popup."
         },
-        "class": {
-          "type": "string",
+        "trigger": {
+          "type": "Snippet<[Record<string, unknown>]>",
           "optional": true,
-          "description": "Additional classes merged onto the tooltip popup."
+          "description": "trigger prop."
         },
         "open": {
           "type": "boolean",
@@ -5213,18 +5222,6 @@
           "type": "(open: boolean) => void",
           "optional": true,
           "description": "Called when open state changes."
-        },
-        "side": {
-          "type": "enum",
-          "optional": true,
-          "values": [
-            "top",
-            "right",
-            "bottom",
-            "left"
-          ],
-          "default": "top",
-          "description": "Preferred floating side."
         },
         "align": {
           "type": "enum",

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.7",
+  "version": "2.4.0",
   "components": {
     "Autocomplete": {
       "name": "Autocomplete",

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.0",
+  "version": "0.1.8",
   "components": {
     "Autocomplete": {
       "name": "Autocomplete",
@@ -1477,6 +1477,7 @@
         "ring-kumo-line",
         "text-kumo-default",
         "text-kumo-disabled",
+        "text-kumo-muted",
         "text-kumo-placeholder",
         "text-kumo-subtle"
       ],

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -1,6 +1,6 @@
 # Kumo Svelte Component Registry
 
-Version: 0.1.6
+Version: 0.1.7
 
 ## Autocomplete
 

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -1,6 +1,6 @@
 # Kumo Svelte Component Registry
 
-Version: 2.4.0
+Version: 0.1.8
 
 ## Autocomplete
 

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -1,6 +1,6 @@
 # Kumo Svelte Component Registry
 
-Version: 0.1.7
+Version: 2.4.0
 
 ## Autocomplete
 

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -260,7 +260,7 @@ A masked input for sensitive values like API keys and passwords. Click to reveal
 
 ## Sidebar
 
-A composable sidebar navigation component with collapsible groups, icon-only mode, and responsive mobile support.
+A composable sidebar navigation component with contained layouts, peeking, sliding views, resizing, icon-only mode, and responsive mobile support.
 
 - Category: Navigation
 - Import: `import { Sidebar } from "kumo-svelte/components/sidebar";`

--- a/packages/kumo-svelte/package.json
+++ b/packages/kumo-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kumo-svelte",
-  "version": "2.4.0",
+  "version": "0.1.8",
   "description": "Svelte port of Cloudflare's Kumo UI library using bits-ui primitives.",
   "type": "module",
   "packageManager": "pnpm@11.3.0",

--- a/packages/kumo-svelte/package.json
+++ b/packages/kumo-svelte/package.json
@@ -59,6 +59,10 @@
     "deploy": "pnpm build && wrangler deploy",
     "dev": "pnpm codegen:registry && vite dev",
     "preview": "vite preview",
+    "test": "CI=true vitest run",
+    "test:run": "vitest run",
+    "test:unit": "vitest run",
+    "test:watch": "vitest --watch",
     "typecheck": "pnpm check"
   },
   "peerDependencies": {
@@ -90,7 +94,12 @@
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.4",
+    "happy-dom": "^20.0.10",
+    "jsdom": "^29.1.1",
     "mdsx": "^0.0.7",
     "svelte": "^5.55.7",
     "svelte-check": "^4.4.8",
@@ -98,6 +107,7 @@
     "tsx": "^4.20.6",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
+    "vitest": "^4.1.7",
     "wrangler": "^4.91.0"
   }
 }

--- a/packages/kumo-svelte/package.json
+++ b/packages/kumo-svelte/package.json
@@ -63,10 +63,14 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^2.60.1",
+    "echarts": "^6.0.0",
     "svelte": "^5.55.7"
   },
   "peerDependenciesMeta": {
     "@sveltejs/kit": {
+      "optional": true
+    },
+    "echarts": {
       "optional": true
     }
   },
@@ -74,7 +78,6 @@
     "@internationalized/date": "^3.12.1",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
-    "echarts": "^6.0.0",
     "esm-env": "^1.2.2",
     "phosphor-svelte": "^3.1.0",
     "shiki": "^4.0.2",

--- a/packages/kumo-svelte/package.json
+++ b/packages/kumo-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kumo-svelte",
-  "version": "0.1.7",
+  "version": "2.4.0",
   "description": "Svelte port of Cloudflare's Kumo UI library using bits-ui primitives.",
   "type": "module",
   "packageManager": "pnpm@11.3.0",

--- a/packages/kumo-svelte/src/lib/components/autocomplete/Autocomplete.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/Autocomplete.svelte
@@ -11,6 +11,7 @@
     type AutocompleteValue,
     type NormalizedAutocompleteItem
   } from './context';
+  import { createKumoFilter } from '../filter';
 
   type FieldError = string | { message?: string; match?: boolean };
 
@@ -55,6 +56,7 @@
   let query = $state(Array.isArray(value) ? value.join(', ') : String(value ?? ''));
   let hasTypedSinceFocus = $state(false);
   let rootElement: HTMLDivElement;
+  const { contains } = createKumoFilter();
 
   const normalizedItems = $derived(items.map(normalizeAutocompleteItem));
   const errorMessage = $derived(
@@ -67,7 +69,7 @@
 
     return normalizedItems.filter((item) => {
       if (filter) return filter(item.raw, query);
-      return item.label.toLowerCase().includes(term) || String(item.value).toLowerCase().includes(term);
+      return contains(item.label, term) || contains(String(item.value), term);
     });
   });
 

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteItem.svelte
@@ -23,6 +23,8 @@
 <button
   type="button"
   disabled={item.disabled}
+  data-kumo-component="Autocomplete"
+  data-kumo-part="item"
   class={cn(
     'group mx-1.5 grid w-[calc(100%-0.75rem)] cursor-pointer grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base outline-none',
     'hover:bg-kumo-overlay focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',

--- a/packages/kumo-svelte/src/lib/components/autocomplete/index.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/index.ts
@@ -7,6 +7,7 @@ import Group from './AutocompleteGroup.svelte';
 import GroupLabel from './AutocompleteGroupLabel.svelte';
 import Collection from './AutocompleteCollection.svelte';
 import Separator from './AutocompleteSeparator.svelte';
+import { createKumoFilter } from '../filter';
 
 export const Autocomplete = Object.assign(Root, {
   InputGroup,
@@ -16,7 +17,8 @@ export const Autocomplete = Object.assign(Root, {
   Group,
   GroupLabel,
   Collection,
-  Separator
+  Separator,
+  useFilter: createKumoFilter
 });
 
 export {

--- a/packages/kumo-svelte/src/lib/components/badge/Badge.svelte
+++ b/packages/kumo-svelte/src/lib/components/badge/Badge.svelte
@@ -26,7 +26,7 @@
   } as const;
 
   export const KUMO_BADGE_DOT_COLORS = {
-    success: 'bg-kumo-badge-green',
+    success: 'bg-kumo-success',
     warning: 'bg-kumo-badge-orange',
     error: 'bg-kumo-badge-red',
     neutral: 'bg-kumo-badge-neutral'

--- a/packages/kumo-svelte/src/lib/components/banner/Banner.svelte
+++ b/packages/kumo-svelte/src/lib/components/banner/Banner.svelte
@@ -2,24 +2,29 @@
   import { cn } from '$lib/utils/cn';
 
   export const KUMO_BANNER_BASE_STYLES =
-    'flex w-full items-start gap-3 rounded-lg border px-4 py-3 text-base';
+    'flex w-full items-start gap-3 rounded-lg px-4 py-3 text-base';
 
   export const KUMO_BANNER_VARIANTS = {
     variant: {
       default: {
-        classes: 'bg-kumo-info-tint/30 border-kumo-info/50 text-kumo-info',
+        classes: 'bg-kumo-banner-info text-kumo-info',
         iconClasses: 'text-kumo-info',
         description: 'Informational banner for general messages'
       },
       alert: {
-        classes: 'bg-kumo-warning-tint/15 border-kumo-warning/50 text-kumo-warning',
+        classes: 'bg-kumo-banner-warning text-kumo-warning',
         iconClasses: 'text-kumo-warning',
         description: 'Warning banner for cautionary messages'
       },
       error: {
-        classes: 'bg-kumo-danger-tint/15 border-kumo-danger/50 text-kumo-danger',
+        classes: 'bg-kumo-danger-tint/60 text-kumo-danger',
         iconClasses: 'text-kumo-danger',
         description: 'Error banner for critical issues'
+      },
+      secondary: {
+        classes: 'bg-kumo-contrast/5 text-kumo-subtle',
+        iconClasses: 'text-kumo-subtle',
+        description: 'Neutral banner for secondary messages'
       }
     }
   } as const;
@@ -85,7 +90,7 @@
         <IconComponent weight="fill" />
       </span>
     {/if}
-    <div class="flex min-w-0 flex-1 items-center justify-between gap-3">
+    <div class={cn('flex min-w-0 flex-1 items-center justify-between gap-3', !title && 'pt-px')}>
       <div class="flex flex-col gap-0.5">
         {#if title}<p class="font-medium leading-snug">{title}</p>{/if}
         {#if description}

--- a/packages/kumo-svelte/src/lib/components/breadcrumbs/BreadcrumbsLink.svelte
+++ b/packages/kumo-svelte/src/lib/components/breadcrumbs/BreadcrumbsLink.svelte
@@ -11,7 +11,7 @@
   let { children, href, icon: Icon, ...rest }: Props = $props();
 </script>
 
-<a href={href} class="flex min-w-0 max-w-full items-center gap-1 text-kumo-subtle no-underline" {...rest}>
+<a href={href} data-kumo-component="Breadcrumbs" data-kumo-part="link" class="flex min-w-0 max-w-full items-center gap-1 text-kumo-subtle no-underline" {...rest}>
   {#if Icon}
     <span class="flex shrink-0 items-center">
       <Icon size={16} />

--- a/packages/kumo-svelte/src/lib/components/button/Button.svelte
+++ b/packages/kumo-svelte/src/lib/components/button/Button.svelte
@@ -120,6 +120,7 @@
     variant?: Variant;
     loading?: boolean;
     title?: string;
+    componentName?: 'Button' | 'LinkButton';
     [key: string]: unknown;
   }
 
@@ -136,6 +137,7 @@
     variant = 'secondary',
     loading = false,
     title,
+    componentName = 'Button',
     ...rest
   }: Props = $props();
 
@@ -160,7 +162,7 @@
     type={href ? undefined : type}
     disabled={href ? undefined : disabled || loading}
     aria-busy={loading || undefined}
-    data-kumo-component="Button"
+    data-kumo-component={componentName}
     data-kumo-part={href ? 'link-button' : 'button'}
     {...externalProps}
     {...rest}

--- a/packages/kumo-svelte/src/lib/components/button/Button.svelte
+++ b/packages/kumo-svelte/src/lib/components/button/Button.svelte
@@ -160,6 +160,8 @@
     type={href ? undefined : type}
     disabled={href ? undefined : disabled || loading}
     aria-busy={loading || undefined}
+    data-kumo-component="Button"
+    data-kumo-part={href ? 'link-button' : 'button'}
     {...externalProps}
     {...rest}
   >

--- a/packages/kumo-svelte/src/lib/components/button/LinkButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/button/LinkButton.svelte
@@ -36,6 +36,7 @@
   {shape}
   {size}
   {variant}
+  componentName="LinkButton"
   class={className}
   {...rest}
 >

--- a/packages/kumo-svelte/src/lib/components/button/button.test.ts
+++ b/packages/kumo-svelte/src/lib/components/button/button.test.ts
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import Button from './Button.svelte';
+
+describe('Button', () => {
+  it('renders a button with Kumo data attributes by default', () => {
+    render(Button, {
+      'aria-label': 'Save'
+    });
+
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button.getAttribute('type')).toBe('button');
+    expect(button.getAttribute('data-kumo-component')).toBe('Button');
+    expect(button.getAttribute('data-kumo-part')).toBe('button');
+  });
+
+  it('renders as a link when href is provided', () => {
+    render(Button, {
+      href: '/settings',
+      'aria-label': 'Settings'
+    });
+
+    const link = screen.getByRole('link', { name: 'Settings' });
+    expect(link.getAttribute('href')).toBe('/settings');
+    expect(link.getAttribute('data-kumo-part')).toBe('link-button');
+  });
+
+  it('marks loading buttons busy and disabled', () => {
+    render(Button, {
+      loading: true,
+      'aria-label': 'Deploy'
+    });
+
+    const button = screen.getByRole('button', { name: 'Deploy' });
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute('aria-busy')).toBe('true');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
   import type { SeriesOption } from 'echarts';
   import type { EChartsType } from 'echarts/core';
   import Chart, { type ChartEvents, type KumoChartOption } from './Chart.svelte';
@@ -69,6 +70,7 @@
   let chartRef: EChartsType | null = $state(null);
   let detectedDarkMode = $state(false);
   let containerRef: HTMLDivElement;
+  let tooltipAnchor: HTMLSpanElement | null = $state(null);
   let tooltipState: { ts: number; rows: { name: string; value: number; color: string }[]; hiddenCount: number } | null = $state(null);
   let mousePos = $state({ x: 0, y: 0 });
   const effectiveDarkMode = $derived(isDarkMode ?? detectedDarkMode);
@@ -303,20 +305,15 @@
     mousePos = { x: event.clientX - rect.left, y: event.clientY - rect.top };
   }
 
-  const tooltipStyle = $derived.by(() => {
-    const tooltipWidth = 280;
-    const tooltipHeight = 180;
-    const sideOffset = 12;
-    const padding = 8;
-    let x = mousePos.x + sideOffset;
-    let y = tooltipFollowCursor === 'x' ? 12 : mousePos.y + sideOffset;
+  const tooltipAnchorStyle = $derived.by(() => {
+    const x = mousePos.x;
+    const y = tooltipFollowCursor === 'x' ? 12 : mousePos.y;
+    return `left:${x}px;top:${y}px;`;
+  });
 
-    if (tooltipBoundary !== undefined && containerRef) {
-      x = Math.min(Math.max(padding, x), Math.max(padding, containerRef.clientWidth - tooltipWidth - padding));
-      y = Math.min(Math.max(padding, y), Math.max(padding, containerRef.clientHeight - tooltipHeight - padding));
-    }
-
-    return `left:${x}px;top:${y}px;max-width:${tooltipWidth}px;`;
+  const tooltipCollisionBoundary = $derived.by(() => {
+    if (tooltipBoundary === undefined || tooltipBoundary === 'clipping-ancestors') return undefined;
+    return tooltipBoundary;
   });
 </script>
 
@@ -345,30 +342,42 @@
   {:else}
     <Chart {echarts} bind:chartRef options={options} {height} isDarkMode={effectiveDarkMode} onEvents={events} optionUpdateBehavior={optionUpdateBehavior as any} />
   {/if}
+  <span bind:this={tooltipAnchor} aria-hidden="true" class="pointer-events-none absolute size-px" style={tooltipAnchorStyle}></span>
   {#if tooltipState}
     {@const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat}
-    <div
-      class="pointer-events-none absolute z-50 min-w-[150px] rounded-lg bg-kumo-base p-2 text-kumo-default shadow-lg shadow-kumo-tip-shadow outline outline-1 outline-kumo-fill"
-      style={tooltipStyle}
-      data-mode={effectiveDarkMode ? 'dark' : 'light'}
-      role="tooltip"
-      aria-label={`Values at ${formatAriaTimestamp(tooltipState.ts)}`}
-    >
-      <div class="mb-1 text-xs font-semibold text-kumo-default">{formatTimestamp(tooltipState.ts)}</div>
-      {#each tooltipState.rows as row (row.name)}
-        <div class="flex items-center justify-between gap-4 py-0.5">
-          <div class="flex min-w-0 items-center gap-2">
-            <span class="size-3 shrink-0 rounded-full" style:background-color={row.color}></span>
-            <span class="truncate text-xs font-medium text-kumo-default" title={row.name}>{row.name}</span>
-          </div>
-          <span class="shrink-0 text-xs font-semibold text-kumo-default">
-            {formatFn ? formatFn(row.value) : formatDefaultValue(row.value)}
-          </span>
-        </div>
-      {/each}
-      {#if tooltipState.hiddenCount > 0}
-        <div class="mt-1 text-xs text-kumo-subtle">+{tooltipState.hiddenCount} more</div>
-      {/if}
-    </div>
+    <TooltipPrimitive.Root open={true} delayDuration={0} disableHoverableContent>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          class="pointer-events-none z-50 min-w-[150px] max-w-[280px] rounded-lg bg-kumo-base p-2 text-kumo-default shadow-lg shadow-kumo-tip-shadow outline outline-1 outline-kumo-fill"
+          customAnchor={tooltipAnchor}
+          side="right"
+          align="start"
+          sideOffset={12}
+          collisionPadding={8}
+          collisionBoundary={tooltipCollisionBoundary}
+          avoidCollisions
+          strategy="fixed"
+          updatePositionStrategy="always"
+          data-mode={effectiveDarkMode ? 'dark' : 'light'}
+          aria-label={`Values at ${formatAriaTimestamp(tooltipState.ts)}`}
+        >
+          <div class="mb-1 text-xs font-semibold text-kumo-default">{formatTimestamp(tooltipState.ts)}</div>
+          {#each tooltipState.rows as row (row.name)}
+            <div class="flex items-center justify-between gap-4 py-0.5">
+              <div class="flex min-w-0 items-center gap-2">
+                <span class="size-3 shrink-0 rounded-full" style:background-color={row.color}></span>
+                <span class="truncate text-xs font-medium text-kumo-default" title={row.name}>{row.name}</span>
+              </div>
+              <span class="shrink-0 text-xs font-semibold text-kumo-default">
+                {formatFn ? formatFn(row.value) : formatDefaultValue(row.value)}
+              </span>
+            </div>
+          {/each}
+          {#if tooltipState.hiddenCount > 0}
+            <div class="mt-1 text-xs text-kumo-subtle">+{tooltipState.hiddenCount} more</div>
+          {/if}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   {/if}
 </div>

--- a/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
@@ -22,6 +22,10 @@
     yAxisName?: string;
     yAxisTickCount?: number;
     tooltipValueFormat?: (value: number) => string;
+    tooltipMode?: 'all' | 'single';
+    tooltipMaxItems?: number;
+    tooltipBoundary?: 'clipping-ancestors' | Element | Element[];
+    tooltipFollowCursor?: 'both' | 'x';
     incomplete?: { before?: number; after?: number };
     height?: number;
     onTimeRangeChange?: (from: number, to: number) => void;
@@ -46,6 +50,10 @@
     yAxisName,
     yAxisTickCount,
     tooltipValueFormat,
+    tooltipMode = 'all',
+    tooltipMaxItems = 10,
+    tooltipBoundary,
+    tooltipFollowCursor = 'both',
     incomplete,
     height = 350,
     onTimeRangeChange,
@@ -60,6 +68,9 @@
 
   let chartRef: EChartsType | null = $state(null);
   let detectedDarkMode = $state(false);
+  let containerRef: HTMLDivElement;
+  let tooltipState: { ts: number; rows: { name: string; value: number; color: string }[]; hiddenCount: number } | null = $state(null);
+  let mousePos = $state({ x: 0, y: 0 });
   const effectiveDarkMode = $derived(isDarkMode ?? detectedDarkMode);
 
   onMount(() => {
@@ -95,10 +106,38 @@
     return `rgba(${parseInt(hex.slice(0, 2), 16)}, ${parseInt(hex.slice(2, 4), 16)}, ${parseInt(hex.slice(4, 6), 16)}, ${a})`;
   };
 
+  const tooltipDateFormat = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  });
+  const defaultNumberFormat = new Intl.NumberFormat(undefined, { maximumFractionDigits: 3 });
   const pad = (n: number) => n.toString().padStart(2, '0');
   const formatTimestamp = (ts: number | string | Date): string => {
+    return tooltipDateFormat.format(new Date(ts));
+  };
+  const formatAriaTimestamp = (ts: number | string | Date): string => {
     const d = new Date(ts);
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  };
+  const findNearest = (points: [number, number][], ts: number) => {
+    if (points.length === 0) return null;
+    let lo = 0;
+    let hi = points.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (points[mid][0] < ts) lo = mid + 1;
+      else hi = mid;
+    }
+    if (lo > 0 && Math.abs(points[lo - 1][0] - ts) < Math.abs(points[lo][0] - ts)) lo -= 1;
+    return points[lo][1];
+  };
+  const formatDefaultValue = (value: number) => {
+    if (Number.isInteger(value)) return String(value);
+    return defaultNumberFormat.format(value);
   };
 
   let options = $derived.by(() => {
@@ -156,32 +195,8 @@
       },
       tooltip: {
         trigger: 'axis',
-        appendTo: 'body',
-        axisPointer: { type: 'shadow' },
-        backgroundColor: effectiveDarkMode ? '#3A3E44' : '#FFFFFF',
-        borderColor: effectiveDarkMode ? '#5B5E64' : '#DDDDDD',
-        textStyle: { color: effectiveDarkMode ? '#B3B4B7' : '#1F1F1F' },
-        extraCssText: `color: ${effectiveDarkMode ? '#B3B4B7' : '#1F1F1F'};`,
-        dangerousHtmlFormatter: (params: any) => {
-          const items = Array.isArray(params) ? params : [params];
-          const seenNames = new Set<string>();
-          const filtered = items.filter((param: any) => {
-            if (seenNames.has(param.seriesName)) return false;
-            seenNames.add(param.seriesName);
-            return true;
-          });
-          const ts = filtered[0]?.value?.[0] ?? filtered[0]?.axisValue;
-          const header = ts != null ? `<div style="font-weight:600;margin-bottom:4px;">${echarts.format.encodeHTML(formatTimestamp(ts))}</div>` : '';
-          const rows = filtered
-            .map((param: any) => {
-              const value = param?.value?.[1];
-              const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat;
-              const formattedValue = formatFn ? echarts.format.encodeHTML(String(formatFn(value))) : echarts.format.encodeHTML(String(value));
-              return `${param.marker} ${echarts.format.encodeHTML(param.seriesName)}: <strong>${formattedValue}</strong>`;
-            })
-            .join('<br/>');
-          return `${header}${rows}`;
-        }
+        showContent: false,
+        axisPointer: { type: 'shadow' }
       },
       backgroundColor: 'transparent',
       animation,
@@ -216,16 +231,54 @@
   });
 
   let events = $derived<Partial<ChartEvents>>(
-    onTimeRangeChange
-      ? {
-          brushend: (params: any) => {
-            const range = params.areas?.[0]?.coordRange;
-            if (!range) return;
-            onTimeRangeChange(range[0], range[1]);
-            chartRef?.dispatchAction({ type: 'brush', areas: [] });
-          }
+    {
+      updateaxispointer: (params: any) => {
+        const ts: number | undefined = params?.axesInfo?.[0]?.value;
+        if (ts == null) return;
+        const seenNames = new Set<string>();
+        const allRows: { name: string; value: number; color: string }[] = [];
+
+        for (const series of data) {
+          if (seenNames.has(series.name)) continue;
+          seenNames.add(series.name);
+          const value = findNearest(series.data, ts);
+          if (value != null) allRows.push({ name: series.name, value, color: series.color });
         }
-      : {}
+
+        allRows.sort((a, b) => b.value - a.value);
+        let rows: { name: string; value: number; color: string }[];
+        let hiddenCount = 0;
+        if (tooltipMode === 'single') {
+          const cursorValue = chartRef ? (chartRef.convertFromPixel('grid', [0, mousePos.y]) as [number, number] | undefined)?.[1] : null;
+          if (cursorValue != null && allRows.length > 0) {
+            rows = [
+              allRows.reduce((best, row) =>
+                Math.abs(row.value - cursorValue) < Math.abs(best.value - cursorValue) ? row : best
+              )
+            ];
+          } else {
+            rows = allRows.slice(0, 1);
+          }
+        } else {
+          rows = allRows.slice(0, tooltipMaxItems);
+          hiddenCount = Math.max(0, allRows.length - tooltipMaxItems);
+        }
+        tooltipState = { ts, rows, hiddenCount };
+      },
+      globalout: () => {
+        tooltipState = null;
+      },
+      ...(onTimeRangeChange
+        ? {
+            brushend: (params: any) => {
+              const range = params.areas?.[0]?.coordRange;
+              if (!range) return;
+              onTimeRangeChange(range[0], range[1]);
+              chartRef?.dispatchAction({ type: 'brush', areas: [] });
+            }
+          }
+        : {})
+    }
   );
 
   $effect(() => {
@@ -235,11 +288,39 @@
         key: 'brush',
         brushOption: { brushType: 'lineX', brushMode: 'single' }
       });
+      return () => {
+        chartRef?.dispatchAction({
+          type: 'takeGlobalCursor',
+          key: 'brush',
+          brushOption: { brushType: false }
+        });
+      };
     }
+  });
+
+  function updateMousePosition(event: MouseEvent) {
+    const rect = containerRef.getBoundingClientRect();
+    mousePos = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+  }
+
+  const tooltipStyle = $derived.by(() => {
+    const tooltipWidth = 280;
+    const tooltipHeight = 180;
+    const sideOffset = 12;
+    const padding = 8;
+    let x = mousePos.x + sideOffset;
+    let y = tooltipFollowCursor === 'x' ? 12 : mousePos.y + sideOffset;
+
+    if (tooltipBoundary !== undefined && containerRef) {
+      x = Math.min(Math.max(padding, x), Math.max(padding, containerRef.clientWidth - tooltipWidth - padding));
+      y = Math.min(Math.max(padding, y), Math.max(padding, containerRef.clientHeight - tooltipHeight - padding));
+    }
+
+    return `left:${x}px;top:${y}px;max-width:${tooltipWidth}px;`;
   });
 </script>
 
-<div class="relative w-full" style:height={`${height}px`}>
+<div bind:this={containerRef} class="relative w-full" style:height={`${height}px`} role="presentation" onmousemove={updateMousePosition}>
   {#if loading}
     {@const mid = height / 2}
     {@const amp = Math.min(height * 0.12, 28)}
@@ -263,5 +344,31 @@
     </div>
   {:else}
     <Chart {echarts} bind:chartRef options={options} {height} isDarkMode={effectiveDarkMode} onEvents={events} optionUpdateBehavior={optionUpdateBehavior as any} />
+  {/if}
+  {#if tooltipState}
+    {@const formatFn = tooltipValueFormat ?? yAxisTickLabelFormat}
+    <div
+      class="pointer-events-none absolute z-50 min-w-[150px] rounded-lg bg-kumo-base p-2 text-kumo-default shadow-lg shadow-kumo-tip-shadow outline outline-1 outline-kumo-fill"
+      style={tooltipStyle}
+      data-mode={effectiveDarkMode ? 'dark' : 'light'}
+      role="tooltip"
+      aria-label={`Values at ${formatAriaTimestamp(tooltipState.ts)}`}
+    >
+      <div class="mb-1 text-xs font-semibold text-kumo-default">{formatTimestamp(tooltipState.ts)}</div>
+      {#each tooltipState.rows as row (row.name)}
+        <div class="flex items-center justify-between gap-4 py-0.5">
+          <div class="flex min-w-0 items-center gap-2">
+            <span class="size-3 shrink-0 rounded-full" style:background-color={row.color}></span>
+            <span class="truncate text-xs font-medium text-kumo-default" title={row.name}>{row.name}</span>
+          </div>
+          <span class="shrink-0 text-xs font-semibold text-kumo-default">
+            {formatFn ? formatFn(row.value) : formatDefaultValue(row.value)}
+          </span>
+        </div>
+      {/each}
+      {#if tooltipState.hiddenCount > 0}
+        <div class="mt-1 text-xs text-kumo-subtle">+{tooltipState.hiddenCount} more</div>
+      {/if}
+    </div>
   {/if}
 </div>

--- a/packages/kumo-svelte/src/lib/components/checkbox/Checkbox.svelte
+++ b/packages/kumo-svelte/src/lib/components/checkbox/Checkbox.svelte
@@ -74,6 +74,7 @@
     {id}
     aria-label={controlLabel}
     aria-labelledby={ariaLabelledBy}
+    data-kumo-component="Checkbox"
     {onCheckedChange}
     {onIndeterminateChange}
     class={cn(
@@ -94,7 +95,7 @@
 {/snippet}
 
 {#if label || children}
-  <label class={cn('!m-0 !min-h-0 !text-base inline-flex items-center gap-2', controlFirst ? 'flex-row' : 'flex-row-reverse justify-end', disabled ? 'cursor-not-allowed' : 'cursor-pointer')}>
+  <label data-kumo-component="Checkbox" data-kumo-part="label" class={cn('!m-0 !min-h-0 !text-base inline-flex items-center gap-2', controlFirst ? 'flex-row' : 'flex-row-reverse justify-end', disabled ? 'cursor-not-allowed' : 'cursor-pointer')}>
     {@render control()}
     <span class="inline-flex items-center gap-1 text-base font-medium text-kumo-default">
       {#if label}{label}{:else}{@render children?.()}{/if}

--- a/packages/kumo-svelte/src/lib/components/checkbox/CheckboxItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/checkbox/CheckboxItem.svelte
@@ -44,6 +44,8 @@
 </script>
 
 <label
+  data-kumo-component="Checkbox"
+  data-kumo-part="item-label"
   class={cn(
     'm-0 relative inline-flex items-center gap-2',
     !(group?.controlFirst ?? true) && 'flex-row-reverse justify-end',
@@ -57,6 +59,8 @@
     {value}
     {name}
     {disabled}
+    data-kumo-component="Checkbox"
+    data-kumo-part="item"
     {onCheckedChange}
     {onIndeterminateChange}
     class={cn(

--- a/packages/kumo-svelte/src/lib/components/code/CodeHighlighted.svelte
+++ b/packages/kumo-svelte/src/lib/components/code/CodeHighlighted.svelte
@@ -41,7 +41,13 @@
   interface Props {
     code: string;
     lang?: CodeHighlightedLang;
+    highlightLines?: number[];
+    labels?: {
+      copy?: string;
+      copied?: string;
+    };
     showCopyButton?: boolean;
+    showLineNumbers?: boolean;
     class?: string;
     style?: string;
     [key: string]: unknown;
@@ -50,8 +56,11 @@
   let {
     code,
     class: className,
+    highlightLines = [],
     lang = 'typescript',
+    labels = {},
     showCopyButton = false,
+    showLineNumbers = false,
     style,
     ...rest
   }: Props = $props();
@@ -79,13 +88,24 @@
       .replace(/(<script\b[^>]*>)\n{2,}/g, '$1\n')
       .replace(/\n{2,}(<\/script>)/g, '\n$1')
   );
+  const highlightLineSet = $derived(new Set(highlightLines));
+
+  function decorateHighlightedLines(html: string) {
+    let lineNumber = 0;
+
+    return html.replace(/<span class="line">/g, () => {
+      lineNumber += 1;
+      return `<span class="line${highlightLineSet.has(lineNumber) ? ' line-highlighted' : ''}" data-line="${lineNumber}">`;
+    });
+  }
+
   const highlightedCode = $derived(
     codeToHtml(normalizedCode, {
       lang: languageAliases[lang] ?? lang,
       themes: KUMO_CODE_HIGHLIGHTED_STYLING.themes,
       defaultColor: false
     }).then((html) =>
-      html
+      decorateHighlightedLines(html)
         .replace(/\s+tabindex="0"/g, '')
         .replace(/(<\/span>)\n(?=<span class="line")/g, '$1')
     )
@@ -98,7 +118,15 @@
   }
 </script>
 
-<div class={cn('not-prose group relative m-0 w-full min-w-0 rounded-md border border-kumo-fill bg-kumo-base p-0', className)} {style} {...rest}>
+<div
+  class={cn(
+    'not-prose group relative m-0 w-full min-w-0 rounded-md border border-kumo-fill bg-kumo-base p-0',
+    showLineNumbers && 'kumo-shiki-line-numbers',
+    className
+  )}
+  {style}
+  {...rest}
+>
   {#await highlightedCode}
     <pre class="m-0 min-w-0 flex-1 overflow-x-auto p-4 font-mono text-sm leading-relaxed text-kumo-subtle"><code class="m-0 bg-transparent p-0">{normalizedCode}</code></pre>
   {:then html}
@@ -114,7 +142,8 @@
       class="code-block-copy-btn"
       class:copied
       data-copied={copied ? '' : undefined}
-      aria-label="Copy code to clipboard"
+      aria-label={copied ? (labels.copied ?? 'Copied!') : (labels.copy ?? 'Copy code to clipboard')}
+      title={copied ? (labels.copied ?? 'Copied!') : (labels.copy ?? 'Copy')}
       onclick={copyCode}
     >
       <span class="code-block-copy-btn__icons">

--- a/packages/kumo-svelte/src/lib/components/collapsible/CollapsibleTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/collapsible/CollapsibleTrigger.svelte
@@ -21,6 +21,8 @@
 </script>
 
 <CollapsiblePrimitive.Trigger
+  data-kumo-component="Collapsible"
+  data-kumo-part="trigger"
   class={cn('cursor-pointer', className)}
   {disabled}
   {type}

--- a/packages/kumo-svelte/src/lib/components/combobox/Combobox.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/Combobox.svelte
@@ -9,6 +9,7 @@
     type ComboboxSize,
     type NormalizedComboboxItem
   } from './context';
+  import { createKumoFilter } from '../filter';
 
   type FieldError = string | { message?: string; match?: boolean };
 
@@ -60,6 +61,7 @@
 
   let query = $state('');
   let rootElement: HTMLDivElement | null = $state(null);
+  const { contains } = createKumoFilter();
 
   const sourceItems = $derived(items ?? options);
   const normalizedItems = $derived(sourceItems.map(normalizeComboboxItem));
@@ -73,7 +75,7 @@
 
     return normalizedItems.filter((item) => {
       if (filter) return filter(item.raw, query);
-      return item.label.toLowerCase().includes(term) || String(item.value).toLowerCase().includes(term);
+      return contains(item.label, term) || contains(String(item.value), term);
     });
   });
 

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxChip.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxChip.svelte
@@ -27,6 +27,8 @@
   <button
     type="button"
     aria-label={removeLabel}
+    data-kumo-component="Combobox"
+    data-kumo-part="chip-remove"
     class="flex cursor-pointer rounded-md bg-transparent p-1 hover:bg-kumo-fill-hover"
     onclick={() => context.remove(value)}
   >

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxInput.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <input
-  class={cn(inputStyles[context.size], 'mx-1.5 w-[calc(100%-0.75rem)] shrink-0 first:mb-2 border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none placeholder:text-kumo-placeholder focus:ring-kumo-focus/50 focus:ring-[1.5px]', className)}
+  class={cn(inputStyles[context.size], 'mx-1.5 w-[calc(100%-0.75rem)] shrink-0 first:mb-2 border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none placeholder:text-kumo-muted focus:ring-kumo-focus/50 focus:ring-[1.5px]', className)}
   value={context.query}
   {placeholder}
   disabled={context.disabled}

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
@@ -24,6 +24,8 @@
 <button
   type="button"
   disabled={item.disabled}
+  data-kumo-component="Combobox"
+  data-kumo-part="item"
   class={cn(
     'group mx-1.5 grid w-[calc(100%-0.75rem)] grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base outline-none',
     'cursor-pointer hover:bg-kumo-tint focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
@@ -27,7 +27,7 @@
   data-kumo-component="Combobox"
   data-kumo-part="item"
   class={cn(
-    'group mx-1.5 grid w-[calc(100%-0.75rem)] grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base outline-none',
+    'group mx-1.5 grid w-[calc(100%-0.75rem)] grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base text-kumo-default outline-none',
     'cursor-pointer hover:bg-kumo-tint focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',
     'disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-kumo-subtle disabled:opacity-60 disabled:hover:bg-transparent',
     className

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTrigger.svelte
@@ -17,6 +17,8 @@
   type="button"
   class={cn('inline-flex items-center gap-2', className)}
   disabled={context.disabled}
+  data-kumo-component="Combobox"
+  data-kumo-part="trigger"
   onclick={() => (context.open = !context.open)}
   {...rest}
 >

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
@@ -59,7 +59,7 @@
     class={cn(
       inputStyles[resolvedSize],
       'w-full border-0 bg-kumo-control text-kumo-default shadow-xs ring ring-kumo-line outline-none',
-      'placeholder:text-kumo-placeholder disabled:cursor-not-allowed disabled:text-kumo-disabled',
+      'placeholder:text-kumo-muted disabled:cursor-not-allowed disabled:text-kumo-disabled',
       context.invalid
         ? '!ring-kumo-danger focus:ring-kumo-danger/50 focus:ring-[1.5px]'
         : 'focus:ring-kumo-focus/50 focus:ring-[1.5px]',

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
@@ -80,6 +80,8 @@
   <button
     type="button"
     aria-label={clearLabel}
+    data-kumo-component="Combobox"
+    data-kumo-part="clear"
     class={cn(
       'absolute top-1/2 flex -translate-y-1/2 cursor-pointer bg-transparent p-0 text-kumo-default',
       'disabled:pointer-events-none disabled:opacity-0',
@@ -94,6 +96,8 @@
   <button
     type="button"
     aria-label={showOptionsLabel}
+    data-kumo-component="Combobox"
+    data-kumo-part="trigger"
     class={cn(
       'absolute top-1/2 m-0 flex -translate-y-1/2 cursor-pointer items-center justify-center bg-transparent p-0 text-kumo-subtle',
       caretRight[resolvedSize]

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerMultipleWithInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerMultipleWithInput.svelte
@@ -44,7 +44,7 @@
 >
   {#if inputSide === 'top'}
     <input
-      class="w-full border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-placeholder"
+      class="w-full border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-muted"
       {placeholder}
       value={context.query}
       disabled={context.disabled}
@@ -61,7 +61,7 @@
     {/each}
     {#if inputSide === 'right'}
       <input
-        class="min-w-[100px] flex-1 border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-placeholder"
+        class="min-w-[100px] flex-1 border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-muted"
         {placeholder}
         value={context.query}
         disabled={context.disabled}

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerValue.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerValue.svelte
@@ -41,6 +41,8 @@
     className
   )}
   disabled={context.disabled}
+  data-kumo-component="Combobox"
+  data-kumo-part="trigger"
   onclick={() => (context.open = !context.open)}
   {...rest}
 >

--- a/packages/kumo-svelte/src/lib/components/combobox/index.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/index.ts
@@ -14,6 +14,7 @@ import Collection from './ComboboxCollection.svelte';
 import Trigger from './ComboboxTrigger.svelte';
 import Value from './ComboboxValue.svelte';
 import Icon from './ComboboxIcon.svelte';
+import { createKumoFilter } from '../filter';
 
 export const Combobox = Object.assign(Root, {
   Content,
@@ -30,7 +31,8 @@ export const Combobox = Object.assign(Root, {
   Collection,
   Trigger,
   Value,
-  Icon
+  Icon,
+  useFilter: createKumoFilter
 });
 
 export {

--- a/packages/kumo-svelte/src/lib/components/date-picker/DatePicker.svelte
+++ b/packages/kumo-svelte/src/lib/components/date-picker/DatePicker.svelte
@@ -7,6 +7,15 @@
   }
 
   export type DatePickerSelection = Date | Date[] | DateRange | undefined;
+  export type DateMatcher =
+    | boolean
+    | Date
+    | DateRange
+    | { before: Date }
+    | { after: Date }
+    | { from: Date; to: Date }
+    | { dayOfWeek: number[] }
+    | ((date: Date) => boolean);
 </script>
 
 <script lang="ts">
@@ -14,7 +23,8 @@
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
 
-  type DisabledMatcher = Date | Date[] | ((date: Date) => boolean);
+  type CaptionLayout = 'label' | 'dropdown' | 'dropdown-months' | 'dropdown-years';
+  type NavLayout = 'around' | 'after';
 
   interface Props {
     mode?: DatePickerMode;
@@ -25,7 +35,18 @@
     numberOfMonths?: number;
     min?: number;
     max?: number;
-    disabled?: boolean | DisabledMatcher;
+    required?: boolean;
+    excludeDisabled?: boolean;
+    disabled?: DateMatcher | DateMatcher[];
+    hidden?: DateMatcher | DateMatcher[];
+    startMonth?: Date;
+    endMonth?: Date;
+    fromMonth?: Date;
+    toMonth?: Date;
+    captionLayout?: CaptionLayout;
+    navLayout?: NavLayout;
+    hideNavigation?: boolean;
+    disableNavigation?: boolean;
     footer?: Snippet | string;
     fixedWeeks?: boolean;
     locale?: string;
@@ -44,7 +65,18 @@
     numberOfMonths = 1,
     min,
     max,
+    required = false,
+    excludeDisabled = false,
     disabled = false,
+    hidden,
+    startMonth,
+    endMonth,
+    fromMonth,
+    toMonth,
+    captionLayout = 'label',
+    navLayout = 'after',
+    hideNavigation = false,
+    disableNavigation = false,
     footer,
     fixedWeeks = true,
     locale = 'en-US',
@@ -63,6 +95,13 @@
   const visibleMonths = $derived(
     Array.from({ length: Math.max(1, numberOfMonths) }, (_, index) => addMonths(displayMonth, index))
   );
+  const navigationStart = $derived(startMonth ?? fromMonth);
+  const navigationEnd = $derived(endMonth ?? toMonth);
+  const canNavigatePrevious = $derived(!disableNavigation && (!navigationStart || compareMonths(addMonths(displayMonth, -1), navigationStart) >= 0));
+  const canNavigateNext = $derived(
+    !disableNavigation && (!navigationEnd || compareMonths(addMonths(displayMonth, numberOfMonths), navigationEnd) <= 0)
+  );
+  const showCaptionDropdowns = $derived(captionLayout !== 'label');
   const rootClass = $derived(cn('rdp-root select-none rounded-xl bg-kumo-base', classNames?.root, reactClassName, className));
 
   function emit(nextSelection: DatePickerSelection) {
@@ -71,7 +110,8 @@
   }
 
   function setMonth(nextMonth: Date) {
-    const normalized = startOfMonth(nextMonth);
+    const normalized = clampMonth(startOfMonth(nextMonth));
+    if (compareMonths(normalized, displayMonth) === 0) return;
     navigationDirection = normalized.getTime() > displayMonth.getTime() ? 'after' : 'before';
     internalMonth = normalized;
     month = normalized;
@@ -91,6 +131,7 @@
       const existingIndex = dates.findIndex((date) => isSameDay(date, day));
 
       if (existingIndex >= 0) {
+        if (required && dates.length <= Math.max(1, min ?? 0)) return;
         emit(dates.filter((_, index) => index !== existingIndex));
         return;
       }
@@ -110,19 +151,21 @@
 
       const nights = differenceInDays(range.from, day);
       if ((min !== undefined && nights < min) || (max !== undefined && nights > max)) return;
+      if (excludeDisabled && rangeContainsMatcher(range.from, day, disabled)) return;
       emit({ from: range.from, to: day });
       return;
     }
 
+    if (required && selected instanceof Date && isSameDay(selected, day)) return;
     emit(day);
   }
 
   function isDisabled(day: Date) {
-    if (disabled === true) return true;
-    if (!disabled) return false;
-    if (disabled instanceof Date) return isSameDay(day, disabled);
-    if (Array.isArray(disabled)) return disabled.some((date) => isSameDay(day, date));
-    return disabled(day);
+    return matches(day, disabled);
+  }
+
+  function isHidden(day: Date) {
+    return matches(day, hidden);
   }
 
   function isSelected(day: Date) {
@@ -163,6 +206,23 @@
     });
   }
 
+  function getMonthOptions() {
+    return Array.from({ length: 12 }, (_, index) => {
+      const optionMonth = new Date(displayMonth.getFullYear(), index, 1);
+      return {
+        value: String(index),
+        label: new Intl.DateTimeFormat(locale, { month: 'long' }).format(optionMonth)
+      };
+    });
+  }
+
+  function getYearOptions() {
+    const currentYear = displayMonth.getFullYear();
+    const startYear = navigationStart?.getFullYear() ?? currentYear - 100;
+    const endYear = navigationEnd?.getFullYear() ?? currentYear + 100;
+    return Array.from({ length: Math.max(1, endYear - startYear + 1) }, (_, index) => startYear + index);
+  }
+
   function getWeeks(monthDate: Date) {
     const firstOfMonth = startOfMonth(monthDate);
     const firstGridDay = addDays(firstOfMonth, -firstOfMonth.getDay());
@@ -187,6 +247,36 @@
     return Boolean(value && !(value instanceof Date) && !Array.isArray(value) && ('from' in value || 'to' in value));
   }
 
+  function isMatcherRange(value: unknown): value is DateRange {
+    return Boolean(value && typeof value === 'object' && ('from' in value || 'to' in value));
+  }
+
+  function matches(day: Date, matcher: DateMatcher | DateMatcher[] | undefined): boolean {
+    if (typeof matcher === 'boolean') return matcher;
+    if (!matcher) return false;
+    if (Array.isArray(matcher)) return matcher.some((entry) => matches(day, entry));
+    if (matcher instanceof Date) return isSameDay(day, matcher);
+    if (typeof matcher === 'function') return matcher(day);
+    if (isMatcherRange(matcher)) {
+      const from = matcher.from ? compareDays(day, matcher.from) >= 0 : true;
+      const to = matcher.to ? compareDays(day, matcher.to) <= 0 : true;
+      return from && to;
+    }
+    if ('before' in matcher) return compareDays(day, matcher.before) < 0;
+    if ('after' in matcher) return compareDays(day, matcher.after) > 0;
+    if ('dayOfWeek' in matcher) return matcher.dayOfWeek.includes(day.getDay());
+    return false;
+  }
+
+  function rangeContainsMatcher(from: Date, to: Date, matcher: DateMatcher | DateMatcher[] | undefined) {
+    const start = compareDays(from, to) <= 0 ? from : to;
+    const end = compareDays(from, to) <= 0 ? to : from;
+    for (let day = startOfDay(start); compareDays(day, end) <= 0; day = addDays(day, 1)) {
+      if (matches(day, matcher)) return true;
+    }
+    return false;
+  }
+
   function startOfDay(date: Date) {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate());
   }
@@ -201,6 +291,16 @@
 
   function addMonths(date: Date, months: number) {
     return new Date(date.getFullYear(), date.getMonth() + months, 1);
+  }
+
+  function compareMonths(a: Date, b: Date) {
+    return startOfMonth(a).getTime() - startOfMonth(b).getTime();
+  }
+
+  function clampMonth(date: Date) {
+    if (navigationStart && compareMonths(date, navigationStart) < 0) return startOfMonth(navigationStart);
+    if (navigationEnd && compareMonths(date, navigationEnd) > 0) return startOfMonth(navigationEnd);
+    return date;
   }
 
   function daysInMonth(date: Date) {
@@ -225,7 +325,7 @@
   }
 </script>
 
-<div class={rootClass} data-nav-layout="after" data-mode={mode} {...rest}>
+<div class={rootClass} data-nav-layout={navLayout} data-mode={mode} {...rest}>
   <div class="rdp-months">
     {#each visibleMonths as visibleMonth, index (visibleMonth.toISOString())}
       <div class={cn('rdp-month', classNames?.month)}>
@@ -236,7 +336,38 @@
             classNames?.month_caption
           )}
         >
-          <span class={cn('rdp-caption_label', classNames?.caption_label)}>{getMonthLabel(visibleMonth)}</span>
+          {#if showCaptionDropdowns && index === 0}
+            <div class="rdp-dropdowns">
+              {#if captionLayout === 'dropdown' || captionLayout === 'dropdown-months'}
+                <select
+                  class={cn('rdp-dropdown rdp-months_dropdown', classNames?.dropdown, classNames?.months_dropdown)}
+                  aria-label="Choose the month"
+                  value={String(displayMonth.getMonth())}
+                  disabled={disableNavigation}
+                  onchange={(event) => setMonth(new Date(displayMonth.getFullYear(), Number(event.currentTarget.value), 1))}
+                >
+                  {#each getMonthOptions() as option (option.value)}
+                    <option value={option.value}>{option.label}</option>
+                  {/each}
+                </select>
+              {/if}
+              {#if captionLayout === 'dropdown' || captionLayout === 'dropdown-years'}
+                <select
+                  class={cn('rdp-dropdown rdp-years_dropdown', classNames?.dropdown, classNames?.years_dropdown)}
+                  aria-label="Choose the year"
+                  value={String(displayMonth.getFullYear())}
+                  disabled={disableNavigation}
+                  onchange={(event) => setMonth(new Date(Number(event.currentTarget.value), displayMonth.getMonth(), 1))}
+                >
+                  {#each getYearOptions() as year (year)}
+                    <option value={String(year)}>{year}</option>
+                  {/each}
+                </select>
+              {/if}
+            </div>
+          {:else}
+            <span class={cn('rdp-caption_label', classNames?.caption_label)}>{getMonthLabel(visibleMonth)}</span>
+          {/if}
         </div>
 
         <div class="rdp-month_grid_wrapper">
@@ -254,10 +385,12 @@
                   {#each week as day (day.toISOString())}
                     {@const outside = day.getMonth() !== visibleMonth.getMonth()}
                     {@const dayDisabled = isDisabled(day)}
+                    {@const dayHidden = isHidden(day)}
                     <td
                       class={cn(
                         'rdp-day',
                         outside && 'rdp-outside',
+                        dayHidden && 'rdp-hidden',
                         isSameDay(day, today) && 'rdp-today',
                         isSelected(day) && 'rdp-selected',
                         dayDisabled && 'rdp-disabled',
@@ -269,16 +402,18 @@
                       )}
                       data-day={day.toISOString()}
                     >
-                      <button
-                        type="button"
-                        class={cn('rdp-day_button', classNames?.day_button)}
-                        disabled={dayDisabled}
-                        aria-label={day.toLocaleDateString(locale, { dateStyle: 'full' })}
-                        aria-pressed={isSelected(day)}
-                        onclick={() => handleDayClick(day)}
-                      >
-                        {day.getDate()}
-                      </button>
+                      {#if !dayHidden}
+                        <button
+                          type="button"
+                          class={cn('rdp-day_button', classNames?.day_button)}
+                          disabled={dayDisabled}
+                          aria-label={day.toLocaleDateString(locale, { dateStyle: 'full' })}
+                          aria-pressed={isSelected(day)}
+                          onclick={() => handleDayClick(day)}
+                        >
+                          {day.getDate()}
+                        </button>
+                      {/if}
                     </td>
                   {/each}
                 </tr>
@@ -290,11 +425,13 @@
     {/each}
   </div>
 
+  {#if !hideNavigation}
   <div class={cn('rdp-nav', classNames?.nav)}>
     <button
       type="button"
       class={cn('rdp-button_previous', classNames?.button_previous)}
       aria-label="Previous month"
+      disabled={!canNavigatePrevious}
       onclick={() => setMonth(addMonths(displayMonth, -1))}
     >
       <CaretLeft class="rdp-chevron" size={16} aria-hidden="true" />
@@ -303,11 +440,13 @@
       type="button"
       class={cn('rdp-button_next', classNames?.button_next)}
       aria-label="Next month"
+      disabled={!canNavigateNext}
       onclick={() => setMonth(addMonths(displayMonth, 1))}
     >
       <CaretRight class="rdp-chevron" size={16} aria-hidden="true" />
     </button>
   </div>
+  {/if}
 
   {#if footer}
     <div class={cn('rdp-footer', classNames?.footer)}>

--- a/packages/kumo-svelte/src/lib/components/date-picker/date-picker.test.ts
+++ b/packages/kumo-svelte/src/lib/components/date-picker/date-picker.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import DatePicker from './DatePicker.svelte';
+
+describe('DatePicker', () => {
+  it('supports hidden and object disabled matchers', () => {
+    render(DatePicker, {
+      month: new Date(2026, 0, 1),
+      hidden: new Date(2026, 0, 10),
+      disabled: [{ dayOfWeek: [0, 6] }, { before: new Date(2026, 0, 5) }]
+    });
+
+    expect(screen.queryByRole('button', { name: 'Saturday, January 10, 2026' })).toBeNull();
+    expect((screen.getByRole('button', { name: 'Sunday, January 11, 2026' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Friday, January 2, 2026' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Monday, January 5, 2026' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('prevents ranges that include disabled dates when excludeDisabled is set', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(DatePicker, {
+      mode: 'range',
+      month: new Date(2026, 0, 1),
+      disabled: new Date(2026, 0, 7),
+      excludeDisabled: true,
+      onChange
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Monday, January 5, 2026' }));
+    await user.click(screen.getByRole('button', { name: 'Friday, January 9, 2026' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith({ from: new Date(2026, 0, 5), to: undefined });
+  });
+
+  it('renders caption dropdowns and clamps disabled navigation', () => {
+    render(DatePicker, {
+      month: new Date(2026, 0, 1),
+      startMonth: new Date(2026, 0, 1),
+      endMonth: new Date(2026, 1, 1),
+      captionLayout: 'dropdown'
+    });
+
+    expect((screen.getByRole('combobox', { name: 'Choose the month' }) as HTMLSelectElement).value).toBe('0');
+    expect((screen.getByRole('combobox', { name: 'Choose the year' }) as HTMLSelectElement).value).toBe('2026');
+    expect((screen.getByRole('button', { name: 'Previous month' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Next month' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
@@ -152,7 +152,7 @@
 </script>
 
 {#snippet triggerChild({ props }: { props: Record<string, unknown> })}
-  {@render trigger?.(props)}
+  {@render trigger?.({ ...props, 'data-kumo-component': 'Dialog', 'data-kumo-part': 'trigger' })}
 {/snippet}
 
 {#if role === 'alertdialog'}

--- a/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
@@ -18,6 +18,8 @@
 <DropdownMenuPrimitive.CheckboxItem
   bind:checked
   {onCheckedChange}
+  data-kumo-component="DropdownMenu"
+  data-kumo-part="checkbox-item"
   class={cn(
     'relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-base outline-hidden transition-colors select-none focus:bg-kumo-tint focus:text-kumo-default focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
     className

--- a/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuItem.svelte
@@ -63,7 +63,7 @@
   );
 </script>
 
-<DropdownMenuPrimitive.Item class={itemClasses} {disabled} {...rest}>
+<DropdownMenuPrimitive.Item class={itemClasses} {disabled} data-kumo-component="DropdownMenu" data-kumo-part="item" {...rest}>
   {#if href}
     {#snippet child({ props }: { props: Record<string, unknown> })}
       <a
@@ -71,6 +71,8 @@
         {href}
         {target}
         rel={rel ?? (target === '_blank' ? 'noreferrer' : undefined)}
+        data-kumo-component="DropdownMenu"
+        data-kumo-part="link-item"
         class={cn('flex w-full items-center text-inherit no-underline', props.class as string | undefined)}
       >
         {#if Icon}<Icon class="mr-2 h-4 w-4" />{/if}

--- a/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuRadioItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuRadioItem.svelte
@@ -17,6 +17,8 @@
 
 <DropdownMenuPrimitive.RadioItem
   {value}
+  data-kumo-component="DropdownMenu"
+  data-kumo-part="radio-item"
   class={cn(
     'relative flex cursor-default items-center rounded-md px-2 py-1.5 text-base outline-hidden select-none',
     'data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-kumo-tint',

--- a/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuSubTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/dropdown-menu/DropdownMenuSubTrigger.svelte
@@ -16,6 +16,8 @@
 </script>
 
 <DropdownMenuPrimitive.SubTrigger
+  data-kumo-component="DropdownMenu"
+  data-kumo-part="submenu-trigger"
   class={cn(
     'flex cursor-default items-center rounded-sm text-base outline-hidden select-none',
     'px-2 py-1.5',

--- a/packages/kumo-svelte/src/lib/components/filter.ts
+++ b/packages/kumo-svelte/src/lib/components/filter.ts
@@ -1,0 +1,29 @@
+export interface KumoFilterOptions {
+  locale?: string | string[];
+}
+
+export function createKumoFilter(options: KumoFilterOptions = {}) {
+  const collator = new Intl.Collator(options.locale, {
+    sensitivity: 'base',
+    usage: 'search'
+  });
+
+  function includes(source: string, query: string) {
+    const normalizedSource = source.normalize('NFC');
+    const normalizedQuery = query.trim().normalize('NFC');
+
+    if (!normalizedQuery) return true;
+    if (normalizedQuery.length > normalizedSource.length) return false;
+
+    for (let index = 0; index <= normalizedSource.length - normalizedQuery.length; index += 1) {
+      const slice = normalizedSource.slice(index, index + normalizedQuery.length);
+      if (collator.compare(slice, normalizedQuery) === 0) return true;
+    }
+
+    return false;
+  }
+
+  return {
+    contains: includes
+  };
+}

--- a/packages/kumo-svelte/src/lib/components/flow/Flow.svelte
+++ b/packages/kumo-svelte/src/lib/components/flow/Flow.svelte
@@ -5,6 +5,8 @@
   import { setFlowContext, type FlowAlign, type FlowOrientation } from './context';
   import FlowList from './FlowList.svelte';
 
+  const MIN_SCROLLBAR_THUMB_SIZE = 10;
+
   interface Props {
     children?: Snippet;
     class?: string;
@@ -31,9 +33,39 @@
   let contentElement = $state<HTMLDivElement>();
   let resizeObserver: ResizeObserver | undefined;
   let previousOverflow: { x: boolean; y: boolean } | undefined;
+  let bounds = $state<{ x: number; y: number }>({ x: 0, y: 0 });
+  let dimensions = $state({
+    viewportWidth: 0,
+    viewportHeight: 0,
+    contentWidth: 0,
+    contentHeight: 0
+  });
+  let panX = $state(0);
+  let panY = $state(0);
+  let isPanning = $state(false);
+  let lastPointer = $state<{ x: number; y: number } | null>(null);
 
   const paddingX = $derived(padding?.x ?? 16);
   const paddingY = $derived(padding?.y ?? 64);
+  const canScrollX = $derived(bounds.x < 0);
+  const canScrollY = $derived(bounds.y < 0);
+  const canPan = $derived(canScrollX || canScrollY);
+  const scrollThumbWidth = $derived(
+    dimensions.contentWidth > 0 && dimensions.viewportWidth > 0
+      ? Math.max(MIN_SCROLLBAR_THUMB_SIZE, (dimensions.viewportWidth / dimensions.contentWidth) * 100)
+      : 0
+  );
+  const scrollThumbHeight = $derived(
+    dimensions.contentHeight > 0 && dimensions.viewportHeight > 0
+      ? Math.max(MIN_SCROLLBAR_THUMB_SIZE, (dimensions.viewportHeight / dimensions.contentHeight) * 100)
+      : 0
+  );
+  const scrollbarXPercent = $derived(
+    bounds.x < 0 ? (panX / bounds.x) * (100 - scrollThumbWidth) : 0
+  );
+  const scrollbarYPercent = $derived(
+    bounds.y < 0 ? (panY / bounds.y) * (100 - scrollThumbHeight) : 0
+  );
 
   setFlowContext({
     get orientation() {
@@ -44,19 +76,94 @@
     }
   });
 
+  function isEventFromNode(target: EventTarget | null) {
+    return target instanceof Element && target.closest('[data-node-id]') !== null;
+  }
+
+  function clamp(value: number, min: number, max: number) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function updateBodyPanState(active: boolean) {
+    document.body.style.cursor = active ? 'grabbing' : '';
+    document.body.style.userSelect = active ? 'none' : '';
+  }
+
+  function endPan() {
+    if (!isPanning) return;
+    isPanning = false;
+    lastPointer = null;
+    updateBodyPanState(false);
+  }
+
   function measureOverflow() {
     if (!canvas || !wrapperElement || !contentElement) return;
 
-    const availableWidth = wrapperElement.clientWidth - paddingX * 2;
-    const availableHeight = wrapperElement.clientHeight - paddingY * 2;
-    const overflow = {
-      x: contentElement.scrollWidth > availableWidth,
-      y: contentElement.scrollHeight > availableHeight
+    const wrapper = wrapperElement.getBoundingClientRect();
+    const content = contentElement.getBoundingClientRect();
+    const availableWidth = wrapper.width - paddingX * 2;
+    const availableHeight = wrapper.height - paddingY * 2;
+    const nextBounds = {
+      x: Math.min(0, availableWidth - content.width),
+      y: Math.min(0, availableHeight - content.height)
     };
+    const overflow = {
+      x: content.width > availableWidth,
+      y: content.height > availableHeight
+    };
+
+    bounds = nextBounds;
+    dimensions = {
+      viewportWidth: availableWidth,
+      viewportHeight: availableHeight,
+      contentWidth: content.width,
+      contentHeight: content.height
+    };
+    panX = clamp(panX, nextBounds.x, 0);
+    panY = clamp(panY, nextBounds.y, 0);
 
     if (previousOverflow?.x === overflow.x && previousOverflow?.y === overflow.y) return;
     previousOverflow = overflow;
     onOverflowChange?.(overflow);
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (!canvas || !canPan || event.button !== 0 || isEventFromNode(event.target)) return;
+
+    isPanning = true;
+    lastPointer = { x: event.clientX, y: event.clientY };
+    updateBodyPanState(true);
+    wrapperElement?.setPointerCapture?.(event.pointerId);
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!isPanning || !lastPointer) return;
+
+    const deltaX = event.clientX - lastPointer.x;
+    const deltaY = event.clientY - lastPointer.y;
+    lastPointer = { x: event.clientX, y: event.clientY };
+
+    panX = clamp(panX + deltaX, bounds.x, 0);
+    panY = clamp(panY + deltaY, bounds.y, 0);
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    wrapperElement?.releasePointerCapture?.(event.pointerId);
+    endPan();
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (!canvas || !canPan) return;
+
+    event.preventDefault();
+
+    if (canScrollX) {
+      panX = clamp(panX - event.deltaX, bounds.x, 0);
+    }
+
+    if (canScrollY) {
+      panY = clamp(panY - event.deltaY, bounds.y, 0);
+    }
   }
 
   onMount(() => {
@@ -68,6 +175,7 @@
 
     return () => {
       resizeObserver?.disconnect();
+      updateBodyPanState(false);
     };
   });
 
@@ -81,7 +189,12 @@
 </script>
 
 {#snippet contents()}
-  <div bind:this={contentElement} class="w-max mx-auto" data-testid="flow-contents">
+  <div
+    bind:this={contentElement}
+    class="w-max mx-auto"
+    style:transform={`translate(${panX}px, ${panY}px)`}
+    data-testid="flow-contents"
+  >
     <FlowList>
       {@render children?.()}
     </FlowList>
@@ -91,14 +204,44 @@
 {#if canvas}
   <div
     bind:this={wrapperElement}
-    class={cn('relative isolate grow overflow-auto', className)}
+    class={cn('group relative isolate grow overflow-hidden', className)}
     style:padding-top={`${paddingY}px`}
     style:padding-bottom={`${paddingY}px`}
     style:padding-left={`${paddingX}px`}
     style:padding-right={`${paddingX}px`}
+    style:cursor={canPan && !isPanning ? 'grab' : undefined}
+    onpointerdown={handlePointerDown}
+    onpointermove={handlePointerMove}
+    onpointerup={handlePointerUp}
+    onpointercancel={handlePointerUp}
+    onwheel={handleWheel}
     {...rest}
   >
     {@render contents()}
+
+    {#if canScrollY}
+      <div
+        class="absolute bottom-1 right-1 top-1 w-1.5 rounded-full bg-kumo-hairline/50 opacity-0 group-hover:opacity-100"
+      >
+        <div
+          class="absolute w-full rounded-full bg-kumo-fill"
+          style:height={`${scrollThumbHeight}%`}
+          style:top={`${scrollbarYPercent}%`}
+        ></div>
+      </div>
+    {/if}
+
+    {#if canScrollX}
+      <div
+        class="absolute bottom-1 left-1 right-1 h-1.5 rounded-full bg-kumo-hairline/50 opacity-0 group-hover:opacity-100"
+      >
+        <div
+          class="absolute h-full rounded-full bg-kumo-fill"
+          style:width={`${scrollThumbWidth}%`}
+          style:left={`${scrollbarXPercent}%`}
+        ></div>
+      </div>
+    {/if}
   </div>
 {:else}
   <div bind:this={wrapperElement} class={cn('relative isolate grow', className)} {...rest}>

--- a/packages/kumo-svelte/src/lib/components/flow/FlowPanningTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/flow/FlowPanningTestHost.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { Flow } from './index';
+</script>
+
+<Flow data-testid="flow-wrapper" padding={{ x: 0, y: 0 }}>
+  <Flow.Node id="start">Start</Flow.Node>
+  <Flow.Node id="middle">Middle</Flow.Node>
+  <Flow.Node id="end">End</Flow.Node>
+</Flow>

--- a/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FlowPanningTestHost from './FlowPanningTestHost.svelte';
+
+const resizeObservers: TestResizeObserver[] = [];
+
+class TestResizeObserver implements ResizeObserver {
+  readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    resizeObservers.push(this);
+  }
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+function setRect(element: Element, rect: Partial<DOMRect>) {
+  const nextRect = {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: rect.width ?? 0,
+    bottom: rect.height ?? 0,
+    width: 0,
+    height: 0,
+    ...rect,
+  } as DOMRect;
+
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(nextRect);
+}
+
+async function measure() {
+  for (const observer of resizeObservers) {
+    observer.callback([], observer);
+  }
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  resizeObservers.length = 0;
+  vi.stubGlobal('ResizeObserver', TestResizeObserver);
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+});
+
+describe('Flow canvas panning', () => {
+  it('pans with the wheel and clamps to measured bounds', async () => {
+    render(FlowPanningTestHost);
+
+    const wrapper = screen.getByTestId('flow-wrapper');
+    const contents = screen.getByTestId('flow-contents');
+    setRect(wrapper, { width: 300, height: 200 });
+    setRect(contents, { width: 800, height: 500 });
+    await measure();
+
+    await fireEvent.wheel(wrapper, { deltaX: 700, deltaY: 400 });
+    expect(contents.style.transform).toBe('translate(-500px, -300px)');
+
+    await fireEvent.wheel(wrapper, { deltaX: -1000, deltaY: -1000 });
+    expect(contents.style.transform).toBe('translate(0px, 0px)');
+  });
+
+  it('drag-pans the canvas while ignoring drags that start on nodes', async () => {
+    render(FlowPanningTestHost);
+
+    const wrapper = screen.getByTestId('flow-wrapper');
+    const contents = screen.getByTestId('flow-contents');
+    setRect(wrapper, { width: 300, height: 200 });
+    setRect(contents, { width: 800, height: 500 });
+    await measure();
+
+    await fireEvent.pointerDown(screen.getByTestId('start'), {
+      button: 0,
+      clientX: 100,
+      clientY: 100,
+      pointerId: 1,
+    });
+    await fireEvent.pointerMove(wrapper, {
+      clientX: 50,
+      clientY: 50,
+      pointerId: 1,
+    });
+    expect(contents.style.transform).toBe('translate(0px, 0px)');
+
+    await fireEvent.pointerDown(wrapper, {
+      button: 0,
+      clientX: 100,
+      clientY: 100,
+      pointerId: 2,
+    });
+    expect(document.body.style.cursor).toBe('grabbing');
+    expect(document.body.style.userSelect).toBe('none');
+
+    await fireEvent.pointerMove(wrapper, {
+      clientX: 40,
+      clientY: 10,
+      pointerId: 2,
+    });
+    expect(contents.style.transform).toBe('translate(-60px, -90px)');
+
+    await fireEvent.pointerUp(wrapper, { pointerId: 2 });
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/input-group/InputGroupAddon.svelte
+++ b/packages/kumo-svelte/src/lib/components/input-group/InputGroupAddon.svelte
@@ -25,6 +25,9 @@
     'relative z-[1] pointer-events-none flex shrink-0 items-center gap-1.5 text-kumo-subtle',
     '*:pointer-events-auto',
     tokens.fontSize,
+    tokens.addonIconSize,
+    tokens.addonLoaderSize,
+    '[&>svg]:shrink-0',
     align === 'start'
       ? cn('-order-1 pr-0', containsButton ? tokens.addonButtonOuterStart : tokens.addonOuterStart)
       : cn('order-1 pl-0', containsButton ? tokens.addonButtonOuterEnd : tokens.addonOuterEnd),

--- a/packages/kumo-svelte/src/lib/components/input-group/InputGroupButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/input-group/InputGroupButton.svelte
@@ -2,7 +2,12 @@
   import type { Component, Snippet } from 'svelte';
   import { Button } from '$lib/components/button';
   import { cn } from '$lib/utils/cn';
-  import { getInputGroupContext, INPUT_GROUP_SIZE, type InputGroupSize } from './context';
+  import {
+    getInputGroupAddonContext,
+    getInputGroupContext,
+    INPUT_GROUP_SIZE,
+    type InputGroupSize
+  } from './context';
 
   type Variant = 'primary' | 'secondary' | 'ghost' | 'destructive' | 'secondary-destructive' | 'outline';
   type Shape = 'base' | 'square' | 'circle';
@@ -41,10 +46,12 @@
   }: Props = $props();
 
   const context = getInputGroupContext();
+  const inAddon = getInputGroupAddonContext();
   const groupSize = $derived(context?.size ?? 'base');
   const isIndividual = $derived(context?.focusMode === 'individual' || context?.focusMode === 'hybrid');
   const effectiveSize = $derived(size ?? (isIndividual ? groupSize : compactButtonSize[groupSize]));
   const iconClass = $derived(INPUT_GROUP_SIZE[groupSize].iconSize);
+  const childIconClass = $derived(INPUT_GROUP_SIZE[groupSize].addonIconSize);
 </script>
 
 <Button
@@ -59,10 +66,9 @@
     isIndividual && [
       'relative h-full! rounded-none ring-0 border border-kumo-line',
       'first:rounded-l-[inherit] last:rounded-r-[inherit]',
-      'not-first:border-l-0',
-      'hover:z-[1]',
-      'focus:z-[2] focus:border-kumo-line',
-      'focus-visible:[outline:solid_1px_var(--color-kumo-focus)] focus-visible:[outline-offset:-1px]',
+      'not-first:-ml-px',
+      'hover:z-1',
+      'focus:z-2 focus-visible:border-kumo-focus/50',
       'disabled:bg-kumo-overlay disabled:text-kumo-inactive!'
     ],
     className
@@ -72,5 +78,9 @@
   {#if IconComponent}
     <IconComponent class={iconClass} />
   {/if}
-  {@render children?.()}
+  {#if children}
+    <span class={cn('contents', childIconClass, '[&>svg]:shrink-0')}>
+      {@render children()}
+    </span>
+  {/if}
 </Button>

--- a/packages/kumo-svelte/src/lib/components/input-group/InputGroupInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/input-group/InputGroupInput.svelte
@@ -53,9 +53,9 @@
       ? [
           'relative ring-0 border border-kumo-line',
           'first:rounded-l-[inherit] last:rounded-r-[inherit]',
-          'not-first:border-l-0',
-          'hover:z-[1] hover:border-kumo-line',
-          'focus:z-[2] focus:border-kumo-line focus:[outline:solid_1px_var(--color-kumo-focus)] focus:[outline-offset:-1px]'
+          'not-first:-ml-px',
+          'hover:z-1 hover:border-kumo-line',
+          'focus:z-2 focus:border-kumo-focus/50'
         ]
       : 'relative z-[1] ring-0! shadow-none focus:ring-0! focus:outline-none',
     className

--- a/packages/kumo-svelte/src/lib/components/input-group/context.ts
+++ b/packages/kumo-svelte/src/lib/components/input-group/context.ts
@@ -13,6 +13,8 @@ export interface InputGroupSizeTokens {
   addonButtonOuterEnd: string;
   suffixPad: string;
   fontSize: string;
+  addonIconSize: string;
+  addonLoaderSize: string;
   iconSize: string;
 }
 
@@ -25,6 +27,8 @@ export const INPUT_GROUP_SIZE: Record<InputGroupSize, InputGroupSizeTokens> = {
     addonButtonOuterEnd: 'pr-1',
     suffixPad: 'pr-1.5',
     fontSize: 'text-xs',
+    addonIconSize: '[&>svg]:size-2.5',
+    addonLoaderSize: '[&>svg[role=status]]:size-2.5!',
     iconSize: 'size-2.5'
   },
   sm: {
@@ -35,6 +39,8 @@ export const INPUT_GROUP_SIZE: Record<InputGroupSize, InputGroupSizeTokens> = {
     addonButtonOuterEnd: 'pr-1',
     suffixPad: 'pr-2',
     fontSize: 'text-xs',
+    addonIconSize: '[&>svg]:size-3.5',
+    addonLoaderSize: '[&>svg[role=status]]:size-3.5!',
     iconSize: 'size-3.5'
   },
   base: {
@@ -45,6 +51,8 @@ export const INPUT_GROUP_SIZE: Record<InputGroupSize, InputGroupSizeTokens> = {
     addonButtonOuterEnd: 'pr-1',
     suffixPad: 'pr-3',
     fontSize: 'text-base',
+    addonIconSize: '[&>svg]:size-4.5',
+    addonLoaderSize: '[&>svg[role=status]]:size-4.5!',
     iconSize: 'size-4.5'
   },
   lg: {
@@ -55,25 +63,27 @@ export const INPUT_GROUP_SIZE: Record<InputGroupSize, InputGroupSizeTokens> = {
     addonButtonOuterEnd: 'pr-1.5',
     suffixPad: 'pr-4',
     fontSize: 'text-base',
+    addonIconSize: '[&>svg]:size-5',
+    addonLoaderSize: '[&>svg[role=status]]:size-5!',
     iconSize: 'size-5'
   }
 };
 
 export const INPUT_GROUP_HAS_CLASSES: Record<InputGroupSize, string> = {
   xs: [
-    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-1',
+    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-0.5',
     'has-[[data-slot=input-group-addon-end]]:[&_input]:pr-1'
   ].join(' '),
   sm: [
-    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-1.5',
+    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-1',
     'has-[[data-slot=input-group-addon-end]]:[&_input]:pr-1.5'
   ].join(' '),
   base: [
-    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-2',
+    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-1.5',
     'has-[[data-slot=input-group-addon-end]]:[&_input]:pr-2'
   ].join(' '),
   lg: [
-    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-2.5',
+    'has-[[data-slot=input-group-addon-start]]:[&_input]:pl-2',
     'has-[[data-slot=input-group-addon-end]]:[&_input]:pr-2.5'
   ].join(' ')
 };

--- a/packages/kumo-svelte/src/lib/components/input/Input.svelte
+++ b/packages/kumo-svelte/src/lib/components/input/Input.svelte
@@ -81,7 +81,7 @@
     bind:value
     id={inputId}
     class={cn(
-      'border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none focus:outline-none',
+      'block w-full border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none focus:outline-none',
       'placeholder:text-kumo-muted disabled:text-kumo-disabled',
       sizes[size],
       normalizedVariant === 'error'

--- a/packages/kumo-svelte/src/lib/components/link/Link.svelte
+++ b/packages/kumo-svelte/src/lib/components/link/Link.svelte
@@ -66,6 +66,8 @@
 
 <a
   class={cn(linkVariants({ variant }), 'group/link inline-flex items-center gap-[0.1875em]', className)}
+  data-kumo-component="Link"
+  data-kumo-part="link"
   href={resolvedHref}
   {...rest}
 >

--- a/packages/kumo-svelte/src/lib/components/menu-bar/MenuBar.svelte
+++ b/packages/kumo-svelte/src/lib/components/menu-bar/MenuBar.svelte
@@ -122,6 +122,8 @@
       <button
         {...props}
         aria-label={option.tooltip}
+        data-kumo-component="MenuBar"
+        data-kumo-part="option"
         class={cn(
           'relative -ml-px flex h-full w-11 cursor-pointer items-center justify-center rounded-md border-none bg-kumo-recessed first:rounded-l-lg last:rounded-r-lg transition-colors focus:z-3 focus:outline-none focus:ring-kumo-focus/50 focus-visible:z-3 focus-visible:ring-2 focus-visible:ring-kumo-brand',
           isActive === id && 'z-2 bg-kumo-base shadow-xs transition-colors'

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
@@ -34,9 +34,6 @@
     commitPage(context.editingPage);
   }
 
-  function commitSelectedPage(nextPage: unknown) {
-    commitPage(Number(nextPage));
-  }
 </script>
 
 <div data-slot="pagination-controls" class={cn('grow flex flex-col items-end', className)} {...rest}>
@@ -64,10 +61,15 @@
         {#if pageSelector === 'dropdown'}
           <Select
             aria-label={context.labels.pageNumber}
-            class="w-max rounded-none ring-kumo-hairline"
+            class="rounded-none ring-kumo-hairline"
+            contentClass="max-h-56"
             value={context.page}
             options={pageOptions}
-            onValueChange={commitSelectedPage}
+            onValueChange={(nextPage) => {
+              const page = Number(nextPage);
+              context.setPage(page);
+              context.setEditingPage(page);
+            }}
           />
         {:else}
           <InputGroupInput

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { CaretDoubleLeft, CaretDoubleRight, CaretLeft, CaretRight } from 'phosphor-svelte';
   import { InputGroup, InputGroupButton, InputGroupInput } from '$lib/components/input-group';
+  import { Select } from '$lib/components/select';
   import { cn } from '$lib/utils/cn';
   import { clamp, getPaginationContext } from './context';
 
@@ -19,7 +20,7 @@
   const pageOptions = $derived(
     Array.from({ length: context.maxPage }, (_, index) => {
       const page = index + 1;
-      return { label: String(page), value: String(page) };
+      return { label: String(page), value: page };
     })
   );
 
@@ -31,6 +32,10 @@
 
   function commitEditingPage() {
     commitPage(context.editingPage);
+  }
+
+  function commitSelectedPage(nextPage: unknown) {
+    commitPage(Number(nextPage));
   }
 </script>
 
@@ -57,16 +62,13 @@
       </InputGroupButton>
       {#if controls === 'full'}
         {#if pageSelector === 'dropdown'}
-          <select
+          <Select
             aria-label={context.labels.pageNumber}
-            class="h-9 rounded-none bg-kumo-base px-3 text-base text-kumo-default shadow-xs outline-none ring ring-kumo-hairline focus:ring-2 focus:ring-kumo-focus/50"
+            class="w-max rounded-none ring-kumo-hairline"
             value={context.page}
-            onchange={(event) => commitPage(Number(event.currentTarget.value))}
-          >
-            {#each pageOptions as option (option.value)}
-              <option value={option.value}>{option.label}</option>
-            {/each}
-          </select>
+            options={pageOptions}
+            onValueChange={commitSelectedPage}
+          />
         {:else}
           <InputGroupInput
             style="width: 50px"

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationDropdownTest.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationDropdownTest.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Pagination from './Pagination.svelte';
+  import PaginationControls from './PaginationControls.svelte';
+
+  interface Props {
+    page?: number;
+    setPage?: (page: number) => void;
+  }
+
+  let { page = 1, setPage = () => {} }: Props = $props();
+</script>
+
+<Pagination {page} {setPage} perPage={10} totalCount={30}>
+  <PaginationControls pageSelector="dropdown" />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationPageSize.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationPageSize.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { Select } from '$lib/components/select';
   import { cn } from '$lib/utils/cn';
   import { getPaginationContext } from './context';
 
@@ -24,9 +25,9 @@
   }: Props = $props();
 
   const context = getPaginationContext();
-  const selectOptions = $derived(options.map((size) => ({ label: String(size), value: String(size) })));
+  const selectOptions = $derived(options.map((size) => ({ label: String(size), value: size })));
 
-  function handleChange(nextValue: string) {
+  function handleChange(nextValue: unknown) {
     const nextSize = Number(nextValue);
     value = nextSize;
     onChange(nextSize);
@@ -43,14 +44,11 @@
       {/if}
     </span>
   {/if}
-  <select
+  <Select
     aria-label={context.labels.pageSize}
-    class="h-9 rounded-lg bg-kumo-base px-3 text-base text-kumo-default shadow-xs outline-none ring ring-kumo-line focus:ring-2 focus:ring-kumo-focus/50"
+    class="w-max ring-kumo-hairline"
     {value}
-    onchange={(event) => handleChange(event.currentTarget.value)}
-  >
-    {#each selectOptions as option (option.value)}
-      <option value={option.value}>{option.label}</option>
-    {/each}
-  </select>
+    options={selectOptions}
+    onValueChange={handleChange}
+  />
 </div>

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationSimpleTest.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationSimpleTest.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Pagination from './Pagination.svelte';
+
+  interface Props {
+    onPageChange?: (page: number) => void;
+  }
+
+  let { onPageChange = () => {} }: Props = $props();
+  let page = $state(2);
+
+  function setPage(nextPage: number) {
+    page = nextPage;
+    onPageChange(nextPage);
+  }
+</script>
+
+<Pagination bind:page {setPage} perPage={10} totalCount={30} controls="simple" />

--- a/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
+++ b/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import Pagination from './Pagination.svelte';
+
+describe('Pagination', () => {
+  it('renders range text and disables boundary controls', () => {
+    render(Pagination, {
+      page: 1,
+      perPage: 10,
+      totalCount: 95
+    });
+
+    expect(screen.getByText((_content, element) => element?.textContent === 'Showing 1-10 of 95')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'First page' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Previous page' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Next page' }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: 'Last page' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('emits clamped page updates from the input selector', async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+
+    render(Pagination, {
+      page: 2,
+      setPage,
+      perPage: 10,
+      totalCount: 25
+    });
+
+    const input = screen.getByRole('textbox', { name: 'Page number' });
+    await user.clear(input);
+    await user.type(input, '99{Enter}');
+
+    expect(setPage).toHaveBeenCalledWith(3);
+  });
+
+  it('supports simple previous and next controls', async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+
+    render(Pagination, {
+      page: 2,
+      setPage,
+      pages: 3,
+      controls: 'simple'
+    });
+
+    expect(screen.queryByRole('button', { name: 'First page' })).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(setPage).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
+++ b/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import PaginationDropdownTest from './PaginationDropdownTest.svelte';
+import PaginationSimpleTest from './PaginationSimpleTest.svelte';
 import Pagination from './Pagination.svelte';
 
 describe('Pagination', () => {
@@ -38,17 +40,29 @@ describe('Pagination', () => {
 
   it('supports simple previous and next controls', async () => {
     const user = userEvent.setup();
-    const setPage = vi.fn();
+    const onPageChange = vi.fn();
 
-    render(Pagination, {
-      page: 2,
-      setPage,
-      pages: 3,
-      controls: 'simple'
+    render(PaginationSimpleTest, {
+      onPageChange
     });
 
     expect(screen.queryByRole('button', { name: 'First page' })).toBeNull();
     await user.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('updates the page from the dropdown selector', async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+
+    render(PaginationDropdownTest, {
+      page: 1,
+      setPage
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Page number' }));
+    await user.click(screen.getByRole('option', { name: '3' }));
 
     expect(setPage).toHaveBeenCalledWith(3);
   });

--- a/packages/kumo-svelte/src/lib/components/popover/PopoverContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/popover/PopoverContent.svelte
@@ -26,7 +26,7 @@
     class: className,
     side = 'bottom',
     align = 'center',
-    sideOffset = 0,
+    sideOffset = 8,
     alignOffset = 0,
     strategy,
     positionMethod,

--- a/packages/kumo-svelte/src/lib/components/popover/PopoverContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/popover/PopoverContent.svelte
@@ -39,6 +39,7 @@
   let contentClass = $derived(
     cn(
       'kumo-popover-popup flex origin-(--bits-floating-transform-origin) flex-col rounded-lg bg-kumo-base px-4 py-3 text-sm text-kumo-default',
+      'z-50',
       'shadow-lg shadow-kumo-tip-shadow outline outline-kumo-fill',
       'transition-[transform,scale,opacity] duration-150',
       'data-starting-style:scale-90 data-starting-style:opacity-0',
@@ -106,12 +107,14 @@
   :global(.kumo-popover-arrow[data-side='left']) {
     right: -13px !important;
     left: auto !important;
+    transform-origin: center center !important;
     transform: none !important;
   }
 
   :global(.kumo-popover-arrow[data-side='right']) {
     right: auto !important;
     left: -13px !important;
+    transform-origin: center center !important;
     transform: none !important;
   }
 </style>

--- a/packages/kumo-svelte/src/lib/components/popover/PopoverTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/popover/PopoverTrigger.svelte
@@ -27,7 +27,7 @@
 </script>
 
 {#snippet defaultTriggerChild({ props }: { props: Record<string, unknown> })}
-  <button {...props} class={cn('inline-flex', className, props.class as string | undefined)} {type}>
+  <button {...props} class={cn('inline-flex', className, props.class as string | undefined)} {type} data-kumo-component="Popover" data-kumo-part="trigger">
     {@render children?.()}
   </button>
 {/snippet}

--- a/packages/kumo-svelte/src/lib/components/radio/Radio.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/Radio.svelte
@@ -1,7 +1,51 @@
 <script module lang="ts">
-  export type RadioVariant = 'default' | 'error';
-  export type RadioAppearance = 'default' | 'card';
+  import { cn } from '$lib/utils/cn';
+
+  export const KUMO_RADIO_VARIANTS = {
+    variant: {
+      default: {
+        classes: 'ring-kumo-hairline',
+        description: 'Default radio appearance'
+      },
+      error: {
+        classes: 'ring-kumo-danger',
+        description: 'Error state for validation failures'
+      }
+    },
+    appearance: {
+      default: {
+        classes: '',
+        description: 'Standard inline radio item'
+      },
+      card: {
+        classes:
+          'rounded-lg border border-kumo-hairline bg-kumo-base p-3 transition-colors hover:bg-kumo-tint has-[[data-state=checked]]:border-kumo-interact has-[[data-state=checked]]:bg-kumo-tint',
+        description:
+          'Choice card appearance with border, padding, and highlighted selection state'
+      }
+    }
+  } as const;
+
+  export const KUMO_RADIO_DEFAULT_VARIANTS = {
+    variant: 'default',
+    appearance: 'default'
+  } as const;
+
+  export type KumoRadioVariant = keyof typeof KUMO_RADIO_VARIANTS.variant;
+  export type KumoRadioAppearance = keyof typeof KUMO_RADIO_VARIANTS.appearance;
+  export type RadioVariant = KumoRadioVariant;
+  export type RadioAppearance = KumoRadioAppearance;
   export type RadioControlPosition = 'start' | 'end';
+
+  export function radioVariants({
+    variant = KUMO_RADIO_DEFAULT_VARIANTS.variant,
+    appearance = KUMO_RADIO_DEFAULT_VARIANTS.appearance
+  }: { variant?: KumoRadioVariant; appearance?: KumoRadioAppearance } = {}) {
+    return cn(
+      KUMO_RADIO_VARIANTS.variant[variant].classes,
+      KUMO_RADIO_VARIANTS.appearance[appearance].classes
+    );
+  }
 </script>
 
 <script lang="ts">

--- a/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
@@ -58,7 +58,7 @@
 <RadioGroupPrimitive.Root bind:value {orientation} {disabled} {required} {name} {onValueChange}>
   <fieldset class={cn('flex flex-col gap-4', className)} {disabled}>
     {#if legend}
-      <legend class="mb-4 text-base font-medium text-kumo-default">
+      <legend class="text-base font-medium text-kumo-default">
         {legend}
       </legend>
     {/if}

--- a/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
@@ -43,6 +43,8 @@
   <RadioGroupPrimitive.Item
     {value}
     {disabled}
+    data-kumo-component="Radio"
+    data-kumo-part="item"
     class={cn(
       isCard
         ? 'relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring ring-2 focus:outline-none focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand'
@@ -73,6 +75,8 @@
 
 {#if isCard}
   <label
+    data-kumo-component="Radio"
+    data-kumo-part="item-label"
     class={cn(
       'm-0 group relative flex items-start gap-3 rounded-lg border border-kumo-hairline bg-kumo-base p-3 transition-colors has-[[data-state=checked]]:border-kumo-interact has-[[data-state=checked]]:bg-kumo-tint',
       controlAtStart && 'flex-row-reverse',
@@ -102,6 +106,8 @@
   </label>
 {:else}
   <label
+    data-kumo-component="Radio"
+    data-kumo-part="item-label"
     class={cn(
       'm-0 group relative inline-flex items-center gap-2',
       effectiveControlPosition === 'end' && 'flex-row-reverse justify-end',

--- a/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
@@ -48,7 +48,7 @@
     class={cn(
       isCard
         ? 'relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring ring-2 focus:outline-none focus:ring-kumo-focus focus-visible:ring-2 focus-visible:ring-kumo-brand'
-        : 'relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2',
+        : 'relative mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-0 bg-kumo-base ring focus:outline-none after:absolute after:-inset-x-3 after:-inset-y-2',
       variant === 'error' ? 'ring-kumo-danger' : 'ring-kumo-line',
       !disabled &&
         variant !== 'error' &&
@@ -109,7 +109,7 @@
     data-kumo-component="Radio"
     data-kumo-part="item-label"
     class={cn(
-      'm-0 group relative inline-flex items-center gap-2',
+      'm-0 group relative inline-flex items-start gap-2',
       effectiveControlPosition === 'end' && 'flex-row-reverse justify-end',
       disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
       className

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -112,6 +112,7 @@
   });
 
   function displayValue(selectionValue: Value) {
+    if (!selectionValue || (Array.isArray(selectionValue) && selectionValue.length === 0)) return placeholder;
     if (renderValue) return renderValue(selectionValue);
     return selectedLabels || placeholder;
   }

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -21,6 +21,8 @@
 
   interface Props {
     class?: string;
+    contentClass?: string;
+    viewportClass?: string;
     options?: Option[];
     items?: Items;
     value?: Value;
@@ -46,6 +48,8 @@
 
   let {
     class: className,
+    contentClass,
+    viewportClass,
     options = [],
     items,
     defaultValue,
@@ -212,12 +216,13 @@
     <SelectPrimitive.Portal to={container}>
       <SelectPrimitive.Content
         class={cn(
-          'z-50 flex max-h-[var(--bits-select-content-available-height)] min-w-[calc(var(--bits-select-anchor-width)+3px)] flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line outline-none'
+          'z-50 flex max-h-[var(--bits-select-content-available-height)] min-w-[calc(var(--bits-select-anchor-width)+3px)] flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line outline-none',
+          contentClass
         )}
         preventScroll
         sideOffset={4}
       >
-        <SelectPrimitive.Viewport class="min-h-0 flex-1 overflow-y-auto overscroll-none scroll-pb-2 scroll-pt-2">
+        <SelectPrimitive.Viewport class={cn('min-h-0 flex-1 overflow-y-auto overscroll-none scroll-pb-2 scroll-pt-2', viewportClass)}>
           {#if children}
             {@render children()}
           {:else}

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -129,6 +129,8 @@
       )}
       aria-label={rest['aria-label'] as string | undefined}
       aria-invalid={Boolean(errorMessage) || undefined}
+      data-kumo-component="Select"
+      data-kumo-part="trigger"
     >
       {#if loading}
         <span class="inline-flex min-w-0 flex-1 items-center">
@@ -169,6 +171,8 @@
                 value={option.value}
                 label={option.label}
                 disabled={option.disabled}
+                data-kumo-component="Select"
+                data-kumo-part="option"
                 class={cn(
                   'group mx-1.5 flex cursor-pointer items-center justify-between gap-2 rounded px-2 py-1.5 text-base outline-none',
                   'focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset',

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -7,11 +7,12 @@
   import { cn } from '$lib/utils/cn';
 
   type Size = 'xs' | 'sm' | 'base' | 'lg';
-  type Value = string | string[];
+  type SelectValue = unknown;
+  type Value = SelectValue | SelectValue[];
 
   interface Option {
     label: string;
-    value: string;
+    value: SelectValue;
     disabled?: boolean;
   }
 
@@ -38,6 +39,7 @@
     required?: boolean;
     children?: Snippet;
     renderValue?: (value: Value) => unknown;
+    onValueChange?: (value: Value) => void;
     container?: HTMLElement | string;
     [key: string]: unknown;
   }
@@ -62,6 +64,7 @@
     required = false,
     children,
     renderValue,
+    onValueChange,
     container,
     ...rest
   }: Props = $props();
@@ -98,23 +101,75 @@
     return options;
   });
 
-  const selectItems = $derived(normalizedOptions.map(({ value, label, disabled }) => ({ value, label, disabled })));
+  const serializedOptions = $derived(
+    normalizedOptions.map((option, index) => ({
+      ...option,
+      serializedValue: serializeOptionValue(index)
+    }))
+  );
+  const selectItems = $derived(
+    serializedOptions.map(({ serializedValue, label, disabled }) => ({ value: serializedValue, label, disabled }))
+  );
   const errorMessage = $derived(typeof error === 'string' ? error : error?.message);
   const isDisabled = $derived(disabled || loading);
+  const primitiveValue = $derived(toPrimitiveValue(value, multiple));
   const selectedLabels = $derived.by(() => {
     if (Array.isArray(value)) {
       return value
-        .map((selectedValue) => normalizedOptions.find((option) => option.value === selectedValue)?.label ?? selectedValue)
+        .map((selectedValue) => normalizedOptions.find((option) => Object.is(option.value, selectedValue))?.label ?? stringifyValue(selectedValue))
         .join(', ');
     }
 
-    return normalizedOptions.find((option) => option.value === value)?.label ?? value;
+    return normalizedOptions.find((option) => Object.is(option.value, value))?.label ?? stringifyValue(value);
   });
 
   function displayValue(selectionValue: Value) {
     if (!selectionValue || (Array.isArray(selectionValue) && selectionValue.length === 0)) return placeholder;
     if (renderValue) return renderValue(selectionValue);
     return selectedLabels || placeholder;
+  }
+
+  function serializeOptionValue(index: number) {
+    return `kumo-select:${index}`;
+  }
+
+  function stringifyValue(selectionValue: SelectValue) {
+    if (selectionValue === null || selectionValue === undefined) return '';
+    return typeof selectionValue === 'string' ? selectionValue : String(selectionValue);
+  }
+
+  function toPrimitiveValue(selectionValue: Value, isMultiple: boolean) {
+    if (isMultiple) {
+      const values = Array.isArray(selectionValue) ? selectionValue : [];
+      return values.map((entry) => serializeSelectedValue(entry)).filter((entry) => entry !== undefined);
+    }
+
+    if (Array.isArray(selectionValue)) return serializeSelectedValue(selectionValue[0]) ?? '';
+    return serializeSelectedValue(selectionValue) ?? '';
+  }
+
+  function serializeSelectedValue(selectionValue: SelectValue) {
+    const option = serializedOptions.find((entry) => Object.is(entry.value, selectionValue));
+    if (option) return option.serializedValue;
+    return typeof selectionValue === 'string' ? selectionValue : undefined;
+  }
+
+  function deserializePrimitiveValue(primitiveValue: string) {
+    const option = serializedOptions.find((entry) => entry.serializedValue === primitiveValue);
+    return option ? option.value : primitiveValue;
+  }
+
+  function setValue(nextValue: Value) {
+    value = nextValue;
+    onValueChange?.(nextValue);
+  }
+
+  function handleSingleValueChange(nextValue: string) {
+    setValue(deserializePrimitiveValue(nextValue));
+  }
+
+  function handleMultipleValueChange(nextValue: string[]) {
+    setValue(nextValue.map((entry) => deserializePrimitiveValue(entry)));
   }
 </script>
 
@@ -141,9 +196,9 @@
           {#snippet children({ selection, placeholder })}
             <span class={cn('block truncate', !selectedLabels && 'text-kumo-placeholder')}>
               {#if selection.type === 'multiple'}
-                {displayValue(selection.selected.map((item) => item.value))}
+                {displayValue(selection.selected.map((item) => deserializePrimitiveValue(item.value)))}
               {:else if selection.selected}
-                {displayValue(selection.selected.value)}
+                {displayValue(deserializePrimitiveValue(selection.selected.value))}
               {:else}
                 {placeholder}
               {/if}
@@ -166,9 +221,9 @@
           {#if children}
             {@render children()}
           {:else}
-            {#each normalizedOptions as option (option.value)}
+            {#each serializedOptions as option (option.serializedValue)}
               <SelectPrimitive.Item
-                value={option.value}
+                value={option.serializedValue}
                 label={option.label}
                 disabled={option.disabled}
                 data-kumo-component="Select"
@@ -212,8 +267,8 @@
   {#if multiple}
     <SelectPrimitive.Root
       type="multiple"
-      value={Array.isArray(value) ? value : []}
-      onValueChange={(nextValue) => (value = nextValue)}
+      value={Array.isArray(primitiveValue) ? primitiveValue : []}
+      onValueChange={handleMultipleValueChange}
       items={selectItems}
       disabled={isDisabled}
       {name}
@@ -225,8 +280,8 @@
   {:else}
     <SelectPrimitive.Root
       type="single"
-      value={Array.isArray(value) ? (value[0] ?? '') : value}
-      onValueChange={(nextValue) => (value = nextValue)}
+      value={Array.isArray(primitiveValue) ? (primitiveValue[0] ?? '') : primitiveValue}
+      onValueChange={handleSingleValueChange}
       items={selectItems}
       disabled={isDisabled}
       {name}

--- a/packages/kumo-svelte/src/lib/components/select/select.test.ts
+++ b/packages/kumo-svelte/src/lib/components/select/select.test.ts
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import Select from './Select.svelte';
+
+describe('Select', () => {
+  it('displays labels for non-string option values', () => {
+    render(Select, {
+      'aria-label': 'Rows per page',
+      value: 50,
+      options: [
+        { label: '25 rows', value: 25 },
+        { label: '50 rows', value: 50 },
+        { label: '100 rows', value: 100 }
+      ]
+    });
+
+    expect(screen.getByRole('button', { name: 'Rows per page' }).textContent).toContain('50 rows');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/sensitive-input/SensitiveInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/sensitive-input/SensitiveInput.svelte
@@ -238,6 +238,8 @@
       class={containerClassName}
       role="button"
       tabindex={isMaskedWithValue && !disabled ? 0 : undefined}
+      data-kumo-component="SensitiveInput"
+      data-kumo-part="masked-container"
       aria-label={isMaskedWithValue ? `${ariaLabelFallback}, masked.` : undefined}
       aria-describedby={isMaskedWithValue ? `${maskedInstructionId} ${liveRegionId}` : undefined}
       aria-disabled={isMaskedWithValue && disabled ? true : undefined}
@@ -299,6 +301,8 @@
         onclick={handleToggleVisibility}
         onkeydown={(event) => event.stopPropagation()}
         aria-label={mode === 'revealed' ? 'Hide value' : 'Reveal value'}
+        data-kumo-component="SensitiveInput"
+        data-kumo-part="toggle-visibility"
         tabindex={showEyeButton ? 0 : -1}
         class={cn(
           'absolute top-1/2 right-0 inline-flex h-auto min-h-0 -translate-y-1/2 cursor-pointer items-center justify-center border-none bg-transparent p-0 m-0 text-kumo-subtle shadow-none hover:text-kumo-default focus:text-kumo-default focus:ring-kumo-focus/50 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-kumo-brand',
@@ -323,6 +327,8 @@
           onclick={copyToClipboard}
           onkeydown={(event) => event.stopPropagation()}
           aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+          data-kumo-component="SensitiveInput"
+          data-kumo-part="copy"
           class="absolute -top-px right-2 m-0 h-auto min-h-0 -translate-y-full cursor-pointer rounded-t-md border-none bg-kumo-brand px-2 py-0.5 text-xs text-white opacity-0 shadow-none transition-opacity hover:brightness-120 focus:ring-kumo-focus/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand group-focus-within/container:opacity-100 group-hover/container:opacity-100"
         >
           {copied ? 'Copied' : 'Copy'}

--- a/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
@@ -11,18 +11,40 @@
 
   let { children, class: className, ...rest }: Props = $props();
   const sidebar = getSidebarContext('Sidebar');
-  const railWidth = $derived(sidebar.open ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
-  const contentWidth = $derived(sidebar.open || sidebar.isPeeking ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
+  const isAlwaysExpanded = $derived(sidebar.collapsible === 'none');
+  const isVisible = $derived(sidebar.open || sidebar.isPeeking || isAlwaysExpanded);
+  const railWidth = $derived(isAlwaysExpanded || sidebar.open ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
+  const contentWidth = $derived(isVisible ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
 </script>
+
+{#if sidebar.isMobile && sidebar.open}
+  <button
+    type="button"
+    aria-label="Close sidebar"
+    class="fixed inset-0 z-40 bg-black/40 md:hidden"
+    data-sidebar="mobile-backdrop"
+    data-kumo-component="Sidebar"
+    data-kumo-part="mobile-backdrop"
+    onclick={() => sidebar.setOpen(false)}
+  ></button>
+{/if}
 
 <aside
   data-state={sidebar.state}
   data-side={sidebar.side}
   data-variant={sidebar.variant}
   data-collapsible={sidebar.collapsible}
+  data-mobile={sidebar.isMobile ? '' : undefined}
   data-sidebar="sidebar"
   style:width={railWidth}
-  class={cn('group/sidebar relative h-full shrink-0 grow-0 overflow-visible transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none', sidebar.variant === 'floating' && 'm-2 rounded-lg shadow-lg', className)}
+  class={cn(
+    'group/sidebar relative h-full shrink-0 grow-0 overflow-visible transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
+    sidebar.isMobile && 'fixed inset-y-0 z-50 w-0 md:relative md:z-auto',
+    sidebar.isMobile && sidebar.side === 'left' && 'left-0',
+    sidebar.isMobile && sidebar.side === 'right' && 'right-0',
+    sidebar.variant === 'floating' && 'm-2 rounded-lg shadow-lg',
+    className
+  )}
   {...rest}
 >
   <div
@@ -34,19 +56,13 @@
       sidebar.variant === 'floating' && 'rounded-lg border border-kumo-line',
       !sidebar.open && 'absolute inset-y-0 z-40',
       !sidebar.open && sidebar.side === 'left' && 'left-0',
-      !sidebar.open && sidebar.side === 'right' && 'right-0'
+      !sidebar.open && sidebar.side === 'right' && 'right-0',
+      sidebar.isMobile && 'fixed inset-y-0 max-w-[85vw] shadow-xl md:static md:max-w-none md:shadow-none',
+      sidebar.isMobile && !sidebar.open && 'hidden md:flex',
+      sidebar.isMobile && sidebar.side === 'left' && 'left-0',
+      sidebar.isMobile && sidebar.side === 'right' && 'right-0'
     )}
   >
-    <div
-      data-sidebar="peek-zone"
-      class="flex min-h-0 flex-1 flex-col"
-      role="presentation"
-      onmouseenter={sidebar.startPeek}
-      onmouseleave={sidebar.stopPeek}
-      onfocus={sidebar.startPeek}
-      onblur={sidebar.stopPeek}
-    >
-      {@render children?.()}
-    </div>
+    {@render children?.()}
   </div>
 </aside>

--- a/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
@@ -22,9 +22,12 @@
       'flex h-full min-w-0 flex-col overflow-hidden whitespace-nowrap bg-(--sidebar-bg) text-kumo-default transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
       sidebar.variant === 'sidebar' && (sidebar.side === 'left' ? 'border-r border-kumo-line' : 'border-l border-kumo-line'),
       sidebar.variant === 'floating' && 'rounded-lg border border-kumo-line',
-      !sidebar.open && 'absolute inset-y-0 z-40',
+      sidebar.isResizing && 'transition-none!',
+      !sidebar.open && (sidebar.contained ? 'absolute' : 'fixed'),
+      !sidebar.open && 'inset-y-0 z-40',
       !sidebar.open && sidebar.side === 'left' && 'left-0',
       !sidebar.open && sidebar.side === 'right' && 'right-0',
+      sidebar.open && 'relative',
       sidebar.isMobile && 'fixed inset-y-0 max-w-[85vw] shadow-xl md:static md:max-w-none md:shadow-none',
       sidebar.isMobile && !sidebar.open && 'hidden md:flex',
       sidebar.isMobile && sidebar.side === 'left' && 'left-0',
@@ -88,7 +91,16 @@
     )}
     {...rest}
   >
-    <div data-sidebar="content-container" style:width={contentWidth} class={contentClasses}>
+    <div
+      data-sidebar="content-container"
+      role="presentation"
+      style:width={contentWidth}
+      class={contentClasses}
+      onmouseenter={sidebar.startPeek}
+      onmouseleave={sidebar.stopPeek}
+      onfocus={sidebar.startPeek}
+      onblur={sidebar.stopPeek}
+    >
       {@render sidebarContent()}
     </div>
   </aside>

--- a/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { Dialog as DialogPrimitive } from 'bits-ui';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { TooltipProvider } from '$lib/components/tooltip';
   import { getSidebarContext } from './context';
 
   interface Props {
@@ -15,42 +17,8 @@
   const isVisible = $derived(sidebar.open || sidebar.isPeeking || isAlwaysExpanded);
   const railWidth = $derived(isAlwaysExpanded || sidebar.open ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
   const contentWidth = $derived(isVisible ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
-</script>
-
-{#if sidebar.isMobile && sidebar.open}
-  <button
-    type="button"
-    aria-label="Close sidebar"
-    class="fixed inset-0 z-40 bg-black/40 md:hidden"
-    data-sidebar="mobile-backdrop"
-    data-kumo-component="Sidebar"
-    data-kumo-part="mobile-backdrop"
-    onclick={() => sidebar.setOpen(false)}
-  ></button>
-{/if}
-
-<aside
-  data-state={sidebar.state}
-  data-side={sidebar.side}
-  data-variant={sidebar.variant}
-  data-collapsible={sidebar.collapsible}
-  data-mobile={sidebar.isMobile ? '' : undefined}
-  data-sidebar="sidebar"
-  style:width={railWidth}
-  class={cn(
-    'group/sidebar relative h-full shrink-0 grow-0 overflow-visible transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
-    sidebar.isMobile && 'fixed inset-y-0 z-50 w-0 md:relative md:z-auto',
-    sidebar.isMobile && sidebar.side === 'left' && 'left-0',
-    sidebar.isMobile && sidebar.side === 'right' && 'right-0',
-    sidebar.variant === 'floating' && 'm-2 rounded-lg shadow-lg',
-    className
-  )}
-  {...rest}
->
-  <div
-    data-sidebar="content-container"
-    style:width={contentWidth}
-    class={cn(
+  const contentClasses = $derived(
+    cn(
       'flex h-full min-w-0 flex-col overflow-hidden whitespace-nowrap bg-(--sidebar-bg) text-kumo-default transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
       sidebar.variant === 'sidebar' && (sidebar.side === 'left' ? 'border-r border-kumo-line' : 'border-l border-kumo-line'),
       sidebar.variant === 'floating' && 'rounded-lg border border-kumo-line',
@@ -61,8 +29,67 @@
       sidebar.isMobile && !sidebar.open && 'hidden md:flex',
       sidebar.isMobile && sidebar.side === 'left' && 'left-0',
       sidebar.isMobile && sidebar.side === 'right' && 'right-0'
-    )}
-  >
+    )
+  );
+</script>
+
+{#snippet sidebarContent()}
+  <TooltipProvider>
     {@render children?.()}
-  </div>
-</aside>
+  </TooltipProvider>
+{/snippet}
+
+{#if sidebar.isMobile}
+  <DialogPrimitive.Root open={sidebar.openMobile} onOpenChange={(open) => sidebar.setOpenMobile(open)}>
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay
+        data-sidebar-backdrop
+        data-kumo-component="Sidebar"
+        data-kumo-part="mobile-backdrop"
+        class="fixed inset-0 z-40 bg-black/50 transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0"
+      />
+      <DialogPrimitive.Content
+        data-sidebar-popup
+        aria-label="Sidebar"
+        class={cn(
+          'fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col bg-kumo-base p-0 duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0',
+          sidebar.side === 'left' && 'left-0 data-ending-style:-translate-x-full data-starting-style:-translate-x-full',
+          sidebar.side === 'right' && 'right-0 data-ending-style:translate-x-full data-starting-style:translate-x-full'
+        )}
+        style="transition-property: transform, opacity; transition-timing-function: var(--default-transition-timing-function);"
+      >
+        <div
+          data-state="expanded"
+          data-side={sidebar.side}
+          data-variant={sidebar.variant}
+          data-collapsible={sidebar.collapsible}
+          data-mobile="true"
+          data-sidebar="sidebar"
+          class={cn('group/sidebar flex h-full w-full flex-col bg-kumo-base text-kumo-default', className)}
+          {...rest}
+        >
+          {@render sidebarContent()}
+        </div>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  </DialogPrimitive.Root>
+{:else}
+  <aside
+    data-state={sidebar.state}
+    data-side={sidebar.side}
+    data-variant={sidebar.variant}
+    data-collapsible={sidebar.collapsible}
+    data-sidebar="sidebar"
+    style:width={railWidth}
+    class={cn(
+      'group/sidebar relative h-full shrink-0 grow-0 overflow-visible transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
+      sidebar.variant === 'floating' && 'm-2 rounded-lg shadow-lg',
+      className
+    )}
+    {...rest}
+  >
+    <div data-sidebar="content-container" style:width={contentWidth} class={contentClasses}>
+      {@render sidebarContent()}
+    </div>
+  </aside>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
@@ -1,14 +1,52 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface Item { label: string; href?: string; active?: boolean; }
-  interface Props { children?: Snippet; class?: string; items?: Item[]; [key: string]: unknown; }
-  let { children, class: className, items = [], ...rest }: Props = $props();
+  import { getSidebarContext } from './context';
+
+  interface Props {
+    children?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }
+
+  let { children, class: className, ...rest }: Props = $props();
+  const sidebar = getSidebarContext('Sidebar');
+  const railWidth = $derived(sidebar.open ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
+  const contentWidth = $derived(sidebar.open || sidebar.isPeeking ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
 </script>
 
-<aside class={cn('flex h-full w-64 flex-col border-r border-kumo-line bg-kumo-surface p-3 text-kumo-default', className)} {...rest}>
-  <nav class="grid gap-1">
-    {#each items as item}<a class={cn('rounded-md px-2 py-1.5 text-sm hover:bg-kumo-tint', item.active && 'bg-kumo-fill font-medium')} href={item.href}>{item.label}</a>{/each}
-  </nav>
-  {@render children?.()}
+<aside
+  data-state={sidebar.state}
+  data-side={sidebar.side}
+  data-variant={sidebar.variant}
+  data-collapsible={sidebar.collapsible}
+  data-sidebar="sidebar"
+  style:width={railWidth}
+  class={cn('group/sidebar relative h-full shrink-0 grow-0 overflow-visible transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none', sidebar.variant === 'floating' && 'm-2 rounded-lg shadow-lg', className)}
+  {...rest}
+>
+  <div
+    data-sidebar="content-container"
+    style:width={contentWidth}
+    class={cn(
+      'flex h-full min-w-0 flex-col overflow-hidden whitespace-nowrap bg-(--sidebar-bg) text-kumo-default transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
+      sidebar.variant === 'sidebar' && (sidebar.side === 'left' ? 'border-r border-kumo-line' : 'border-l border-kumo-line'),
+      sidebar.variant === 'floating' && 'rounded-lg border border-kumo-line',
+      !sidebar.open && 'absolute inset-y-0 z-40',
+      !sidebar.open && sidebar.side === 'left' && 'left-0',
+      !sidebar.open && sidebar.side === 'right' && 'right-0'
+    )}
+  >
+    <div
+      data-sidebar="peek-zone"
+      class="flex min-h-0 flex-1 flex-col"
+      role="presentation"
+      onmouseenter={sidebar.startPeek}
+      onmouseleave={sidebar.stopPeek}
+      onfocus={sidebar.startPeek}
+      onblur={sidebar.stopPeek}
+    >
+      {@render children?.()}
+    </div>
+  </div>
 </aside>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
@@ -4,9 +4,13 @@
   import { cn } from '$lib/utils/cn';
   interface Props { children?: Snippet; class?: string; defaultOpen?: boolean; open?: boolean; onOpenChange?: (open: boolean) => void; [key: string]: unknown; }
   let { children, class: className, defaultOpen = false, open = $bindable(defaultOpen), onOpenChange, ...rest }: Props = $props();
+  const contentId = `kumo-sidebar-collapsible-${Math.random().toString(36).slice(2)}`;
   const context = {
     get open() {
       return open;
+    },
+    get contentId() {
+      return contentId;
     },
     toggle() {
       open = !open;

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { setContext } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; defaultOpen?: boolean; open?: boolean; onOpenChange?: (open: boolean) => void; [key: string]: unknown; }
+  let { children, class: className, defaultOpen = false, open = $bindable(defaultOpen), onOpenChange, ...rest }: Props = $props();
+  const context = {
+    get open() {
+      return open;
+    },
+    toggle() {
+      open = !open;
+      onOpenChange?.(open);
+    }
+  };
+  setContext('kumo-sidebar-collapsible', context);
+</script>
+
+<div data-sidebar="collapsible" data-open={open ? '' : undefined} class={cn('min-w-0', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { getContext } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface CollapsibleContext { get open(): boolean; toggle(): void; }
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+  const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');
+</script>
+
+{#if collapsible?.open}
+  <div data-sidebar="collapsible-content" class={cn('grid', className)} {...rest}>
+    {@render children?.()}
+  </div>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
@@ -2,14 +2,27 @@
   import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface CollapsibleContext { get open(): boolean; toggle(): void; }
+  interface CollapsibleContext { get open(): boolean; get contentId(): string; toggle(): void; }
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
   const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');
 </script>
 
-{#if collapsible?.open}
-  <div data-sidebar="collapsible-content" class={cn('grid', className)} {...rest}>
+<div
+  id={collapsible?.contentId}
+  data-sidebar="collapsible-content"
+  data-open={collapsible?.open ? '' : undefined}
+  role="region"
+  aria-hidden={collapsible?.open ? undefined : 'true'}
+  inert={collapsible?.open ? undefined : true}
+  class={cn(
+    'grid overflow-hidden transition-[grid-template-rows,opacity] duration-(--sidebar-animation-duration) motion-reduce:transition-none',
+    collapsible?.open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
+    className
+  )}
+  {...rest}
+>
+  <div class="min-h-0 overflow-hidden">
     {@render children?.()}
   </div>
-{/if}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { getContext } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface CollapsibleContext { get open(): boolean; toggle(): void; }
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+  const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');
+</script>
+
+<button type="button" class={cn('contents', className)} aria-expanded={collapsible?.open} onclick={() => collapsible?.toggle()} {...rest}>
+  {@render children?.()}
+</button>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
@@ -2,12 +2,19 @@
   import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface CollapsibleContext { get open(): boolean; toggle(): void; }
+  interface CollapsibleContext { get open(): boolean; get contentId(): string; toggle(): void; }
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
   const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');
 </script>
 
-<button type="button" class={cn('contents', className)} aria-expanded={collapsible?.open} onclick={() => collapsible?.toggle()} {...rest}>
+<button
+  type="button"
+  class={cn('contents', className)}
+  aria-expanded={collapsible?.open}
+  aria-controls={collapsible?.contentId}
+  onclick={() => collapsible?.toggle()}
+  {...rest}
+>
   {@render children?.()}
 </button>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="content" class={cn('relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3.5 py-[13px]', className)} {...rest}>
+  <div class="flex min-w-0 flex-col gap-2">
+    {@render children?.()}
+  </div>
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  import { getSidebarContext } from './context';
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
-  const sidebar = getSidebarContext('Sidebar.Content');
 </script>
 
 <div
   data-sidebar="content"
-  class={cn('relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3.5 py-[13px]', className)}
+  class={cn(
+    'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-[11px] py-[13px] transition-[padding] duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:px-3.5 group-data-[state=collapsed]/sidebar:overflow-x-hidden!',
+    className
+  )}
   role="presentation"
-  onmouseenter={sidebar.startPeek}
-  onmouseleave={sidebar.stopPeek}
-  onfocus={sidebar.startPeek}
-  onblur={sidebar.stopPeek}
   {...rest}
 >
-  <div class="flex min-w-0 flex-col gap-2">
+  <div class="flex min-w-0 flex-col gap-2 group-data-[state=collapsed]/sidebar:min-w-0!">
     {@render children?.()}
   </div>
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { getSidebarContext } from './context';
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
+  const sidebar = getSidebarContext('Sidebar.Content');
 </script>
 
-<div data-sidebar="content" class={cn('relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3.5 py-[13px]', className)} {...rest}>
+<div
+  data-sidebar="content"
+  class={cn('relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3.5 py-[13px]', className)}
+  role="presentation"
+  onmouseenter={sidebar.startPeek}
+  onmouseleave={sidebar.stopPeek}
+  onfocus={sidebar.startPeek}
+  onblur={sidebar.stopPeek}
+  {...rest}
+>
   <div class="flex min-w-0 flex-col gap-2">
     {@render children?.()}
   </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarFooter.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarFooter.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="footer" class={cn('sticky bottom-0 flex h-12 shrink-0 items-center gap-4 overflow-hidden whitespace-nowrap border-t border-kumo-line bg-(--sidebar-bg) px-4', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarFooter.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarFooter.svelte
@@ -5,6 +5,13 @@
   let { children, class: className, ...rest }: Props = $props();
 </script>
 
-<div data-sidebar="footer" class={cn('sticky bottom-0 flex h-12 shrink-0 items-center gap-4 overflow-hidden whitespace-nowrap border-t border-kumo-line bg-(--sidebar-bg) px-4', className)} {...rest}>
+<div
+  data-sidebar="footer"
+  class={cn(
+    'sticky bottom-0 flex h-12 w-(--sidebar-width) shrink-0 items-center gap-4 overflow-hidden whitespace-nowrap border-t border-kumo-line bg-(--sidebar-bg) bg-clip-padding px-[11px] transition-[width,padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none group-not-data-[state=collapsed]/sidebar:px-4 group-data-[state=collapsed]/sidebar:w-(--sidebar-width-icon) group-data-[state=collapsed]/sidebar:border-r group-data-[state=collapsed]/sidebar:border-kumo-line',
+    className
+  )}
+  {...rest}
+>
   {@render children?.()}
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroup.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="group" class={cn('flex min-w-0 flex-col gap-y-px', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="group-label" class={cn('truncate px-3 pt-4 pb-2 text-sm font-medium text-kumo-subtle group-data-[state=collapsed]/sidebar:my-3 group-data-[state=collapsed]/sidebar:border-b group-data-[state=collapsed]/sidebar:border-kumo-line group-data-[state=collapsed]/sidebar:p-0 group-data-[state=collapsed]/sidebar:text-transparent', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
@@ -5,6 +5,17 @@
   let { children, class: className, ...rest }: Props = $props();
 </script>
 
-<div data-sidebar="group-label" class={cn('truncate px-3 pt-4 pb-2 text-sm font-medium text-kumo-subtle group-data-[state=collapsed]/sidebar:my-3 group-data-[state=collapsed]/sidebar:border-b group-data-[state=collapsed]/sidebar:border-kumo-line group-data-[state=collapsed]/sidebar:p-0 group-data-[state=collapsed]/sidebar:text-transparent', className)} {...rest}>
-  {@render children?.()}
+<div
+  data-sidebar="group-label"
+  class={cn(
+    'grid grid-rows-[0fr] overflow-hidden border-b border-kumo-line my-3 transition-[grid-template-rows,margin,border-color] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) [[data-sidebar=group]:first-child_&]:my-0 [[data-sidebar=group]:first-child_&]:border-transparent group-not-data-[state=collapsed]/sidebar:grid-rows-[1fr] group-not-data-[state=collapsed]/sidebar:my-0 group-not-data-[state=collapsed]/sidebar:border-transparent',
+    className
+  )}
+  {...rest}
+>
+  <div class="min-h-0">
+    <div class="truncate px-3 mt-4 mb-2 text-sm font-medium text-kumo-subtle [[data-sidebar=group]:first-child_&]:mt-2">
+      {@render children?.()}
+    </div>
+  </div>
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarHeader.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarHeader.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="header" class={cn('flex h-[58px] items-center gap-1 overflow-hidden border-b border-kumo-line px-3.5', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenu.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenu.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<ul data-sidebar="menu" class={cn('m-0 flex min-w-0 list-none flex-col items-stretch gap-y-px p-0', className)} {...rest}>
+  {@render children?.()}
+</ul>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuBadge.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuBadge.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<span data-sidebar="menu-badge" class={cn('inline-flex shrink-0 select-none items-center rounded-full border border-dashed border-kumo-line px-1.5 py-0.5 text-[11px]/none font-medium text-kumo-strong group-data-[state=collapsed]/sidebar:hidden', className)} {...rest}>
+  {@render children?.()}
+</span>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import type { Component, Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+
+  interface Props {
+    children?: Snippet;
+    class?: string;
+    icon?: Component;
+    active?: boolean;
+    size?: 'base' | 'sm';
+    href?: string;
+    tooltip?: string;
+    [key: string]: unknown;
+  }
+
+  let { children, class: className, icon: Icon, active = false, size = 'base', href, tooltip, ...rest }: Props = $props();
+
+  const classes = $derived(
+    cn(
+      'group/menu-button relative flex w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg text-kumo-default outline-none transition-[color,background-color,box-shadow,outline] duration-(--sidebar-animation-duration)',
+      size === 'base' && 'min-h-8.5 px-3 py-0 text-sm font-medium',
+      size === 'sm' && 'min-h-7 px-2 py-0 text-sm',
+      !active && 'hover:bg-kumo-tint',
+      active && 'bg-kumo-tint',
+      'focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong',
+      className
+    )
+  );
+</script>
+
+<li data-sidebar="menu-item" class="relative group-data-[state=collapsed]/sidebar:overflow-hidden">
+  {#if href}
+    <a
+      class={cn(classes, 'no-underline!')}
+      {href}
+      title={tooltip}
+      data-active={active || undefined}
+      data-sidebar="menu-button"
+      data-kumo-component="Sidebar"
+      data-kumo-part="menu-button-link"
+      data-size={size}
+      {...rest}
+    >
+      <span class="flex min-w-0 flex-1 items-center gap-3">
+        {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
+        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
+      </span>
+    </a>
+  {:else}
+    <button
+      type="button"
+      class={classes}
+      title={tooltip}
+      data-active={active || undefined}
+      data-sidebar="menu-button"
+      data-kumo-component="Sidebar"
+      data-kumo-part="menu-button"
+      data-size={size}
+      {...rest}
+    >
+      <span class="flex min-w-0 flex-1 items-center gap-3">
+        {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
+        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
+      </span>
+    </button>
+  {/if}
+</li>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
@@ -28,10 +28,12 @@
   const classes = $derived(
     cn(
       'group/menu-button relative flex w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg text-kumo-default outline-none transition-[color,background-color,box-shadow,outline] duration-(--sidebar-animation-duration)',
+      'before:absolute before:inset-x-0 before:-inset-y-px',
       size === 'base' && 'min-h-8.5 px-3 py-0 text-sm font-medium',
       size === 'sm' && 'min-h-7 px-2 py-0 text-sm',
       !active && 'hover:bg-kumo-tint',
       active && 'bg-kumo-tint',
+      'has-[[data-active]]:bg-transparent has-[[data-active]]:hover:bg-kumo-tint',
       'focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong',
       className
     )
@@ -52,9 +54,11 @@
       aria-label={tooltip}
       {...rest}
     >
-      <span class="flex min-w-0 flex-1 items-center gap-3">
+      <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
         {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
-        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
+        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
+          {@render children?.()}
+        </span>
       </span>
     </a>
   {:else}
@@ -69,9 +73,11 @@
       aria-label={tooltip}
       {...rest}
     >
-      <span class="flex min-w-0 flex-1 items-center gap-3">
+      <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
         {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
-        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
+        <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
+          {@render children?.()}
+        </span>
       </span>
     </button>
   {/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { Component, Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  import { getSidebarMenuItemContext } from './context';
+  import { Tooltip } from '$lib/components/tooltip';
+  import { getSidebarContext, getSidebarMenuItemContext } from './context';
 
   interface Props {
     children?: Snippet;
@@ -16,6 +17,13 @@
 
   let { children, class: className, icon: Icon, active = false, size = 'base', href, tooltip, ...rest }: Props = $props();
   const menuItem = getSidebarMenuItemContext();
+  let sidebar = $state<ReturnType<typeof getSidebarContext> | undefined>();
+
+  try {
+    sidebar = getSidebarContext('Sidebar.MenuButton');
+  } catch {
+    sidebar = undefined;
+  }
 
   const classes = $derived(
     cn(
@@ -28,6 +36,7 @@
       className
     )
   );
+  const showTooltip = $derived(Boolean(tooltip && sidebar?.state === 'collapsed' && !sidebar.peekable));
 </script>
 
 {#snippet control()}
@@ -35,7 +44,6 @@
     <a
       class={cn(classes, 'no-underline!')}
       {href}
-      title={tooltip}
       data-active={active || undefined}
       data-sidebar="menu-button"
       data-kumo-component="Sidebar"
@@ -53,7 +61,6 @@
     <button
       type="button"
       class={classes}
-      title={tooltip}
       data-active={active || undefined}
       data-sidebar="menu-button"
       data-kumo-component="Sidebar"
@@ -70,10 +77,18 @@
   {/if}
 {/snippet}
 
+{#snippet controlWithTooltip()}
+  {#if tooltip && sidebar}
+    <Tooltip content={showTooltip ? tooltip : undefined} side="right" trigger={control} />
+  {:else}
+    {@render control()}
+  {/if}
+{/snippet}
+
 {#if menuItem?.insideMenuItem}
-  {@render control()}
+  {@render controlWithTooltip()}
 {:else}
   <li data-sidebar="menu-item" class="relative group-data-[state=collapsed]/sidebar:overflow-hidden">
-    {@render control()}
+    {@render controlWithTooltip()}
   </li>
 {/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Component, Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { getSidebarMenuItemContext } from './context';
 
   interface Props {
     children?: Snippet;
@@ -14,6 +15,7 @@
   }
 
   let { children, class: className, icon: Icon, active = false, size = 'base', href, tooltip, ...rest }: Props = $props();
+  const menuItem = getSidebarMenuItemContext();
 
   const classes = $derived(
     cn(
@@ -28,7 +30,7 @@
   );
 </script>
 
-<li data-sidebar="menu-item" class="relative group-data-[state=collapsed]/sidebar:overflow-hidden">
+{#snippet control()}
   {#if href}
     <a
       class={cn(classes, 'no-underline!')}
@@ -39,6 +41,7 @@
       data-kumo-component="Sidebar"
       data-kumo-part="menu-button-link"
       data-size={size}
+      aria-label={tooltip}
       {...rest}
     >
       <span class="flex min-w-0 flex-1 items-center gap-3">
@@ -56,6 +59,7 @@
       data-kumo-component="Sidebar"
       data-kumo-part="menu-button"
       data-size={size}
+      aria-label={tooltip}
       {...rest}
     >
       <span class="flex min-w-0 flex-1 items-center gap-3">
@@ -64,4 +68,12 @@
       </span>
     </button>
   {/if}
-</li>
+{/snippet}
+
+{#if menuItem?.insideMenuItem}
+  {@render control()}
+{:else}
+  <li data-sidebar="menu-item" class="relative group-data-[state=collapsed]/sidebar:overflow-hidden">
+    {@render control()}
+  </li>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.test.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.test.ts
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import SidebarMenuButton from './SidebarMenuButton.svelte';
+
+describe('SidebarMenuButton', () => {
+  it('wraps itself in a menu item when rendered standalone', () => {
+    const { container } = render(SidebarMenuButton, {
+      tooltip: 'Dashboard'
+    });
+
+    const button = screen.getByRole('button', { name: 'Dashboard' });
+    expect(container.querySelector('li[data-sidebar="menu-item"]')).toBeTruthy();
+    expect(button.getAttribute('data-kumo-component')).toBe('Sidebar');
+    expect(button.getAttribute('data-kumo-part')).toBe('menu-button');
+    expect(button.hasAttribute('title')).toBe(false);
+  });
+
+  it('renders link menu buttons with active and size state', () => {
+    render(SidebarMenuButton, {
+      href: '/analytics',
+      tooltip: 'Analytics',
+      active: true,
+      size: 'sm'
+    });
+
+    const link = screen.getByRole('link', { name: 'Analytics' });
+    expect(link.getAttribute('href')).toBe('/analytics');
+    expect(link.getAttribute('data-active')).toBe('true');
+    expect(link.getAttribute('data-size')).toBe('sm');
+    expect(link.getAttribute('data-kumo-part')).toBe('menu-button-link');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuChevron.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuChevron.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { CaretRight } from 'phosphor-svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { class?: string; open?: boolean; [key: string]: unknown; }
+  let { class: className, open = false, ...rest }: Props = $props();
+</script>
+
+<CaretRight data-sidebar="menu-chevron" class={cn('ml-auto size-4 shrink-0 text-kumo-subtle transition-transform duration-200 group-data-[state=collapsed]/sidebar:hidden', open && 'rotate-90', className)} {...rest} />

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuItem.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { setSidebarMenuItemContext } from './context';
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
+  setSidebarMenuItemContext({
+    get insideMenuItem() {
+      return true;
+    }
+  });
 </script>
 
 <li data-sidebar="menu-item" class={cn('relative group-data-[state=collapsed]/sidebar:overflow-hidden', className)} {...rest}>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuItem.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<li data-sidebar="menu-item" class={cn('relative group-data-[state=collapsed]/sidebar:overflow-hidden', className)} {...rest}>
+  {@render children?.()}
+</li>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSub.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSub.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<ul data-sidebar="menu-sub" class={cn('relative m-0 flex min-w-0 list-none flex-col gap-y-px overflow-hidden p-0 pl-7 pr-0 group-data-[state=collapsed]/sidebar:hidden', className)} {...rest}>
+  <div class="absolute inset-y-px left-[19px] z-10 w-px bg-kumo-line"></div>
+  {@render children?.()}
+</ul>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { getSidebarMenuSubItemContext } from './context';
   interface Props { children?: Snippet; class?: string; active?: boolean; href?: string; [key: string]: unknown; }
   let { children, class: className, active = false, href, ...rest }: Props = $props();
+  const menuSubItem = getSidebarMenuSubItemContext();
   const classes = $derived(cn('relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-colors duration-150 hover:bg-kumo-tint focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong', active && 'bg-kumo-tint', className));
 </script>
 
-<li data-sidebar="menu-sub-item" class="relative">
+{#snippet control()}
   {#if href}
     <a class={cn(classes, 'no-underline!')} {href} data-active={active || undefined} data-sidebar="menu-sub-button" data-kumo-component="Sidebar" data-kumo-part="menu-sub-button-link" {...rest}>
       <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
@@ -16,4 +18,12 @@
       <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
     </button>
   {/if}
-</li>
+{/snippet}
+
+{#if menuSubItem?.insideMenuSubItem}
+  {@render control()}
+{:else}
+  <li data-sidebar="menu-sub-item" class="relative">
+    {@render control()}
+  </li>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; active?: boolean; href?: string; [key: string]: unknown; }
+  let { children, class: className, active = false, href, ...rest }: Props = $props();
+  const classes = $derived(cn('relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-colors duration-150 hover:bg-kumo-tint focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong', active && 'bg-kumo-tint', className));
+</script>
+
+<li data-sidebar="menu-sub-item" class="relative">
+  {#if href}
+    <a class={cn(classes, 'no-underline!')} {href} data-active={active || undefined} data-sidebar="menu-sub-button" data-kumo-component="Sidebar" data-kumo-part="menu-sub-button-link" {...rest}>
+      <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
+    </a>
+  {:else}
+    <button type="button" class={classes} data-active={active || undefined} data-sidebar="menu-sub-button" data-kumo-component="Sidebar" data-kumo-part="menu-sub-button" {...rest}>
+      <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
+    </button>
+  {/if}
+</li>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubItem.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<li data-sidebar="menu-sub-item" class={cn('relative', className)} {...rest}>
+  {@render children?.()}
+</li>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubItem.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
+  import { setSidebarMenuSubItemContext } from './context';
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
+  setSidebarMenuSubItemContext({
+    get insideMenuSubItem() {
+      return true;
+    }
+  });
 </script>
 
 <li data-sidebar="menu-sub-item" class={cn('relative', className)} {...rest}>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
@@ -175,7 +175,13 @@
   style:--sidebar-animation-duration={`${animationDuration}ms`}
   style:--sidebar-easing="cubic-bezier(0.77, 0, 0.175, 1)"
   style:--sidebar-bg="var(--color-kumo-base)"
-  class={cn('group/sidebar-wrapper isolate flex w-full', !contained && 'min-h-svh', variant === 'inset' && 'bg-kumo-recessed', className)}
+  class={cn(
+    'group/sidebar-wrapper isolate flex w-full',
+    !contained && 'min-h-svh',
+    variant === 'inset' && 'bg-kumo-recessed',
+    isResizing && 'select-none',
+    className
+  )}
 >
   {@render children()}
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  import {
+    setSidebarContext,
+    type SidebarCollapsible,
+    type SidebarSide,
+    type SidebarState,
+    type SidebarVariant
+  } from './context';
+
+  interface Props {
+    children: Snippet;
+    class?: string;
+    defaultOpen?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    variant?: SidebarVariant;
+    side?: SidebarSide;
+    collapsible?: SidebarCollapsible;
+    resizable?: boolean;
+    defaultWidth?: number;
+    minWidth?: number;
+    maxWidth?: number;
+    onWidthChange?: (width: number) => void;
+    contained?: boolean;
+    peekable?: boolean;
+    animationDuration?: number;
+  }
+
+  let {
+    children,
+    class: className,
+    defaultOpen = true,
+    open = $bindable(defaultOpen),
+    onOpenChange,
+    variant = 'sidebar',
+    side = 'left',
+    collapsible = 'icon',
+    resizable = false,
+    defaultWidth = 256,
+    minWidth = 200,
+    maxWidth = 480,
+    onWidthChange,
+    contained = false,
+    peekable = false,
+    animationDuration = 250
+  }: Props = $props();
+
+  let width: number = $state(256);
+  let isPeeking: boolean = $state(false);
+
+  const sidebarState: SidebarState = $derived(isPeeking ? 'peeking' : open ? 'expanded' : 'collapsed');
+  const sidebarWidth = $derived(resizable ? `${width}px` : '16.25rem');
+
+  $effect(() => {
+    width = Math.min(maxWidth, Math.max(minWidth, defaultWidth));
+  });
+
+  function setOpen(nextOpen: boolean) {
+    open = nextOpen;
+    if (nextOpen) isPeeking = false;
+    onOpenChange?.(nextOpen);
+  }
+
+  function setWidth(nextWidth: number) {
+    width = Math.min(maxWidth, Math.max(minWidth, nextWidth));
+    onWidthChange?.(width);
+  }
+
+  function toggleSidebar() {
+    setOpen(!open);
+  }
+
+  function startPeek() {
+    if (peekable && !open) isPeeking = true;
+  }
+
+  function stopPeek() {
+    isPeeking = false;
+  }
+
+  setSidebarContext({
+    get state() {
+      return sidebarState;
+    },
+    get open() {
+      return open;
+    },
+    setOpen,
+    get side() {
+      return side;
+    },
+    get variant() {
+      return variant;
+    },
+    get collapsible() {
+      return collapsible;
+    },
+    get width() {
+      return width;
+    },
+    get resizable() {
+      return resizable;
+    },
+    get minWidth() {
+      return minWidth;
+    },
+    get maxWidth() {
+      return maxWidth;
+    },
+    setWidth,
+    get peekable() {
+      return peekable;
+    },
+    get isPeeking() {
+      return isPeeking;
+    },
+    startPeek,
+    stopPeek,
+    toggleSidebar
+  });
+</script>
+
+<div
+  data-sidebar-wrapper
+  data-state={sidebarState}
+  data-side={side}
+  data-contained={contained ? '' : undefined}
+  style:--sidebar-width={sidebarWidth}
+  style:--sidebar-width-icon="57px"
+  style:--sidebar-animation-duration={`${animationDuration}ms`}
+  style:--sidebar-easing="cubic-bezier(0.77, 0, 0.175, 1)"
+  style:--sidebar-bg="var(--color-kumo-base)"
+  class={cn('group/sidebar-wrapper isolate flex w-full', !contained && 'min-h-svh', variant === 'inset' && 'bg-kumo-recessed', className)}
+>
+  {@render children()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
   import {
@@ -49,18 +50,39 @@
 
   let width: number = $state(256);
   let isPeeking: boolean = $state(false);
+  let isMobile: boolean = $state(false);
+  let openMobile: boolean = $state(false);
+  let isResizing: boolean = $state(false);
 
-  const sidebarState: SidebarState = $derived(isPeeking ? 'peeking' : open ? 'expanded' : 'collapsed');
+  const visibleOpen = $derived(isMobile ? openMobile : open);
+  const sidebarState: SidebarState = $derived(isPeeking ? 'peeking' : visibleOpen ? 'expanded' : 'collapsed');
   const sidebarWidth = $derived(resizable ? `${width}px` : '16.25rem');
+
+  onMount(() => {
+    const media = window.matchMedia('(max-width: 767px)');
+    const update = () => {
+      isMobile = media.matches;
+      if (!media.matches) openMobile = false;
+    };
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  });
 
   $effect(() => {
     width = Math.min(maxWidth, Math.max(minWidth, defaultWidth));
   });
 
   function setOpen(nextOpen: boolean) {
-    open = nextOpen;
+    if (isMobile) openMobile = nextOpen;
+    else open = nextOpen;
     if (nextOpen) isPeeking = false;
     onOpenChange?.(nextOpen);
+  }
+
+  function setOpenMobile(nextOpen: boolean) {
+    openMobile = nextOpen;
+    if (nextOpen) isPeeking = false;
   }
 
   function setWidth(nextWidth: number) {
@@ -69,7 +91,7 @@
   }
 
   function toggleSidebar() {
-    setOpen(!open);
+    setOpen(!visibleOpen);
   }
 
   function startPeek() {
@@ -85,9 +107,16 @@
       return sidebarState;
     },
     get open() {
-      return open;
+      return visibleOpen;
     },
     setOpen,
+    get isMobile() {
+      return isMobile;
+    },
+    get openMobile() {
+      return openMobile;
+    },
+    setOpenMobile,
     get side() {
       return side;
     },
@@ -97,11 +126,23 @@
     get collapsible() {
       return collapsible;
     },
+    get contained() {
+      return contained;
+    },
+    get animationDuration() {
+      return animationDuration;
+    },
     get width() {
       return width;
     },
     get resizable() {
       return resizable;
+    },
+    get isResizing() {
+      return isResizing;
+    },
+    setIsResizing(nextIsResizing: boolean) {
+      isResizing = nextIsResizing;
     },
     get minWidth() {
       return minWidth;
@@ -126,6 +167,8 @@
   data-sidebar-wrapper
   data-state={sidebarState}
   data-side={side}
+  data-mobile={isMobile ? '' : undefined}
+  data-resizing={isResizing ? '' : undefined}
   data-contained={contained ? '' : undefined}
   style:--sidebar-width={sidebarWidth}
   style:--sidebar-width-icon="57px"

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarRail.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarRail.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { cn } from '$lib/utils/cn';
+  import { getSidebarContext } from './context';
+  interface Props { class?: string; [key: string]: unknown; }
+  let { class: className, ...rest }: Props = $props();
+  const sidebar = getSidebarContext('Sidebar.Rail');
+</script>
+
+<button
+  type="button"
+  data-sidebar="rail"
+  data-kumo-component="Sidebar"
+  data-kumo-part="rail"
+  aria-label="Toggle sidebar"
+  tabindex="-1"
+  class={cn('absolute inset-y-0 z-1 hidden w-4 -translate-x-1/2 cursor-pointer transition-all after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-kumo-brand/20 sm:flex', sidebar.side === 'left' ? 'right-0' : 'left-0', className)}
+  onclick={sidebar.toggleSidebar}
+  {...rest}
+></button>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarResizeHandle.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarResizeHandle.svelte
@@ -10,6 +10,7 @@
   function onPointerDown(event: PointerEvent) {
     if (!sidebar.resizable) return;
     event.preventDefault();
+    sidebar.setIsResizing(true);
     startX = event.clientX;
     startWidth = sidebar.open ? sidebar.width : sidebar.minWidth;
 
@@ -24,6 +25,7 @@
       sidebar.setWidth(nextWidth);
     };
     const onUp = () => {
+      sidebar.setIsResizing(false);
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
     };

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarResizeHandle.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarResizeHandle.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { cn } from '$lib/utils/cn';
+  import { getSidebarContext } from './context';
+  interface Props { class?: string; [key: string]: unknown; }
+  let { class: className, ...rest }: Props = $props();
+  const sidebar = getSidebarContext('Sidebar.ResizeHandle');
+  let startX = 0;
+  let startWidth = 0;
+
+  function onPointerDown(event: PointerEvent) {
+    if (!sidebar.resizable) return;
+    event.preventDefault();
+    startX = event.clientX;
+    startWidth = sidebar.open ? sidebar.width : sidebar.minWidth;
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const delta = sidebar.side === 'left' ? moveEvent.clientX - startX : startX - moveEvent.clientX;
+      const nextWidth = startWidth + delta;
+      if (nextWidth < sidebar.minWidth) {
+        sidebar.setOpen(false);
+        return;
+      }
+      sidebar.setOpen(true);
+      sidebar.setWidth(nextWidth);
+    };
+    const onUp = () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    };
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    const grow = sidebar.side === 'left' ? 'ArrowRight' : 'ArrowLeft';
+    const shrink = sidebar.side === 'left' ? 'ArrowLeft' : 'ArrowRight';
+    if (event.key === grow) {
+      event.preventDefault();
+      sidebar.setOpen(true);
+      sidebar.setWidth(sidebar.open ? sidebar.width + 10 : sidebar.minWidth);
+    } else if (event.key === shrink) {
+      event.preventDefault();
+      const next = sidebar.width - 10;
+      if (next < sidebar.minWidth) sidebar.setOpen(false);
+      else sidebar.setWidth(next);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      sidebar.setOpen(false);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      sidebar.setOpen(true);
+      sidebar.setWidth(sidebar.maxWidth);
+    }
+  }
+</script>
+
+{#if sidebar.resizable}
+  <button
+    type="button"
+    aria-label="Resize sidebar"
+    data-sidebar="resize-handle"
+    class={cn('absolute inset-y-0 z-2 hidden w-3 cursor-col-resize after:absolute after:inset-y-0 after:w-0.5 after:bg-transparent hover:after:bg-kumo-hairline focus:outline-none focus-visible:after:bg-kumo-hairline sm:block', sidebar.side === 'left' ? 'right-0 after:right-0' : 'left-0 after:left-0', className)}
+    onpointerdown={onPointerDown}
+    onkeydown={onKeyDown}
+    {...rest}
+  ></button>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSeparator.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSeparator.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
+  let { children, class: className, ...rest }: Props = $props();
+</script>
+
+<div data-sidebar="separator" class={cn('my-3 px-2', className)} {...rest}>
+  <div class="border-b border-kumo-line"></div>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingView.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingView.svelte
@@ -2,19 +2,26 @@
   import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface SlidingContext { get activeKey(): string; }
+  interface SlidingContext { get activeKey(): string; get direction(): 'left' | 'right'; }
   interface Props { children?: Snippet; class?: string; value: string; [key: string]: unknown; }
   let { children, class: className, value, ...rest }: Props = $props();
   const sliding = getContext<SlidingContext>('kumo-sidebar-sliding-view');
+  const active = $derived(sliding?.activeKey === value);
 </script>
 
 <div
   data-sidebar="sliding-view"
-  data-active={sliding?.activeKey === value ? '' : undefined}
-  class={cn('absolute inset-0 min-h-0 transition-transform duration-(--sidebar-animation-duration) data-[active]:relative data-[active]:translate-x-0 not-data-[active]:translate-x-full', className)}
+  data-active={active ? '' : undefined}
+  aria-hidden={active ? undefined : 'true'}
+  inert={active ? undefined : true}
+  class={cn(
+    'absolute inset-0 min-h-0 transition-transform duration-(--sidebar-animation-duration) motion-reduce:transition-none',
+    active && 'relative translate-x-0',
+    !active && sliding?.direction === 'right' && '-translate-x-full',
+    !active && sliding?.direction !== 'right' && 'translate-x-full',
+    className
+  )}
   {...rest}
 >
-  {#if sliding?.activeKey === value}
-    {@render children?.()}
-  {/if}
+  {@render children?.()}
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingView.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingView.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { getContext } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface SlidingContext { get activeKey(): string; }
+  interface Props { children?: Snippet; class?: string; value: string; [key: string]: unknown; }
+  let { children, class: className, value, ...rest }: Props = $props();
+  const sliding = getContext<SlidingContext>('kumo-sidebar-sliding-view');
+</script>
+
+<div
+  data-sidebar="sliding-view"
+  data-active={sliding?.activeKey === value ? '' : undefined}
+  class={cn('absolute inset-0 min-h-0 transition-transform duration-(--sidebar-animation-duration) data-[active]:relative data-[active]:translate-x-0 not-data-[active]:translate-x-full', className)}
+  {...rest}
+>
+  {#if sliding?.activeKey === value}
+    {@render children?.()}
+  {/if}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
@@ -7,6 +7,9 @@
   setContext('kumo-sidebar-sliding-view', {
     get activeKey() {
       return activeKey;
+    },
+    get direction() {
+      return direction;
     }
   });
 </script>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { setContext } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  interface Props { children?: Snippet; class?: string; activeKey: string; direction?: 'left' | 'right'; [key: string]: unknown; }
+  let { children, class: className, activeKey, direction = 'left', ...rest }: Props = $props();
+  setContext('kumo-sidebar-sliding-view', {
+    get activeKey() {
+      return activeKey;
+    }
+  });
+</script>
+
+<div data-sidebar="sliding-views" data-direction={direction} class={cn('relative min-h-0 flex-1 overflow-hidden', className)} {...rest}>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarTestHost.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import {
+    Sidebar,
+    SidebarContent,
+    SidebarFooter,
+    SidebarProvider,
+    SidebarTrigger
+  } from './index';
+
+  interface Props {
+    defaultOpen?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }
+
+  let { defaultOpen = true, open = $bindable(), onOpenChange }: Props = $props();
+</script>
+
+{#if open === undefined}
+  <SidebarProvider {defaultOpen} {onOpenChange}>
+    <Sidebar>
+      <SidebarContent>
+        <div data-testid="state-reader"></div>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarTrigger />
+      </SidebarFooter>
+    </Sidebar>
+    <div data-testid="main">Main</div>
+  </SidebarProvider>
+{:else}
+  <SidebarProvider {defaultOpen} bind:open {onOpenChange}>
+    <Sidebar>
+      <SidebarContent>
+        <div data-testid="state-reader"></div>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarTrigger />
+      </SidebarFooter>
+    </Sidebar>
+    <div data-testid="main">Main</div>
+  </SidebarProvider>
+{/if}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarTrigger.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  import { getSidebarContext } from './context';
+  interface Props { children?: Snippet; class?: string; onclick?: (event: MouseEvent) => void; [key: string]: unknown; }
+  let { children, class: className, onclick, ...rest }: Props = $props();
+  const sidebar = getSidebarContext('Sidebar.Trigger');
+</script>
+
+<button
+  type="button"
+  data-sidebar="trigger"
+  data-kumo-component="Sidebar"
+  data-kumo-part="trigger"
+  aria-expanded={sidebar.open}
+  aria-label={sidebar.open ? 'Collapse sidebar' : 'Expand sidebar'}
+  class={cn('flex size-8.5 cursor-pointer items-center justify-center rounded-lg text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand', className)}
+  onclick={(event) => {
+    onclick?.(event);
+    sidebar.toggleSidebar();
+  }}
+  {...rest}
+>
+  {#if children}
+    {@render children()}
+  {:else}
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" class="shrink-0">
+      <path d="M21.25 6.72v10.56a2.97 2.97 0 0 1-2.97 2.97H5.72a2.97 2.97 0 0 1-2.97-2.97V6.72a2.97 2.97 0 0 1 2.97-2.97h12.56a2.97 2.97 0 0 1 2.97 2.97" />
+      <path d="M6.25 7.25v9.5" class={cn('transition-transform duration-(--sidebar-animation-duration) ease-(--sidebar-easing)', sidebar.open ? 'translate-x-px' : 'translate-x-[10.5px]')} />
+    </svg>
+  {/if}
+</button>

--- a/packages/kumo-svelte/src/lib/components/sidebar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/context.ts
@@ -9,11 +9,18 @@ export interface SidebarContextValue {
   get state(): SidebarState;
   get open(): boolean;
   setOpen(open: boolean): void;
+  get isMobile(): boolean;
+  get openMobile(): boolean;
+  setOpenMobile(open: boolean): void;
   get side(): SidebarSide;
   get variant(): SidebarVariant;
   get collapsible(): SidebarCollapsible;
+  get contained(): boolean;
+  get animationDuration(): number;
   get width(): number;
   get resizable(): boolean;
+  get isResizing(): boolean;
+  setIsResizing(isResizing: boolean): void;
   get minWidth(): number;
   get maxWidth(): number;
   setWidth(width: number): void;
@@ -24,7 +31,17 @@ export interface SidebarContextValue {
   toggleSidebar(): void;
 }
 
+export interface SidebarMenuItemContextValue {
+  get insideMenuItem(): boolean;
+}
+
+export interface SidebarMenuSubItemContextValue {
+  get insideMenuSubItem(): boolean;
+}
+
 const SIDEBAR_CONTEXT = Symbol('kumo-sidebar');
+const SIDEBAR_MENU_ITEM_CONTEXT = Symbol('kumo-sidebar-menu-item');
+const SIDEBAR_MENU_SUB_ITEM_CONTEXT = Symbol('kumo-sidebar-menu-sub-item');
 
 export function setSidebarContext(context: SidebarContextValue) {
   setContext(SIDEBAR_CONTEXT, context);
@@ -34,4 +51,20 @@ export function getSidebarContext(component: string) {
   const context = getContext<SidebarContextValue | undefined>(SIDEBAR_CONTEXT);
   if (!context) throw new Error(`${component} must be used inside <Sidebar.Provider>.`);
   return context;
+}
+
+export function setSidebarMenuItemContext(context: SidebarMenuItemContextValue) {
+  setContext(SIDEBAR_MENU_ITEM_CONTEXT, context);
+}
+
+export function getSidebarMenuItemContext() {
+  return getContext<SidebarMenuItemContextValue | undefined>(SIDEBAR_MENU_ITEM_CONTEXT);
+}
+
+export function setSidebarMenuSubItemContext(context: SidebarMenuSubItemContextValue) {
+  setContext(SIDEBAR_MENU_SUB_ITEM_CONTEXT, context);
+}
+
+export function getSidebarMenuSubItemContext() {
+  return getContext<SidebarMenuSubItemContextValue | undefined>(SIDEBAR_MENU_SUB_ITEM_CONTEXT);
 }

--- a/packages/kumo-svelte/src/lib/components/sidebar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/context.ts
@@ -1,0 +1,37 @@
+import { getContext, setContext } from 'svelte';
+
+export type SidebarState = 'expanded' | 'collapsed' | 'peeking';
+export type SidebarSide = 'left' | 'right';
+export type SidebarVariant = 'sidebar' | 'floating' | 'inset';
+export type SidebarCollapsible = 'icon' | 'offcanvas' | 'none';
+
+export interface SidebarContextValue {
+  get state(): SidebarState;
+  get open(): boolean;
+  setOpen(open: boolean): void;
+  get side(): SidebarSide;
+  get variant(): SidebarVariant;
+  get collapsible(): SidebarCollapsible;
+  get width(): number;
+  get resizable(): boolean;
+  get minWidth(): number;
+  get maxWidth(): number;
+  setWidth(width: number): void;
+  get peekable(): boolean;
+  get isPeeking(): boolean;
+  startPeek(): void;
+  stopPeek(): void;
+  toggleSidebar(): void;
+}
+
+const SIDEBAR_CONTEXT = Symbol('kumo-sidebar');
+
+export function setSidebarContext(context: SidebarContextValue) {
+  setContext(SIDEBAR_CONTEXT, context);
+}
+
+export function getSidebarContext(component: string) {
+  const context = getContext<SidebarContextValue | undefined>(SIDEBAR_CONTEXT);
+  if (!context) throw new Error(`${component} must be used inside <Sidebar.Provider>.`);
+  return context;
+}

--- a/packages/kumo-svelte/src/lib/components/sidebar/index.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/index.ts
@@ -1,1 +1,111 @@
-export { default as Sidebar } from './Sidebar.svelte';
+import Root from './Sidebar.svelte';
+import Provider from './SidebarProvider.svelte';
+import Header from './SidebarHeader.svelte';
+import Content from './SidebarContent.svelte';
+import Footer from './SidebarFooter.svelte';
+import Group from './SidebarGroup.svelte';
+import GroupLabel from './SidebarGroupLabel.svelte';
+import Menu from './SidebarMenu.svelte';
+import MenuItem from './SidebarMenuItem.svelte';
+import MenuButton from './SidebarMenuButton.svelte';
+import MenuBadge from './SidebarMenuBadge.svelte';
+import MenuSub from './SidebarMenuSub.svelte';
+import MenuSubItem from './SidebarMenuSubItem.svelte';
+import MenuSubButton from './SidebarMenuSubButton.svelte';
+import Separator from './SidebarSeparator.svelte';
+import Trigger from './SidebarTrigger.svelte';
+import Rail from './SidebarRail.svelte';
+import ResizeHandle from './SidebarResizeHandle.svelte';
+import MenuChevron from './SidebarMenuChevron.svelte';
+import Collapsible from './SidebarCollapsible.svelte';
+import CollapsibleTrigger from './SidebarCollapsibleTrigger.svelte';
+import CollapsibleContent from './SidebarCollapsibleContent.svelte';
+import SlidingViews from './SidebarSlidingViews.svelte';
+import SlidingView from './SidebarSlidingView.svelte';
+
+export const Sidebar: typeof Root & {
+  Provider: typeof Provider;
+  Root: typeof Root;
+  Header: typeof Header;
+  Content: typeof Content;
+  Footer: typeof Footer;
+  Group: typeof Group;
+  GroupLabel: typeof GroupLabel;
+  Menu: typeof Menu;
+  MenuItem: typeof MenuItem;
+  MenuButton: typeof MenuButton;
+  MenuBadge: typeof MenuBadge;
+  MenuSub: typeof MenuSub;
+  MenuSubItem: typeof MenuSubItem;
+  MenuSubButton: typeof MenuSubButton;
+  Separator: typeof Separator;
+  Trigger: typeof Trigger;
+  Rail: typeof Rail;
+  ResizeHandle: typeof ResizeHandle;
+  MenuChevron: typeof MenuChevron;
+  Collapsible: typeof Collapsible;
+  CollapsibleTrigger: typeof CollapsibleTrigger;
+  CollapsibleContent: typeof CollapsibleContent;
+  SlidingViews: typeof SlidingViews;
+  SlidingView: typeof SlidingView;
+} = Object.assign(Root, {
+  Provider,
+  Root,
+  Header,
+  Content,
+  Footer,
+  Group,
+  GroupLabel,
+  Menu,
+  MenuItem,
+  MenuButton,
+  MenuBadge,
+  MenuSub,
+  MenuSubItem,
+  MenuSubButton,
+  Separator,
+  Trigger,
+  Rail,
+  ResizeHandle,
+  MenuChevron,
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+  SlidingViews,
+  SlidingView
+});
+
+export {
+  Root as SidebarRoot,
+  Provider as SidebarProvider,
+  Header as SidebarHeader,
+  Content as SidebarContent,
+  Footer as SidebarFooter,
+  Group as SidebarGroup,
+  GroupLabel as SidebarGroupLabel,
+  Menu as SidebarMenu,
+  MenuItem as SidebarMenuItem,
+  MenuButton as SidebarMenuButton,
+  MenuBadge as SidebarMenuBadge,
+  MenuSub as SidebarMenuSub,
+  MenuSubItem as SidebarMenuSubItem,
+  MenuSubButton as SidebarMenuSubButton,
+  Separator as SidebarSeparator,
+  Trigger as SidebarTrigger,
+  Rail as SidebarRail,
+  ResizeHandle as SidebarResizeHandle,
+  MenuChevron as SidebarMenuChevron,
+  Collapsible as SidebarCollapsibleRoot,
+  CollapsibleTrigger as SidebarCollapsibleTrigger,
+  CollapsibleContent as SidebarCollapsibleContent,
+  SlidingViews as SidebarSlidingViews,
+  SlidingView as SidebarSlidingView
+};
+
+export type {
+  SidebarCollapsible as SidebarCollapsibleMode,
+  SidebarContextValue,
+  SidebarSide,
+  SidebarState,
+  SidebarVariant
+} from './context';

--- a/packages/kumo-svelte/src/lib/components/sidebar/sidebar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/sidebar.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Sidebar,
+  SidebarCollapsibleContent,
+  SidebarCollapsibleRoot,
+  SidebarCollapsibleTrigger,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuChevron,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarRoot,
+  SidebarSeparator,
+  SidebarSlidingView,
+  SidebarSlidingViews,
+  SidebarTrigger
+} from './index';
+import SidebarTestHost from './SidebarTestHost.svelte';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  });
+});
+
+describe('Sidebar exports', () => {
+  it('should export compound component with all sub-components', () => {
+    expect(Sidebar).toBeDefined();
+    expect(Sidebar.Provider).toBe(SidebarProvider);
+    expect(Sidebar.Root).toBe(SidebarRoot);
+    expect(Sidebar.Header).toBe(SidebarHeader);
+    expect(Sidebar.Content).toBe(SidebarContent);
+    expect(Sidebar.Footer).toBe(SidebarFooter);
+    expect(Sidebar.Group).toBe(SidebarGroup);
+    expect(Sidebar.GroupLabel).toBe(SidebarGroupLabel);
+    expect(Sidebar.Menu).toBe(SidebarMenu);
+    expect(Sidebar.MenuItem).toBe(SidebarMenuItem);
+    expect(Sidebar.MenuButton).toBe(SidebarMenuButton);
+    expect(Sidebar.MenuBadge).toBe(SidebarMenuBadge);
+    expect(Sidebar.MenuSub).toBe(SidebarMenuSub);
+    expect(Sidebar.MenuSubItem).toBe(SidebarMenuSubItem);
+    expect(Sidebar.MenuSubButton).toBe(SidebarMenuSubButton);
+    expect(Sidebar.Separator).toBe(SidebarSeparator);
+    expect(Sidebar.Trigger).toBe(SidebarTrigger);
+    expect(Sidebar.Rail).toBe(SidebarRail);
+    expect(Sidebar.MenuChevron).toBe(SidebarMenuChevron);
+    expect(Sidebar.Collapsible).toBe(SidebarCollapsibleRoot);
+    expect(Sidebar.CollapsibleTrigger).toBe(SidebarCollapsibleTrigger);
+    expect(Sidebar.CollapsibleContent).toBe(SidebarCollapsibleContent);
+    expect(Sidebar.SlidingViews).toBe(SidebarSlidingViews);
+    expect(Sidebar.SlidingView).toBe(SidebarSlidingView);
+  });
+
+  it('should not export removed components', () => {
+    expect(Sidebar).not.toHaveProperty('Input');
+    expect(Sidebar).not.toHaveProperty('MenuAction');
+    expect(Sidebar).not.toHaveProperty('GroupContent');
+  });
+});
+
+describe('Sidebar toggle', () => {
+  it('should start expanded with defaultOpen=true', () => {
+    const { container } = render(SidebarTestHost, { props: { defaultOpen: true } });
+
+    expect(container.querySelector('[data-sidebar-wrapper]')?.getAttribute('data-state')).toBe('expanded');
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' }).getAttribute('aria-expanded')).toBe(
+      'true'
+    );
+  });
+
+  it('should start collapsed with defaultOpen=false', () => {
+    const { container } = render(SidebarTestHost, { props: { defaultOpen: false } });
+
+    expect(container.querySelector('[data-sidebar-wrapper]')?.getAttribute('data-state')).toBe('collapsed');
+    expect(screen.getByRole('button', { name: 'Expand sidebar' }).getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+  });
+
+  it('should toggle on Trigger click', async () => {
+    const { container } = render(SidebarTestHost, { props: { defaultOpen: true } });
+
+    const trigger = screen.getByRole('button', { name: 'Collapse sidebar' });
+    await fireEvent.click(trigger);
+
+    expect(screen.getByRole('button', { name: 'Expand sidebar' }).getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+    expect(container.querySelector('[data-sidebar-wrapper]')?.getAttribute('data-state')).toBe('collapsed');
+  });
+
+  it('should call onOpenChange when controlled', async () => {
+    const onOpenChange = vi.fn();
+    render(SidebarTestHost, { props: { open: true, onOpenChange } });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/switch/Switch.svelte
+++ b/packages/kumo-svelte/src/lib/components/switch/Switch.svelte
@@ -94,6 +94,7 @@
     id={controlId}
     aria-label={controlLabel}
     aria-busy={transitioning || undefined}
+    data-kumo-component="Switch"
     onCheckedChange={handleCheckedChange}
     class={cn(
       'relative inline-flex items-center ring cursor-pointer border-none p-0',
@@ -121,7 +122,7 @@
 {/snippet}
 
 {#if label || children}
-  <span class={cn('m-0 relative inline-flex items-center gap-2', !controlFirst && 'flex-row-reverse justify-end', disabled && 'opacity-50')}>
+  <span data-kumo-component="Switch" data-kumo-part="label" class={cn('m-0 relative inline-flex items-center gap-2', !controlFirst && 'flex-row-reverse justify-end', disabled && 'opacity-50')}>
     {@render control()}
     <label for={controlId} class={cn('text-base font-medium text-kumo-default', disabled ? 'cursor-not-allowed' : 'cursor-pointer')}>
       {#if label}{label}{:else}{@render children?.()}{/if}

--- a/packages/kumo-svelte/src/lib/components/switch/SwitchItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/switch/SwitchItem.svelte
@@ -41,6 +41,8 @@
 </script>
 
 <span
+  data-kumo-component="Switch"
+  data-kumo-part="item-label"
   class={cn(
     'm-0 relative inline-flex items-center gap-2',
     !controlFirst && 'flex-row-reverse justify-end',
@@ -54,6 +56,8 @@
     {disabled}
     aria-busy={transitioning || undefined}
     aria-label={label}
+    data-kumo-component="Switch"
+    data-kumo-part="item"
     onCheckedChange={handleCheckedChange}
     class={cn(
       'relative inline-flex items-center ring cursor-pointer border-none p-0',

--- a/packages/kumo-svelte/src/lib/components/table-of-contents/TableOfContentsGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/table-of-contents/TableOfContentsGroup.svelte
@@ -22,6 +22,8 @@
     <a
       {href}
       aria-current={active ? 'true' : undefined}
+      data-kumo-component="TableOfContents"
+      data-kumo-part="group-link"
       class={cn(
         ITEM_BASE,
         active

--- a/packages/kumo-svelte/src/lib/components/table-of-contents/TableOfContentsItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/table-of-contents/TableOfContentsItem.svelte
@@ -30,6 +30,8 @@
   {#if as === 'button'}
     <button
       aria-current={active ? 'true' : undefined}
+      data-kumo-component="TableOfContents"
+      data-kumo-part="item"
       class={itemClass}
       {...rest}
     >
@@ -39,6 +41,8 @@
     <a
       {href}
       aria-current={active ? 'true' : undefined}
+      data-kumo-component="TableOfContents"
+      data-kumo-part="item"
       class={itemClass}
       {...rest}
     >

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
@@ -263,6 +263,8 @@
         <TabsPrimitive.Trigger
           value={tab.value}
           disabled={tab.disabled}
+          data-kumo-component="Tabs"
+          data-kumo-part="tab"
           class={cn(
             'relative z-2 flex items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand',
             isOverflowing ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',

--- a/packages/kumo-svelte/src/lib/components/toasty/KumoToastContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/toasty/KumoToastContent.svelte
@@ -66,6 +66,8 @@
     </div>
   {/if}
   <button
+    data-kumo-component="Toast"
+    data-kumo-part="close"
     class="absolute top-2 right-2 flex h-4 w-4 items-center justify-center rounded border-none bg-transparent text-current/50 hover:bg-kumo-contrast/10 hover:text-current"
     aria-label="Close"
     type="button"

--- a/packages/kumo-svelte/src/lib/docs/CLITerminal.svelte
+++ b/packages/kumo-svelte/src/lib/docs/CLITerminal.svelte
@@ -610,6 +610,10 @@ Examples:
     tabindex="0"
     onclick={focusInput}
     onkeydown={(event) => {
+      if (event.target !== event.currentTarget) {
+        return;
+      }
+
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         focusInput();

--- a/packages/kumo-svelte/src/lib/docs/MdxPage.svelte
+++ b/packages/kumo-svelte/src/lib/docs/MdxPage.svelte
@@ -25,6 +25,7 @@
   const sourceFile = $derived(
     typeof metadata.sourceFile === 'string' ? metadata.sourceFile : undefined
   );
+  const wideContent = $derived(metadata.contentLayout === 'wide');
   const bitsUIComponent = $derived(
     typeof metadata.bitsUIComponent === 'string'
       ? metadata.bitsUIComponent
@@ -172,22 +173,28 @@
 
   <main class="flex grow flex-col md:pr-12">
     <div class="mx-auto w-full grow md:border-r md:border-kumo-hairline">
-      <div class="sticky top-24 z-1 border-b border-kumo-hairline bg-kumo-canvas xl:hidden md:top-12">
+      <div
+        class={wideContent
+          ? 'hidden'
+          : 'sticky top-24 z-1 border-b border-kumo-hairline bg-kumo-canvas xl:hidden md:top-12'}
+      >
         <div class="mx-auto max-w-7xl px-2 py-3 md:px-3">
           <TableOfContents layout="select" headings={tocHeadings} />
         </div>
       </div>
 
       <div class="mx-auto max-w-7xl p-12 pr-10">
-        <div class="grid grid-cols-1 gap-16 xl:grid-cols-[3fr_1fr]">
+        <div class={wideContent ? 'grid grid-cols-1' : 'grid grid-cols-1 gap-16 xl:grid-cols-[3fr_1fr]'}>
           <div class="kumo-prose prose min-w-0 max-w-none">
             {@render children?.()}
           </div>
-          <aside class="hidden min-w-0 xl:block">
-            <div class="sticky top-24">
-              <TableOfContents headings={tocHeadings} />
-            </div>
-          </aside>
+          {#if !wideContent}
+            <aside class="hidden min-w-0 xl:block">
+              <div class="sticky top-24">
+                <TableOfContents headings={tocHeadings} />
+              </div>
+            </aside>
+          {/if}
         </div>
       </div>
     </div>

--- a/packages/kumo-svelte/src/lib/docs/PropsTable.svelte
+++ b/packages/kumo-svelte/src/lib/docs/PropsTable.svelte
@@ -57,7 +57,7 @@
     Empty: ['title'],
     Label: ['children'],
     ClipboardText: ['text'],
-    CodeHighlighted: ['code', 'lang'],
+    CodeHighlighted: ['code'],
     DatePicker: ['mode'],
     'Collapsible.DefaultTrigger': ['children'],
     'Collapsible.DefaultPanel': ['children'],

--- a/packages/kumo-svelte/src/lib/docs/TailwindColorTokens.svelte
+++ b/packages/kumo-svelte/src/lib/docs/TailwindColorTokens.svelte
@@ -1,121 +1,215 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+
+  type Token = {
+    name: string;
+    global?: boolean;
+  };
+
   type TokenGroup = {
     title: string;
-    tokens: string[];
+    tokens?: Token[];
+    groups?: TokenGroup[];
   };
 
   const tokenGroups: TokenGroup[] = [
     {
       title: 'Text Colors',
       tokens: [
-        '--text-color-kumo-default',
-        '--text-color-kumo-inverse',
-        '--text-color-kumo-strong',
-        '--text-color-kumo-subtle',
-        '--text-color-kumo-inactive',
-        '--text-color-kumo-placeholder',
-        '--text-color-kumo-brand',
-        '--text-color-kumo-link',
-        '--text-color-kumo-info',
-        '--text-color-kumo-success',
-        '--text-color-kumo-danger',
-        '--text-color-kumo-warning'
+        { name: '--text-color-kumo-default' },
+        { name: '--text-color-kumo-inverse' },
+        { name: '--text-color-kumo-strong' },
+        { name: '--text-color-kumo-subtle' },
+        { name: '--text-color-kumo-inactive' },
+        { name: '--text-color-kumo-placeholder' },
+        { name: '--text-color-kumo-brand' },
+        { name: '--text-color-kumo-link' },
+        { name: '--text-color-kumo-info' },
+        { name: '--text-color-kumo-success' },
+        { name: '--text-color-kumo-danger' },
+        { name: '--text-color-kumo-warning' }
       ]
     },
     {
       title: 'Surface, State & Theme Colors',
       tokens: [
-        '--color-kumo-canvas',
-        '--color-kumo-elevated',
-        '--color-kumo-recessed',
-        '--color-kumo-base',
-        '--color-kumo-tint',
-        '--color-kumo-contrast',
-        '--color-kumo-overlay',
-        '--color-kumo-control',
-        '--color-kumo-interact',
-        '--color-kumo-fill',
-        '--color-kumo-fill-hover',
-        '--color-kumo-brand',
-        '--color-kumo-brand-hover',
-        '--color-kumo-line',
-        '--color-kumo-hairline',
-        '--color-kumo-focus',
-        '--color-kumo-shadow-edge',
-        '--color-kumo-shadow-drop',
-        '--color-kumo-tip-shadow',
-        '--color-kumo-tip-stroke',
-        '--color-kumo-info-tint',
-        '--color-kumo-info',
-        '--color-kumo-warning-tint',
-        '--color-kumo-warning',
-        '--color-kumo-danger-tint',
-        '--color-kumo-danger',
-        '--color-kumo-success-tint',
-        '--color-kumo-success'
+        { name: '--color-kumo-canvas' },
+        { name: '--color-kumo-elevated' },
+        { name: '--color-kumo-recessed' },
+        { name: '--color-kumo-base' },
+        { name: '--color-kumo-tint' },
+        { name: '--color-kumo-contrast' },
+        { name: '--color-kumo-overlay' },
+        { name: '--color-kumo-control' },
+        { name: '--color-kumo-interact' },
+        { name: '--color-kumo-fill' },
+        { name: '--color-kumo-fill-hover' },
+        { name: '--color-kumo-brand' },
+        { name: '--color-kumo-brand-hover' },
+        { name: '--color-kumo-line' },
+        { name: '--color-kumo-hairline' },
+        { name: '--color-kumo-focus' },
+        { name: '--color-kumo-shadow-edge' },
+        { name: '--color-kumo-shadow-drop' },
+        { name: '--color-kumo-tip-shadow' },
+        { name: '--color-kumo-tip-stroke' },
+        { name: '--color-kumo-info-tint' },
+        { name: '--color-kumo-info' },
+        { name: '--color-kumo-warning-tint' },
+        { name: '--color-kumo-warning' },
+        { name: '--color-kumo-danger-tint' },
+        { name: '--color-kumo-danger' },
+        { name: '--color-kumo-success-tint' },
+        { name: '--color-kumo-success' }
       ]
     },
     {
-      title: 'Badge Colors',
-      tokens: [
-        '--text-color-kumo-badge-orange-subtle',
-        '--text-color-kumo-badge-teal-subtle',
-        '--text-color-kumo-badge-neutral-subtle',
-        '--text-color-kumo-badge-inverted',
-        '--color-kumo-badge-red',
-        '--color-kumo-badge-orange',
-        '--color-kumo-badge-orange-subtle',
-        '--color-kumo-badge-purple',
-        '--color-kumo-badge-green',
-        '--color-kumo-badge-teal',
-        '--color-kumo-badge-teal-subtle',
-        '--color-kumo-badge-blue',
-        '--color-kumo-badge-neutral',
-        '--color-kumo-badge-inverted'
+      title: 'Component Colors',
+      groups: [
+        {
+          title: 'Badge',
+          tokens: [
+            { name: '--text-color-kumo-badge-orange-subtle' },
+            { name: '--text-color-kumo-badge-teal-subtle' },
+            { name: '--text-color-kumo-badge-neutral-subtle' },
+            { name: '--text-color-kumo-badge-inverted' },
+            { name: '--color-kumo-badge-red' },
+            { name: '--color-kumo-badge-orange' },
+            { name: '--color-kumo-badge-purple' },
+            { name: '--color-kumo-badge-teal' },
+            { name: '--color-kumo-badge-blue' },
+            { name: '--color-kumo-badge-neutral' },
+            { name: '--color-kumo-badge-inverted' }
+          ]
+        },
+        {
+          title: 'Banner',
+          tokens: [{ name: '--color-kumo-banner-info' }, { name: '--color-kumo-banner-warning' }]
+        }
       ]
     }
   ];
 
-  const tokenCount = tokenGroups.reduce((count, group) => count + group.tokens.length, 0);
+  const groupCount = (group: TokenGroup): number =>
+    (group.tokens?.length ?? 0) + (group.groups?.reduce((count, child) => count + groupCount(child), 0) ?? 0);
+
+  const tokenCount = tokenGroups.reduce((count, group) => count + groupCount(group), 0);
+
+  let tokenValues = $state<Record<string, { light: string; dark: string }>>({});
+
+  const formatValue = (value: string | undefined) => value?.trim() || ' ';
+
+  onMount(() => {
+    const nextValues: Record<string, { light: string; dark: string }> = {};
+
+    document.querySelectorAll<HTMLElement>('[data-token-card]').forEach((card) => {
+      const token = card.dataset.token;
+
+      if (!token) {
+        return;
+      }
+
+      const light = card.querySelector<HTMLElement>('[data-token-mode="light"]');
+      const dark = card.querySelector<HTMLElement>('[data-token-mode="dark"]');
+
+      nextValues[token] = {
+        light: light ? getComputedStyle(light).getPropertyValue(token) : '',
+        dark: dark ? getComputedStyle(dark).getPropertyValue(token) : ''
+      };
+    });
+
+    tokenValues = nextValues;
+  });
 </script>
 
-<section class="not-prose my-8 space-y-8">
-  <div>
-    <h2 class="text-2xl font-semibold tracking-normal text-kumo-strong">Colors</h2>
-    <p class="mt-2 text-sm text-kumo-subtle">Displaying {tokenCount} tokens</p>
-  </div>
+{#snippet tokenGrid(tokens: Token[])}
+  <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-2">
+    {#each tokens as token}
+      <div
+        data-token-card
+        data-token={token.name}
+        class="flex min-w-0 items-center gap-3 rounded-md border border-kumo-fill bg-kumo-base px-3 py-2 text-xs"
+      >
+        <div class="flex min-w-0 flex-1 flex-col gap-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="font-mono text-xs font-medium break-normal">{token.name}</span>
+            {#if token.global}
+              <span class="rounded-full bg-kumo-tint px-2 py-0.5 text-[10px] font-medium text-kumo-subtle">
+                global
+              </span>
+            {/if}
+          </div>
 
-  {#each tokenGroups as group}
-    <section class="space-y-3">
-      <h3 class="text-lg font-semibold tracking-normal text-kumo-strong">
-        {group.title} ({group.tokens.length})
-      </h3>
-
-      <div class="overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base">
-        {#each group.tokens as token}
           <div
-            class="grid gap-3 border-b border-kumo-hairline p-4 last:border-b-0 sm:grid-cols-[minmax(16rem,1fr)_minmax(11rem,14rem)_minmax(11rem,14rem)] sm:items-center"
+            data-theme="kumo"
+            data-mode="light"
+            data-token-mode="light"
+            class="flex min-w-0 items-start gap-2"
           >
-            <code class="text-sm text-kumo-default">{token}</code>
-
-            <div data-mode="light" class="flex items-center gap-3">
-              <span
-                class="size-8 shrink-0 rounded border border-kumo-hairline shadow-xs"
-                style:background-color={`var(${token})`}
-              ></span>
-              <span class="text-sm text-kumo-subtle">Light</span>
-            </div>
-
-            <div data-mode="dark" class="flex items-center gap-3">
-              <span
-                class="size-8 shrink-0 rounded border border-kumo-hairline shadow-xs"
-                style:background-color={`var(${token})`}
-              ></span>
-              <span class="text-sm text-kumo-subtle">Dark</span>
+            <span
+              class="inline-flex h-8 w-8 shrink-0 rounded border border-kumo-fill"
+              style:background={`var(${token.name})`}
+            ></span>
+            <div class="flex min-w-0 flex-col text-xs text-kumo-default">
+              <span class="text-[10px] tracking-wide uppercase opacity-70">Light</span>
+              <span class="text-[10px] leading-tight break-normal opacity-60">
+                {formatValue(tokenValues[token.name]?.light)}
+              </span>
             </div>
           </div>
-        {/each}
+
+          <div
+            data-theme="kumo"
+            data-mode="dark"
+            data-token-mode="dark"
+            class="flex min-w-0 items-start gap-2"
+          >
+            <span
+              class="inline-flex h-8 w-8 shrink-0 rounded border border-kumo-fill"
+              style:background={`var(${token.name})`}
+            ></span>
+            <div class="flex min-w-0 flex-col text-xs text-kumo-default">
+              <span class="text-[10px] tracking-wide uppercase opacity-70">Dark</span>
+              <span class="text-[10px] leading-tight break-normal opacity-60">
+                {formatValue(tokenValues[token.name]?.dark)}
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
-    </section>
-  {/each}
+    {/each}
+  </div>
+{/snippet}
+
+<section class="not-prose my-8">
+  <div class="flex flex-col gap-6 text-kumo-default">
+    <div>
+      <h2 class="text-2xl font-semibold tracking-normal text-kumo-strong">Colors</h2>
+      <p class="mt-2 text-sm text-kumo-subtle">Displaying {tokenCount} tokens</p>
+    </div>
+
+    {#each tokenGroups as group}
+      <section class="space-y-3">
+        <h3 class="text-lg font-semibold tracking-normal text-kumo-strong">
+          {group.title} ({groupCount(group)})
+        </h3>
+
+        {#if group.tokens}
+          {@render tokenGrid(group.tokens)}
+        {/if}
+
+        {#each group.groups ?? [] as child}
+          <section class="space-y-3 pt-3">
+            <h4 class="text-base font-semibold tracking-normal text-kumo-strong">
+              {child.title} ({groupCount(child)})
+            </h4>
+
+            {#if child.tokens}
+              {@render tokenGrid(child.tokens)}
+            {/if}
+          </section>
+        {/each}
+      </section>
+    {/each}
+  </div>
 </section>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BadgeColorVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BadgeColorVariantsDemo.svelte
@@ -6,7 +6,6 @@
   <Badge variant="neutral">Neutral</Badge>
   <Badge variant="red">Red</Badge>
   <Badge variant="orange">Orange</Badge>
-  <Badge variant="green">Green</Badge>
   <Badge variant="teal">Teal</Badge>
   <Badge variant="blue">Blue</Badge>
   <Badge variant="purple">Purple</Badge>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerCustomContentDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerCustomContentDemo.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { Banner } from '$lib';
+  import { Banner, Text } from '$lib';
   import { Info } from 'phosphor-svelte';
 </script>
 
-<Banner
-  icon={Info}
-  title="Custom content supported"
-  description="This banner supports custom content with Text."
-/>
+<Banner icon={Info} title="Custom content supported">
+  {#snippet description()}
+    <Text DANGEROUS_className="text-inherit">
+      This banner supports <strong>custom content</strong> with Text.
+    </Text>
+  {/snippet}
+</Banner>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerSecondaryDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerSecondaryDemo.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { Banner } from '$lib';
-  import { DotsThreeCircle } from 'phosphor-svelte';
+  import { Info } from 'phosphor-svelte';
 </script>
 
 <Banner
-  icon={DotsThreeCircle}
+  icon={Info}
   variant="secondary"
-  title="Sync paused"
-  description="Changes will resume when your connection is restored."
+  title="Maintenance scheduled"
+  description="This service will be unavailable for 10 minutes."
 />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerSecondaryDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerSecondaryDemo.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { Banner } from '$lib';
+  import { DotsThreeCircle } from 'phosphor-svelte';
+</script>
+
+<Banner
+  icon={DotsThreeCircle}
+  variant="secondary"
+  title="Sync paused"
+  description="Changes will resume when your connection is restored."
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerVariantsDemo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Banner } from '$lib';
-  import { Info, Warning, WarningCircle, DotsThreeCircle } from 'phosphor-svelte';
+  import { Info, Warning, WarningCircle } from 'phosphor-svelte';
 </script>
 
 <div class="w-full space-y-3">
@@ -18,9 +18,9 @@
     description="We couldn't save your changes. Please try again."
   />
   <Banner
-    icon={DotsThreeCircle}
+    icon={Info}
     variant="secondary"
-    title="Sync paused"
-    description="Changes will resume when your connection is restored."
+    title="Maintenance scheduled"
+    description="This service will be unavailable for 10 minutes."
   />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerVariantsDemo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Banner } from '$lib';
-  import { Info, Warning, WarningCircle } from 'phosphor-svelte';
+  import { Info, Warning, WarningCircle, DotsThreeCircle } from 'phosphor-svelte';
 </script>
 
 <div class="w-full space-y-3">
@@ -16,5 +16,11 @@
     variant="error"
     title="Save failed"
     description="We couldn't save your changes. Please try again."
+  />
+  <Banner
+    icon={DotsThreeCircle}
+    variant="secondary"
+    title="Sync paused"
+    description="Changes will resume when your connection is restored."
   />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerWithActionDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerWithActionDemo.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   import { Banner, Button } from '$lib';
-  import { Info } from 'phosphor-svelte';
+  import { Info, X } from 'phosphor-svelte';
 </script>
 
-<Banner icon={Info} title="Update available" description="A new version is ready to install.">
-  {#snippet action()}
-    <Button size="sm" variant="primary">Update now</Button>
-  {/snippet}
-</Banner>
+<div class="w-full space-y-3">
+  <Banner icon={Info} title="Update available" description="A new version is ready to install.">
+    {#snippet action()}
+      <Button size="sm" variant="primary">Update now</Button>
+    {/snippet}
+  </Banner>
+  <Banner icon={Info} title="Update available" description="A new version is ready to install.">
+    {#snippet action()}
+      <Button size="sm" variant="ghost" shape="square" aria-label="Dismiss">
+        <X class="size-4" />
+      </Button>
+    {/snippet}
+  </Banner>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerWithIconDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BannerWithIconDemo.svelte
@@ -6,6 +6,6 @@
 <Banner
   icon={Warning}
   variant="alert"
-  title="Session expiring"
-  description="Your session will expire in 5 minutes."
+  title="Review required"
+  description="Please review your billing information before proceeding."
 />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CheckboxIndeterminateDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CheckboxIndeterminateDemo.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import { Select } from '$lib';
+  import { Checkbox } from '$lib';
+
+  let indeterminate = $state(true);
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-<div class="inline-flex items-center gap-2 text-sm text-kumo-default">
-      <span class="flex size-4 items-center justify-center rounded-sm bg-kumo-base ring ring-kumo-line"><span class="h-0.5 w-2 rounded bg-kumo-brand"></span></span>
-      Select all
-    </div>
+  <Checkbox label="Select all" bind:indeterminate />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextAlternateDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextAlternateDemo.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText text="Production endpoint" textToCopy="https://api-edge.example.workers.dev" />
+  <ClipboardText text="sk_live_***********" textToCopy="sk_live_51H8_abc123" />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextApiKeyDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextApiKeyDemo.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText text="cf_live_2xv4e7k9n8p3m6q1" />
+  <ClipboardText text="sk_live_51H8..." />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextBasicDemo.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText text="api-edge" />
+  <ClipboardText text="0c239dd2" />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextLongDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextLongDemo.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText class="max-w-md" text="https://api-edge.example.workers.dev/v1/accounts/9f3a7c1b2d4e6f8a/workers/deployments/latest" />
+  <ClipboardText text="https://example.com/very/long/url/path" />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextShortDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextShortDemo.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText size="sm" text="api-edge" />
+  <ClipboardText text="abc123" />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextTooltipDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ClipboardTextTooltipDemo.svelte
@@ -3,5 +3,8 @@
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <ClipboardText value="wrangler deploy --env production" tooltip={{ text: 'Copy command', copiedText: 'Copied command' }} />
+  <ClipboardText
+    text="npx kumo add button"
+    tooltip={{ text: 'Copy', copiedText: 'Copied!', side: 'top' }}
+  />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CloudflareLogoCopyDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CloudflareLogoCopyDemo.svelte
@@ -1,22 +1,58 @@
 <script lang="ts">
   import { CloudflareLogo, DropdownMenu } from '$lib';
-  import { ArrowSquareOut as ExternalLink, Cloud, Code as Code2, Copy, Download } from 'phosphor-svelte';
+  import { ArrowSquareOut, Cloud, Code, DownloadSimple } from 'phosphor-svelte';
   import { generateCloudflareLogoSvg } from '$lib/components/cloudflare-logo';
-  import { PoweredByCloudflare } from '$lib/components/cloudflare-logo';
 
-  let copiedCloudflareLogo = $state<string | undefined>();
+  let copied = $state<string | null>(null);
 
-  async function copyCloudflareLogo(variant: 'glyph' | 'full') {
-      await navigator.clipboard.writeText(generateCloudflareLogoSvg({ variant }));
-      copiedCloudflareLogo = variant;
-      setTimeout(() => {
-        copiedCloudflareLogo = undefined;
-      }, 2000);
-    }
+  async function copyToClipboard(text: string, label: string) {
+    await navigator.clipboard.writeText(text);
+    copied = label;
+    setTimeout(() => {
+      copied = null;
+    }, 2000);
+  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
+<div class="flex items-center gap-4">
+  <DropdownMenu>
+    <DropdownMenu.Trigger>
+      <button
+        type="button"
+        class="flex items-center gap-2 rounded-lg bg-black px-4 py-3 text-white transition-opacity hover:opacity-80"
+      >
+        <CloudflareLogo variant="glyph" color="white" class="w-8" />
+        <span class="font-medium">Logo</span>
+      </button>
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content>
+      <DropdownMenu.Item
+        icon={Cloud}
+        onSelect={() => copyToClipboard(generateCloudflareLogoSvg({ variant: 'glyph' }), 'glyph')}
+      >
+        {copied === 'glyph' ? 'Copied!' : 'Copy logo as SVG'}
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        icon={Code}
+        onSelect={() => copyToClipboard(generateCloudflareLogoSvg({ variant: 'full' }), 'full')}
+      >
+        {copied === 'full' ? 'Copied!' : 'Copy full logo as SVG'}
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        icon={DownloadSimple}
+        onSelect={() => window.open('https://www.cloudflare.com/press-kit/', '_blank', 'noopener')}
+      >
+        Download brand assets
+      </DropdownMenu.Item>
+      <DropdownMenu.Separator />
+      <DropdownMenu.Item
+        icon={ArrowSquareOut}
+        onSelect={() => window.open('https://www.cloudflare.com/brand-assets/', '_blank', 'noopener')}
+      >
+        Visit brand guidelines
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu>
 
-      <PoweredByCloudflare />
-    
+  <span class="text-sm text-kumo-subtle">Click to open the brand assets menu</span>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedAliasesDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedAliasesDemo.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<CodeHighlighted
+  code={`type Route = {
+  pattern: string;
+  script: string;
+};`}
+  lang="ts"
+  showCopyButton
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedAliasesDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedAliasesDemo.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import { CodeHighlighted } from 'kumo-svelte';
+
+  const svelteCode = `<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+
+  const code = \`const x = 1;\`;
+<` + `/script>
+
+<CodeHighlighted {code} lang="ts" />`;
 </script>
 
 <CodeHighlighted
-  code={`type Route = {
-  pattern: string;
-  script: string;
-};`}
-  lang="ts"
+  code={svelteCode}
+  lang="svelte"
   showCopyButton
 />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedBasicDemo.svelte
@@ -3,9 +3,7 @@
 </script>
 
 <CodeHighlighted
-  code={`interface WorkerRoute {
-  pattern: string;
-  script: string;
-}`}
+  code={`const greeting = "Hello, World!";
+console.log(greeting);`}
   lang="typescript"
 />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedCustomHighlightColorDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedCustomHighlightColorDemo.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<CodeHighlighted
+  code={`function greet(name: string) {
+  // This line is highlighted
+  console.log(\`Hello, \${name}!\`);
+
+  return name.toUpperCase();
+}`}
+  lang="typescript"
+  highlightLines={[2, 3]}
+  style="--kumo-code-highlight-bg: hsla(220, 80%, 50%, 0.1)"
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedFullFeaturedDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedFullFeaturedDemo.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+
+  const svelteCode = `<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+
+  interface Props {
+    code: string;
+    language?: 'svelte' | 'typescript' | 'bash' | 'json';
+  }
+
+  let { code, language = 'typescript' }: Props = $props();
+<` + `/script>
+
+<CodeHighlighted
+  {code}
+  lang={language}
+  showCopyButton
+  showLineNumbers
+  highlightLines={[10, 11, 12, 13, 14]}
+/>`;
+</script>
+
+<CodeHighlighted
+  code={svelteCode}
+  lang="svelte"
+  showCopyButton
+  showLineNumbers
+  highlightLines={[10, 11, 12, 13, 14]}
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedHighlightLinesDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedHighlightLinesDemo.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<CodeHighlighted
+  code={`function processData(items: string[]) {
+  // Filter out empty items
+  const filtered = items.filter(Boolean);
+
+  // Transform to uppercase (highlighted)
+  const transformed = filtered.map((item) => item.toUpperCase());
+
+  // Return sorted result
+  return transformed.toSorted();
+}`}
+  lang="typescript"
+  highlightLines={[5, 6]}
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLabelsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLabelsDemo.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<CodeHighlighted
+  code={`pnpm add kumo-svelte`}
+  lang="bash"
+  showCopyButton
+  labels={{ copy: 'Copy command', copied: 'Copied command' }}
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLanguageVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLanguageVariantsDemo.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<div class="grid gap-4 md:grid-cols-2">
+  <CodeHighlighted
+    code={`diff --git a/worker.ts b/worker.ts
++export default {
++  fetch(request) {
++    return new Response('Ready');
++  }
++}`}
+    lang="diff"
+  />
+  <CodeHighlighted
+    code={`query WorkerDeployments($accountTag: string!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      workersScripts {
+        scriptName
+      }
+    }
+  }
+}`}
+    lang="graphql"
+  />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLanguageVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLanguageVariantsDemo.svelte
@@ -1,27 +1,65 @@
 <script lang="ts">
   import { CodeHighlighted } from 'kumo-svelte';
+
+  const svelteCode = `<script lang="ts">
+  let count = $state(0);
+<` + `/script>
+
+<button onclick={() => count += 1}>
+  Count: {count}
+</button>`;
 </script>
 
 <div class="grid gap-4 md:grid-cols-2">
   <CodeHighlighted
-    code={`diff --git a/worker.ts b/worker.ts
-+export default {
-+  fetch(request) {
-+    return new Response('Ready');
-+  }
-+}`}
-    lang="diff"
+    code={`interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+async function fetchUser(id: string): Promise<User> {
+  const response = await fetch(\`/api/users/\${id}\`);
+  return response.json();
+}`}
+    lang="typescript"
   />
   <CodeHighlighted
-    code={`query WorkerDeployments($accountTag: string!) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      workersScripts {
-        scriptName
-      }
-    }
+    code={svelteCode}
+    lang="svelte"
+  />
+  <CodeHighlighted
+    code={`# Install Kumo Svelte
+npm install kumo-svelte
+
+# Or with pnpm
+pnpm add kumo-svelte
+
+# Start development server
+pnpm dev`}
+    lang="bash"
+  />
+  <CodeHighlighted
+    code={`{
+  "name": "kumo-svelte",
+  "version": "1.0.0",
+  "dependencies": {
+    "shiki": "^3.0.0",
+    "svelte": "^5.0.0"
   }
 }`}
-    lang="graphql"
+    lang="json"
+  />
+  <CodeHighlighted
+    code={`.button {
+  background: var(--color-brand);
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+
+  &:hover {
+    background: var(--color-brand-hover);
+  }
+}`}
+    lang="css"
   />
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLineNumbersDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedLineNumbersDemo.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+
+  const svelteCode = `<script lang="ts">
+  let size = $state({ width: 0, height: 0 });
+
+  function handleResize() {
+    size = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    };
+  }
+
+  $effect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+<` + `/script>`;
+</script>
+
+<CodeHighlighted code={svelteCode} lang="svelte" showLineNumbers />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedSharedBlocksDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CodeHighlightedSharedBlocksDemo.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { CodeHighlighted } from 'kumo-svelte';
+</script>
+
+<div class="space-y-4">
+  <CodeHighlighted code={`const config = { theme: "dark" };`} lang="typescript" />
+  <CodeHighlighted code={`npm run build`} lang="bash" />
+  <CodeHighlighted code={`{ "success": true }`} lang="json" />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleAccordionDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleAccordionDemo.svelte
@@ -1,10 +1,34 @@
 <script lang="ts">
-  import { Collapsible } from '$lib';
+  import { Collapsible, Text } from '$lib';
+
+  let activeIndex = $state<number | null>(0);
+
+  const items = [
+    {
+      title: 'What is Kumo?',
+      content: "Kumo is Cloudflare's new design system built on Base UI and Tailwind CSS v4."
+    },
+    {
+      title: 'How do I install it?',
+      content: 'Run `npm install @cloudflare/kumo` and import the components you need.'
+    },
+    {
+      title: 'Is it accessible?',
+      content: 'Yes! Kumo is built on Base UI which provides excellent accessibility out of the box.'
+    }
+  ];
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Collapsible open={false}>
-      {#snippet trigger()}Build details{/snippet}
-      <p class="text-sm text-kumo-subtle">Dependencies installed, routes generated, and static assets uploaded.</p>
-    </Collapsible>
+<div class="w-full space-y-2">
+  {#each items as item, i}
+    <Collapsible.Root
+      open={activeIndex === i}
+      onOpenChange={(open) => (activeIndex = open ? i : null)}
+    >
+      <Collapsible.DefaultTrigger>{item.title}</Collapsible.DefaultTrigger>
+      <Collapsible.DefaultPanel>
+        <Text>{item.content}</Text>
+      </Collapsible.DefaultPanel>
+    </Collapsible.Root>
+  {/each}
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleBasicDemo.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
-  import { Collapsible } from '$lib';
+  import { Collapsible, Text } from '$lib';
+
+  let isOpen = $state(false);
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Collapsible open={true}>
-      {#snippet trigger()}Build details{/snippet}
-      <p class="text-sm text-kumo-subtle">Dependencies installed, routes generated, and static assets uploaded.</p>
-    </Collapsible>
+<div class="w-full">
+  <Collapsible.Root bind:open={isOpen}>
+    <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+    <Collapsible.DefaultPanel>
+      <Text>Kumo is Cloudflare's new design system.</Text>
+    </Collapsible.DefaultPanel>
+  </Collapsible.Root>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleCustomTriggerDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleCustomTriggerDemo.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
-  import { Collapsible } from '$lib';
+  import { Collapsible, Text } from '$lib';
+
+  let isOpen = $state(false);
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Collapsible open={false}>
-      {#snippet trigger()}Build details{/snippet}
-      <p class="text-sm text-kumo-subtle">Dependencies installed, routes generated, and static assets uploaded.</p>
-    </Collapsible>
+<div class="w-full">
+  <Collapsible.Root bind:open={isOpen}>
+    <Collapsible.Trigger
+      class="group flex h-6.5 w-max shrink-0 items-center gap-1 rounded-md border-0 bg-kumo-base px-2 text-xs font-medium !text-kumo-default shadow-xs ring ring-kumo-hairline select-none not-disabled:hover:bg-kumo-tint focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand disabled:cursor-not-allowed disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 data-[state=open]:bg-kumo-base"
+    >
+      {isOpen ? 'Hide details' : 'Show details'}
+    </Collapsible.Trigger>
+    <Collapsible.Panel class="mt-3 rounded-lg bg-kumo-tint p-4">
+      <Text>
+        This panel uses custom styling instead of the default border-left accent.
+      </Text>
+    </Collapsible.Panel>
+  </Collapsible.Root>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleHeroDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleHeroDemo.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
-  import { Collapsible } from '$lib';
+  import { Collapsible, Text } from '$lib';
+
+  let isOpen = $state(true);
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Collapsible open={true}>
-      {#snippet trigger()}Build details{/snippet}
-      <p class="text-sm text-kumo-subtle">Dependencies installed, routes generated, and static assets uploaded.</p>
-    </Collapsible>
+<div class="w-full">
+  <Collapsible.Root bind:open={isOpen}>
+    <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+    <Collapsible.DefaultPanel>
+      <Text>Kumo is Cloudflare's new design system.</Text>
+    </Collapsible.DefaultPanel>
+  </Collapsible.Root>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleMultipleDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CollapsibleMultipleDemo.svelte
@@ -1,10 +1,30 @@
 <script lang="ts">
-  import { Collapsible } from '$lib';
+  import { Collapsible, Text } from '$lib';
+
+  let open1 = $state(false);
+  let open2 = $state(false);
+  let open3 = $state(false);
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Collapsible open={false}>
-      {#snippet trigger()}Build details{/snippet}
-      <p class="text-sm text-kumo-subtle">Dependencies installed, routes generated, and static assets uploaded.</p>
-    </Collapsible>
+<div class="w-full space-y-2">
+  <Collapsible.Root bind:open={open1}>
+    <Collapsible.DefaultTrigger>What is Kumo?</Collapsible.DefaultTrigger>
+    <Collapsible.DefaultPanel>
+      <Text>Kumo is Cloudflare's new design system.</Text>
+    </Collapsible.DefaultPanel>
+  </Collapsible.Root>
+
+  <Collapsible.Root bind:open={open2}>
+    <Collapsible.DefaultTrigger>How do I use it?</Collapsible.DefaultTrigger>
+    <Collapsible.DefaultPanel>
+      <Text>Install the components and import them into your project.</Text>
+    </Collapsible.DefaultPanel>
+  </Collapsible.Root>
+
+  <Collapsible.Root bind:open={open3}>
+    <Collapsible.DefaultTrigger>Is it open source?</Collapsible.DefaultTrigger>
+    <Collapsible.DefaultPanel>
+      <Text>Check the repository for license information.</Text>
+    </Collapsible.DefaultPanel>
+  </Collapsible.Root>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/GridAsymmetricDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/GridAsymmetricDemo.svelte
@@ -2,17 +2,48 @@
   import { Grid, Surface, Text } from 'kumo-svelte';
 </script>
 
-<Grid variant="2-1" gap="sm">
-  <Grid.Item>
-    <Surface class="rounded-lg p-4">
-      <Text bold>Main Content</Text>
-      <div class="mt-1"><Text variant="secondary">Two-thirds width</Text></div>
-    </Surface>
-  </Grid.Item>
-  <Grid.Item>
-    <Surface class="rounded-lg p-4">
-      <Text bold>Sidebar</Text>
-      <div class="mt-1"><Text variant="secondary">One-third width</Text></div>
-    </Surface>
-  </Grid.Item>
-</Grid>
+<div class="flex flex-col gap-8">
+  <div>
+    <p class="mb-2 text-kumo-subtle">variant="2-1" (66% / 33%)</p>
+    <Grid variant="2-1" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4">
+          <Text bold>Main Content</Text>
+          <div class="mt-1">
+            <Text variant="secondary">Two-thirds width</Text>
+          </div>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4">
+          <Text bold>Sidebar</Text>
+          <div class="mt-1">
+            <Text variant="secondary">One-third width</Text>
+          </div>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">variant="1-2" (33% / 66%)</p>
+    <Grid variant="1-2" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4">
+          <Text bold>Sidebar</Text>
+          <div class="mt-1">
+            <Text variant="secondary">One-third width</Text>
+          </div>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4">
+          <Text bold>Main Content</Text>
+          <div class="mt-1">
+            <Text variant="secondary">Two-thirds width</Text>
+          </div>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/GridGapDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/GridGapDemo.svelte
@@ -2,7 +2,68 @@
   import { Grid, Surface, Text } from 'kumo-svelte';
 </script>
 
-<Grid variant="side-by-side" gap="base">
-  <Grid.Item><Surface class="rounded-lg p-4 text-center"><Text>1</Text></Surface></Grid.Item>
-  <Grid.Item><Surface class="rounded-lg p-4 text-center"><Text>2</Text></Surface></Grid.Item>
-</Grid>
+<div class="flex flex-col gap-8">
+  <div>
+    <p class="mb-2 text-kumo-subtle">gap="none"</p>
+    <Grid variant="side-by-side" gap="none">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">gap="sm"</p>
+    <Grid variant="side-by-side" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">gap="base" (default, responsive)</p>
+    <Grid variant="side-by-side" gap="base">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">gap="lg"</p>
+    <Grid variant="side-by-side" gap="lg">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/GridVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/GridVariantsDemo.svelte
@@ -2,8 +2,67 @@
   import { Grid, Surface, Text } from 'kumo-svelte';
 </script>
 
-<Grid variant="3up" gap="sm">
-  <Grid.Item><Surface class="rounded-lg p-4 text-center"><Text>1</Text></Surface></Grid.Item>
-  <Grid.Item><Surface class="rounded-lg p-4 text-center"><Text>2</Text></Surface></Grid.Item>
-  <Grid.Item><Surface class="rounded-lg p-4 text-center"><Text>3</Text></Surface></Grid.Item>
-</Grid>
+<div class="flex flex-col gap-8">
+  <div>
+    <p class="mb-2 text-kumo-subtle">variant="2up"</p>
+    <Grid variant="2up" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">variant="3up"</p>
+    <Grid variant="3up" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>3</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+
+  <div>
+    <p class="mb-2 text-kumo-subtle">variant="4up"</p>
+    <Grid variant="4up" gap="sm">
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>1</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>2</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>3</Text>
+        </Surface>
+      </Grid.Item>
+      <Grid.Item>
+        <Surface class="rounded-lg p-4 text-center">
+          <Text>4</Text>
+        </Surface>
+      </Grid.Item>
+    </Grid>
+  </div>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupDemo.svelte
@@ -30,7 +30,7 @@
         {#if status === 'loading'}
           <Loader />
         {:else}
-          <CheckCircle class="text-kumo-success" />
+          <CheckCircle weight="duotone" class="text-kumo-success" />
         {/if}
       </InputGroup.Addon>
     {/if}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupIconsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupIconsDemo.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { LinkSimple } from 'phosphor-svelte';
+  import { LinkIcon } from 'phosphor-svelte';
   import { InputGroup } from 'kumo-svelte';
 </script>
 
 <InputGroup class="w-full max-w-3xs">
   <InputGroup.Addon>
-    <LinkSimple />
+    <LinkIcon />
   </InputGroup.Addon>
   <InputGroup.Input placeholder="Paste a link..." aria-label="Link" />
 </InputGroup>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupSuffixDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/InputGroupSuffixDemo.svelte
@@ -8,7 +8,7 @@
     <InputGroup.Input aria-label="Subdomain" value="kumo" maxlength={20} />
     <InputGroup.Suffix>.workers.dev</InputGroup.Suffix>
     <InputGroup.Addon align="end">
-      <CheckCircle class="text-kumo-success" />
+      <CheckCircle weight="duotone" class="text-kumo-success" />
     </InputGroup.Addon>
   </InputGroup>
 
@@ -19,7 +19,7 @@
     <InputGroup.Input aria-label="Subdomain" value="kumo" maxlength={20} />
     <InputGroup.Suffix>.workers.dev</InputGroup.Suffix>
     <InputGroup.Addon align="end">
-      <XCircle class="text-kumo-danger" />
+      <XCircle weight="duotone" class="text-kumo-danger" />
     </InputGroup.Addon>
   </InputGroup>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LayerCardFilterSubrequestsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LayerCardFilterSubrequestsDemo.svelte
@@ -1,10 +1,88 @@
 <script lang="ts">
-  import { Button, LayerCard } from '$lib';
-  import { ArrowRight } from 'phosphor-svelte';
+  import { Badge, Input, LayerCard, Tabs } from 'kumo-svelte';
+
+  const ORIGINS = [
+    { origin: 'challenges.cloudflare.com', s2xx: 1, s4xx: 0, duration: '95.4ms' },
+    { origin: 'Unknown', s2xx: 19, s4xx: 7, duration: '463.7ms' },
+    { origin: 'api.example.com', s2xx: 42, s4xx: 3, duration: '128.1ms' }
+  ];
+
+  type StatusFilter = 'all' | '2xx' | '3xx' | '4xx' | '5xx';
+
+  let filter: StatusFilter = $state('all');
+  let search = $state('');
+
+  const tabs = [
+    { value: 'all', label: 'All' },
+    { value: '2xx', label: '2xx' },
+    { value: '3xx', label: '3xx' },
+    { value: '4xx', label: '4xx' },
+    { value: '5xx', label: '5xx' }
+  ];
+
+  const filtered = $derived(
+    ORIGINS.filter((origin) => {
+      if (filter === '2xx' && origin.s2xx === 0) return false;
+      if (filter === '4xx' && origin.s4xx === 0) return false;
+      if (search && !origin.origin.toLowerCase().includes(search.toLowerCase())) return false;
+      return true;
+    })
+  );
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
+<LayerCard class="w-full max-w-[540px]">
+  <LayerCard.Secondary>Subrequests</LayerCard.Secondary>
 
-      <LayerCard><LayerCard.Secondary class="flex items-center justify-between"><div>Next Steps</div><Button variant="ghost" size="sm" shape="square" aria-label="Go to next steps"><ArrowRight class="size-4" /></Button></LayerCard.Secondary><LayerCard.Primary>Get started with Kumo</LayerCard.Primary></LayerCard>
-    
-</div>
+  <LayerCard.Primary>
+    <div class="mb-2 flex items-center gap-3">
+      <Input
+        size="sm"
+        placeholder="Filter origins..."
+        aria-label="Filter origins"
+        bind:value={search}
+        class="min-w-0 flex-1"
+      />
+      <Tabs
+        variant="segmented"
+        size="sm"
+        class="shrink-0"
+        {tabs}
+        bind:value={filter}
+      />
+    </div>
+
+    <div class="-mx-1 text-sm">
+      <div
+        class="grid grid-cols-[1fr_auto_auto] gap-x-4 border-b border-kumo-fill px-1 pb-2 text-xs font-medium text-kumo-subtle"
+      >
+        <span>Origin</span>
+        <span class="w-28 text-right">Requests</span>
+        <span class="w-20 text-right">Duration</span>
+      </div>
+
+      {#each filtered as row, i (row.origin)}
+        <div
+          class={[
+            'grid grid-cols-[1fr_auto_auto] items-center gap-x-4 px-1 py-2.5',
+            i < filtered.length - 1 && 'border-b border-kumo-hairline'
+          ]}
+        >
+          <span class="truncate font-medium text-kumo-default">{row.origin}</span>
+          <div class="flex w-28 items-center justify-end gap-1.5">
+            {#if row.s2xx > 0}
+              <Badge variant="success">2xx {row.s2xx}</Badge>
+            {/if}
+            {#if row.s4xx > 0}
+              <Badge variant="error">4xx {row.s4xx}</Badge>
+            {/if}
+          </div>
+          <span class="w-20 text-right text-kumo-subtle">{row.duration}</span>
+        </div>
+      {/each}
+    </div>
+
+    <div class="-mx-1 border-t border-kumo-fill pt-2 text-xs text-kumo-subtle">
+      Showing {filtered.length} of {ORIGINS.length}
+    </div>
+  </LayerCard.Primary>
+</LayerCard>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkBasicDemo.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { Link, Text } from '$lib';
+  import { Link } from 'kumo-svelte';
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Text>Read the <Link href="/installation">installation guide</Link> before deploying.</Text>
+<div class="grid gap-x-6 gap-y-4 text-base md:grid-cols-3">
+  <Link href="#">Default inline link</Link>
+  <Link href="#" variant="current">Current color link</Link>
+  <Link href="#" variant="plain">Plain inline link</Link>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkCurrentVariantDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkCurrentVariantDemo.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Link, Text } from '$lib';
+  import { Link } from 'kumo-svelte';
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Text>Read the <Link href="/installation">installation guide</Link> before deploying.</Text>
-</div>
+<p class="text-base text-kumo-danger">
+  This error message contains a <Link href="#" variant="current">link</Link> that inherits the red color
+  from its parent.
+</p>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkExternalDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkExternalDemo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Link, Text } from '$lib';
+  import { Link, LinkExternalIcon } from 'kumo-svelte';
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Text>Read the <Link href="/installation">installation guide</Link> before deploying.</Text>
-</div>
+<Link href="https://cloudflare.com" target="_blank" rel="noopener noreferrer" class="text-base">
+  Visit Cloudflare <LinkExternalIcon />
+</Link>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkInParagraphDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkInParagraphDemo.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Link, Text } from '$lib';
+  import { Link } from 'kumo-svelte';
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<Text>Read the <Link href="/installation">installation guide</Link> before deploying.</Text>
-</div>
+<p class="mx-auto max-w-md text-base leading-relaxed text-kumo-default">
+  This is a paragraph with an <Link href="#">inline link</Link> that flows naturally with the surrounding
+  text. Links maintain proper underline offset for readability.
+</p>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkPlainVariantDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkPlainVariantDemo.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { Link, Text } from '$lib';
+</script>
+
+<nav class="flex gap-4 text-sm" aria-label="Product links">
+  <Link href="/components/button" variant="plain">Buttons</Link>
+  <Link href="/components/select" variant="plain">Select</Link>
+  <Text class="text-kumo-subtle">
+    <Link href="/components/link" variant="current">Current page</Link>
+  </Text>
+</nav>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkPlainVariantDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LinkPlainVariantDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Link, Text } from '$lib';
+  import { Link, Text } from 'kumo-svelte';
 </script>
 
 <nav class="flex gap-4 text-sm" aria-label="Product links">

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationBasicDemo.svelte
@@ -2,19 +2,10 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCompoundCustomInfoDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCompoundCustomInfoDemo.svelte
@@ -2,19 +2,17 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={25} totalCount={100}>
+  <Pagination.Info>
+    {#snippet children({ page, totalCount })}
+      Page {page} of {Math.ceil((totalCount ?? 1) / 25)}
+    {/snippet}
+  </Pagination.Info>
+  <Pagination.Controls />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCustomPageSizeOptionsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCustomPageSizeOptionsDemo.svelte
@@ -13,8 +13,16 @@
   }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={paginationPerPage} totalCount={200}>
+  <Pagination.Info />
+  <Pagination.Separator />
+  <Pagination.PageSize
+    value={paginationPerPage}
+    onChange={(size) => {
+      setPaginationPerPage(size);
+      setPaginationPage(1);
+    }}
+    options={[10, 20, 50]}
+  />
+  <Pagination.Controls />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCustomTextDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationCustomTextDemo.svelte
@@ -2,19 +2,16 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination
+  text={({ perPage }) => `Page ${paginationPage} - showing ${perPage} per page`}
+  page={paginationPage}
+  setPage={setPaginationPage}
+  perPage={25}
+  totalCount={100}
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationDropdownSelectorDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationDropdownSelectorDemo.svelte
@@ -2,16 +2,26 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
+  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
+
+  function setPaginationPerPage(nextPerPage: number) {
+    paginationPerPage = nextPerPage;
+  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-  <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100}>
-    <Pagination.Info />
-    <Pagination.Separator />
-    <Pagination.Controls pageSelector="dropdown" />
-  </Pagination>
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={paginationPerPage} totalCount={500}>
+  <Pagination.Info />
+  <Pagination.Separator />
+  <Pagination.PageSize
+    value={paginationPerPage}
+    onChange={(size) => {
+      setPaginationPerPage(size);
+      setPaginationPage(1);
+    }}
+  />
+  <Pagination.Controls pageSelector="dropdown" />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationFullDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationFullDemo.svelte
@@ -2,19 +2,10 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} controls="full" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationI18nDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationI18nDemo.svelte
@@ -2,19 +2,31 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination
+  page={paginationPage}
+  setPage={setPaginationPage}
+  perPage={10}
+  totalCount={100}
+  labels={{
+    firstPage: 'Première page',
+    previousPage: 'Page précédente',
+    nextPage: 'Page suivante',
+    lastPage: 'Dernière page',
+    pageNumber: 'Numéro de page',
+    pageSize: 'Taille de page'
+  }}
+>
+  <Pagination.Info>
+    {#snippet children({ pageShowingRange, totalCount })}
+      Affichage de <span class="tabular-nums">{pageShowingRange}</span> sur
+      <span class="tabular-nums">{totalCount}</span>
+    {/snippet}
+  </Pagination.Info>
+  <Pagination.Controls />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationLargeDatasetDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationLargeDatasetDemo.svelte
@@ -2,19 +2,10 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(1);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={25} totalCount={1250} />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationMidPageDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationMidPageDemo.svelte
@@ -2,19 +2,10 @@
   import { Pagination } from '$lib';
 
   let paginationPage = $state(5);
-  let paginationPerPage = $state(25);
 
   function setPaginationPage(nextPage: number) {
     paginationPage = nextPage;
   }
-
-  function setPaginationPerPage(nextPerPage: number) {
-    paginationPerPage = nextPerPage;
-  }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationPageSizeRightDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationPageSizeRightDemo.svelte
@@ -13,8 +13,17 @@
   }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={paginationPerPage} totalCount={500}>
+  <Pagination.Info />
+  <div class="flex items-center gap-2">
+    <Pagination.Controls />
+    <Pagination.Separator />
+    <Pagination.PageSize
+      value={paginationPerPage}
+      onChange={(size) => {
+        setPaginationPerPage(size);
+        setPaginationPage(1);
+      }}
+    />
+  </div>
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationPageSizeSelectorDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationPageSizeSelectorDemo.svelte
@@ -13,8 +13,15 @@
   }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} />
-    
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={paginationPerPage} totalCount={500}>
+  <Pagination.Info />
+  <Pagination.Separator />
+  <Pagination.PageSize
+    value={paginationPerPage}
+    onChange={(size) => {
+      setPaginationPerPage(size);
+      setPaginationPage(1);
+    }}
+  />
+  <Pagination.Controls />
+</Pagination>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationSimpleDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationSimpleDemo.svelte
@@ -8,6 +8,4 @@
   }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-  <Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} controls="simple" />
-</div>
+<Pagination page={paginationPage} setPage={setPaginationPage} perPage={10} totalCount={100} controls="simple" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PoweredByCloudflareFooterDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PoweredByCloudflareFooterDemo.svelte
@@ -1,22 +1,8 @@
 <script lang="ts">
-  import { CloudflareLogo, DropdownMenu } from '$lib';
-  import { ArrowSquareOut as ExternalLink, Cloud, Code as Code2, Copy, Download } from 'phosphor-svelte';
-  import { generateCloudflareLogoSvg } from '$lib/components/cloudflare-logo';
   import { PoweredByCloudflare } from '$lib/components/cloudflare-logo';
-
-  let copiedCloudflareLogo = $state<string | undefined>();
-
-  async function copyCloudflareLogo(variant: 'glyph' | 'full') {
-      await navigator.clipboard.writeText(generateCloudflareLogoSvg({ variant }));
-      copiedCloudflareLogo = variant;
-      setTimeout(() => {
-        copiedCloudflareLogo = undefined;
-      }, 2000);
-    }
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-
-      <PoweredByCloudflare />
-    
-</div>
+<footer class="flex w-full items-center justify-between rounded-lg border border-kumo-hairline bg-kumo-elevated px-6 py-4">
+  <span class="text-sm text-kumo-subtle">&copy; 2026 Your Company. All rights reserved.</span>
+  <PoweredByCloudflare />
+</footer>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioBasicDemo.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('email');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Notification preference" bind:value>
+  <Radio.Item label="Email" value="email" />
+  <Radio.Item label="SMS" value="sms" />
+  <Radio.Item label="Push notification" value="push" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardControlStartDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardControlStartDemo.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('free');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Plan'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Choose a plan" appearance="card" controlPosition="start" bind:value>
+  <Radio.Item
+    label="Free"
+    description="For personal or hobby projects that aren't business-critical."
+    value="free"
+  />
+  <Radio.Item
+    label="Pro"
+    description="For professional websites that aren't business-critical."
+    value="pro"
+  />
+  <Radio.Item
+    label="Business"
+    description="For small businesses operating online."
+    value="business"
+  />
+  <Radio.Item
+    label="Contract"
+    description="For mission-critical applications that are core to your business."
+    value="contract"
+  />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardDemo.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('free');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Plan'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Choose a plan" appearance="card" bind:value>
+  <Radio.Item
+    label="Free"
+    description="For personal or hobby projects that aren't business-critical."
+    value="free"
+  />
+  <Radio.Item
+    label="Pro"
+    description="For professional websites that aren't business-critical."
+    value="pro"
+  />
+  <Radio.Item
+    label="Business"
+    description="For small businesses operating online."
+    value="business"
+  />
+  <Radio.Item
+    label="Contract"
+    description="For mission-critical applications that are core to your business."
+    value="contract"
+  />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardHorizontalDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioCardHorizontalDemo.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('free');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'flex gap-4'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Plan'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Choose a plan" appearance="card" orientation="horizontal" bind:value>
+  <Radio.Item
+    label="Free"
+    description="For personal or hobby projects that aren't business-critical."
+    value="free"
+  />
+  <Radio.Item
+    label="Pro"
+    description="For professional websites that aren't business-critical."
+    value="pro"
+  />
+  <Radio.Item
+    label="Business"
+    description="For small businesses operating online."
+    value="business"
+  />
+  <Radio.Item
+    label="Contract"
+    description="For mission-critical applications that are core to your business."
+    value="contract"
+  />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioControlPositionDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioControlPositionDemo.svelte
@@ -1,17 +1,8 @@
 <script lang="ts">
   import { Radio } from '$lib';
-
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Preferences" controlPosition="end" defaultValue="a">
+  <Radio.Item label="Label before radio" value="a" />
+  <Radio.Item label="Another option" value="b" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDefaultDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDefaultDemo.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('personal');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Account type" bind:value>
+  <Radio.Item label="Personal" value="personal" />
+  <Radio.Item label="Business" value="business" />
+  <Radio.Item label="Enterprise" value="enterprise" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDescriptionDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDescriptionDemo.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('standard');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group
+  legend="Shipping method"
+  description="Choose how you'd like to receive your order"
+  bind:value
+>
+  <Radio.Item label="Standard (5-7 days)" value="standard" />
+  <Radio.Item label="Express (2-3 days)" value="express" />
+  <Radio.Item label="Overnight" value="overnight" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDisabledDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioDisabledDemo.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
   import { Radio } from '$lib';
-
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'disabled'} />
-      
-    </div>
+<div class="grid grid-cols-2 gap-6">
+  <Radio.Group legend="Disabled group" disabled defaultValue="a">
+    <Radio.Item label="Option A" value="a" />
+    <Radio.Item label="Option B" value="b" />
+  </Radio.Group>
+  <Radio.Group legend="Individual disabled" defaultValue="available">
+    <Radio.Item label="Available" value="available" />
+    <Radio.Item label="Unavailable" value="unavailable" disabled />
+  </Radio.Group>
+  <Radio.Group legend="Disabled card group" appearance="card" disabled defaultValue="a">
+    <Radio.Item label="Option A" description="This option is disabled." value="a" />
+    <Radio.Item label="Option B" description="This option is disabled." value="b" />
+  </Radio.Group>
+  <Radio.Group legend="Individual disabled card" appearance="card" defaultValue="available">
+    <Radio.Item
+      label="Available"
+      description="This option can be selected."
+      value="available"
+    />
+    <Radio.Item
+      label="Unavailable"
+      description="This option is not available."
+      value="unavailable"
+      disabled
+    />
+  </Radio.Group>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioErrorDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioErrorDemo.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
   import { Radio } from '$lib';
-
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'grid gap-3'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      <p class="text-sm text-kumo-danger">Choose an environment to continue.</p>
-    </div>
+<div class="grid grid-cols-2 gap-6">
+  <Radio.Group legend="Payment method" error="Please select a payment method to continue">
+    <Radio.Item label="Credit Card" value="card" variant="error" />
+    <Radio.Item label="PayPal" value="paypal" variant="error" />
+  </Radio.Group>
+  <Radio.Group
+    legend="Payment method"
+    appearance="card"
+    error="Please select a payment method to continue"
+  >
+    <Radio.Item
+      label="Credit Card"
+      description="Pay with Visa, Mastercard, American Express, or Elo."
+      value="card"
+      variant="error"
+    />
+    <Radio.Item
+      label="PayPal"
+      description="Pay with your PayPal account."
+      value="paypal"
+      variant="error"
+    />
+  </Radio.Group>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioHorizontalDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioHorizontalDemo.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
   import { Radio } from '$lib';
 
-  const radioOptions = [
-      { label: 'Production', value: 'production', description: 'Route live traffic.' },
-      { label: 'Preview', value: 'preview', description: 'Test before release.' },
-      { label: 'Disabled', value: 'disabled', disabled: true }
-    ];
+  let value = $state('md');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
-<div class={'flex gap-4'}>
-      {#if !false}<p class={'text-sm font-medium text-kumo-default'}>{'Environment'}</p>{/if}
-      <Radio options={radioOptions} value={'production'} />
-      
-    </div>
-</div>
+<Radio.Group legend="Size" orientation="horizontal" bind:value>
+  <Radio.Item label="Small" value="sm" />
+  <Radio.Item label="Medium" value="md" />
+  <Radio.Item label="Large" value="lg" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioLegendCustomDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioLegendCustomDemo.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
-  import { ChartLegend, ChartPalette } from 'kumo-svelte';
+  import { Radio } from '$lib';
+
+  let value = $state('email');
 </script>
 
-<div class="flex flex-wrap gap-4">
-  <ChartLegend
-    variant="large"
-    name="Requests"
-    color={ChartPalette.semantic('Neutral')}
-    value="1,234"
-    unit="req/s"
-  />
-  <ChartLegend
-    variant="large"
-    name="Storage"
-    color={ChartPalette.semantic('Attention')}
-    value="56"
-    unit="GB"
-  />
-</div>
+<Radio.Group bind:value>
+  <Radio.Legend class="text-sm font-normal text-kumo-subtle">
+    Notification preference
+  </Radio.Legend>
+  <Radio.Item label="Email" value="email" />
+  <Radio.Item label="SMS" value="sms" />
+  <Radio.Item label="Push notification" value="push" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioLegendSrOnlyDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioLegendSrOnlyDemo.svelte
@@ -1,20 +1,11 @@
 <script lang="ts">
-  import { ChartLegend, ChartPalette } from 'kumo-svelte';
+  import { Radio } from '$lib';
+
+  let value = $state('all');
 </script>
 
-<div class="flex flex-wrap gap-4">
-  <ChartLegend
-    variant="large"
-    name="Requests"
-    color={ChartPalette.semantic('Neutral')}
-    value="1,234"
-    unit="req/s"
-  />
-  <ChartLegend
-    variant="large"
-    name="Storage"
-    color={ChartPalette.semantic('Attention')}
-    value="56"
-    unit="GB"
-  />
-</div>
+<Radio.Group defaultValue="all" bind:value>
+  <Radio.Legend class="sr-only">Paths</Radio.Legend>
+  <Radio.Item label="Allow all paths" value="all" />
+  <Radio.Item label="Restrict to specific paths" value="specific" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioRichLabelDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioRichLabelDemo.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
-  import { Checkbox, Input, Label, Select, Tooltip } from '$lib';
+  import { Badge, Radio } from '$lib';
+
+  let value = $state('pro');
 </script>
 
-<div class="flex min-h-24 w-full items-center justify-center">
+{#snippet freeLabel()}
+  <span class="flex items-center gap-2">
+    Free
+    <Badge variant="neutral">$0</Badge>
+  </span>
+{/snippet}
 
-      <div class="w-full max-w-sm space-y-2">
-        <Label for="label-demo">API token</Label>
-        <Input id="label-demo" placeholder="Enter token" />
-      </div>
-    
-</div>
+{#snippet proLabel()}
+  <span class="flex items-center gap-2">
+    Pro
+    <Badge variant="primary">Popular</Badge>
+  </span>
+{/snippet}
+
+<Radio.Group legend="Choose a plan" appearance="card" bind:value>
+  <Radio.Item label={freeLabel} description="For personal or hobby projects." value="free" />
+  <Radio.Item label={proLabel} description="For professional websites." value="pro" />
+</Radio.Group>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarDemoShell.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarDemoShell.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { DropdownMenu, Sidebar } from 'kumo-svelte';
   import {
+    ArrowLeft,
+    ArrowsLeftRight,
     Bell,
-    CaretRight,
     CaretUpDown,
     ChartBar,
     Check,
-    Cloud,
     Code,
+    Cube,
     Database,
     Flask,
     Gear,
@@ -14,206 +17,335 @@
     House,
     Lock,
     MagnifyingGlass,
-    Rocket,
     ShieldCheck,
-    SidebarSimple
+    Stack,
+    User
   } from 'phosphor-svelte';
-  import { cn } from '$lib/utils/cn';
-  import DemoBadge from './sidebar-demo-parts/DemoBadge.svelte';
-  import DemoMenuButton from './sidebar-demo-parts/DemoMenuButton.svelte';
-  import DemoMenuSub from './sidebar-demo-parts/DemoMenuSub.svelte';
-  import DemoMenuSubButton from './sidebar-demo-parts/DemoMenuSubButton.svelte';
-  import DemoSidebarGroup from './sidebar-demo-parts/DemoSidebarGroup.svelte';
 
-  type Demo = 'basic' | 'collapsible' | 'toggle' | 'full' | 'resizable' | 'right';
+  type Demo = 'basic' | 'collapsible' | 'toggle' | 'full' | 'resizable' | 'right' | 'peeking' | 'sliding';
 
   interface Props {
     demo?: Demo;
   }
 
   let { demo = 'basic' }: Props = $props();
-  let collapsed = $state(false);
-  let overviewOpen = $state(true);
-  let buildOpen = $state(true);
-  let protectOpen = $state(true);
-  let width = $state(240);
-  let accountMenuOpen = $state(false);
-  let activeAccount = $state({ id: '1', name: 'Acme Inc', icon: Cloud });
+  let open = $state(true);
+  let surface = $state<'account' | 'zone' | 'domain'>('account');
+  let selectedAccount = $state({ id: '1', name: 'Company', icon: Cube });
 
   const accounts = [
-    { id: '1', name: 'Acme Inc', icon: Cloud },
-    { id: '2', name: 'Personal', icon: Rocket },
+    { id: '1', name: 'Company', icon: Cube },
+    { id: '2', name: 'Personal', icon: Stack },
     { id: '3', name: 'Staging', icon: Flask }
   ];
 
-  const sidebarStyle = $derived(demo === 'resizable' && !collapsed ? `width: ${width}px` : undefined);
-  const isCollapsed = $derived(collapsed && demo !== 'right');
-  const ActiveAccountIcon = $derived(activeAccount.icon);
+  const providerProps = $derived({
+    contained: true,
+    defaultOpen: true,
+    side: demo === 'right' ? 'right' as const : 'left' as const,
+    resizable: demo === 'resizable',
+    defaultWidth: 240,
+    minWidth: 180,
+    maxWidth: 400,
+    peekable: demo === 'full' || demo === 'peeking'
+  });
 
-  const toggle = () => {
-    collapsed = !collapsed;
-  };
-
-  const resize = () => {
-    width = width === 240 ? 320 : 240;
-  };
+  const ActiveAccountIcon = $derived(selectedAccount.icon);
 </script>
 
-<div class="relative h-[540px] w-full overflow-hidden rounded-lg border border-kumo-hairline bg-kumo-base">
-  <div class={cn('flex h-full w-full', demo === 'right' && 'flex-row-reverse')} data-state={isCollapsed ? 'collapsed' : 'expanded'}>
-    <aside
-      class={cn(
-        'group/sidebar relative flex h-full shrink-0 grow-0 flex-col overflow-hidden whitespace-nowrap bg-kumo-base text-kumo-default transition-[width] duration-250 ease-[cubic-bezier(0.77,0,0.175,1)]',
-        demo === 'right' ? 'border-l border-kumo-hairline' : 'border-r border-kumo-hairline',
-        isCollapsed ? 'w-12' : 'w-64'
-      )}
-      style={sidebarStyle}
-      data-state={isCollapsed ? 'collapsed' : 'expanded'}
-    >
-      {#if demo === 'toggle' || demo === 'resizable'}
-        <div class="flex items-center gap-2 overflow-hidden border-b border-kumo-hairline px-2 py-3 group-data-[state=collapsed]/sidebar:border-b-0">
-          <div class="flex w-full min-w-0 items-center gap-2 px-3 transition-[padding] duration-250 ease-[cubic-bezier(0.77,0,0.175,1)] group-data-[state=collapsed]/sidebar:px-2">
-            <div class="size-4 shrink-0 rounded bg-kumo-brand"></div>
-            <span class="truncate text-sm font-semibold text-kumo-strong group-data-[state=collapsed]/sidebar:hidden">Acme Inc</span>
-          </div>
-        </div>
-      {:else if demo === 'full'}
-        <div class="relative flex items-center gap-2 overflow-visible border-b border-kumo-hairline px-2 py-3">
-          <button
-            class="flex w-full min-w-0 items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-kumo-default outline-none transition-[color,background-color,padding] duration-250 ease-[cubic-bezier(0.77,0,0.175,1)] hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-hairline"
-            aria-haspopup="menu"
-            aria-expanded={accountMenuOpen}
-            onclick={() => (accountMenuOpen = !accountMenuOpen)}
-          >
-            <ActiveAccountIcon class="size-4 shrink-0 text-kumo-brand" weight="fill" />
-            <span class="flex-1 truncate text-left font-semibold text-kumo-strong">{activeAccount.name}</span>
-            <CaretUpDown class="size-4 shrink-0 text-kumo-subtle" />
-          </button>
-          {#if accountMenuOpen}
-            <div class="absolute left-2 right-2 top-[calc(100%-0.5rem)] z-20 rounded-lg border border-kumo-hairline bg-kumo-base p-1 text-sm text-kumo-default shadow-lg">
-              {#each accounts as account (account.id)}
-                {@const AccountIcon = account.icon}
-                <button
-                  class="flex min-h-[34px] w-full items-center gap-2 rounded-md px-2 py-1 text-left hover:bg-kumo-tint"
-                  role="menuitem"
-                  onclick={() => {
-                    activeAccount = account;
-                    accountMenuOpen = false;
-                  }}
-                >
-                  <AccountIcon class="size-4 text-kumo-brand" weight="fill" />
-                  <span>{account.name}</span>
-                  {#if account.id === activeAccount.id}
-                    <Check class="ml-auto size-4" />
-                  {/if}
-                </button>
-              {/each}
-            </div>
-          {/if}
-        </div>
-      {/if}
+{#snippet demoMain(children?: Snippet)}
+  <main class="flex flex-1 flex-col items-center justify-center gap-2 p-8 text-base text-kumo-subtle">
+    {#if children}
+      {@render children()}
+    {:else}
+      Main content area
+    {/if}
+  </main>
+{/snippet}
 
-      <div class="flex min-w-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden px-2 py-2 group-data-[state=collapsed]/sidebar:gap-0 group-data-[state=collapsed]/sidebar:py-0">
-        {#if demo === 'full'}
-          <div class="px-1 pb-2">
-            <button class="flex w-full items-center gap-2 rounded-lg bg-kumo-base px-3 py-2 text-sm text-kumo-subtle ring ring-kumo-hairline hover:bg-kumo-overlay">
-              <MagnifyingGlass class="size-4 shrink-0" />
-              <span class="flex-1 truncate text-left">Quick search...</span>
-              <kbd class="ml-auto font-sans text-xs">⌘K</kbd>
-            </button>
-          </div>
-        {/if}
-
-        {#if demo === 'right'}
-          <DemoSidebarGroup label="Details" open={overviewOpen}>
-            <DemoMenuButton icon={Gear} active>Properties</DemoMenuButton>
-            <DemoMenuButton icon={ChartBar}>Metrics</DemoMenuButton>
-            <DemoMenuButton icon={Bell}>Alerts</DemoMenuButton>
-          </DemoSidebarGroup>
-        {:else if demo === 'toggle'}
-          <DemoSidebarGroup label="" open>
-            <DemoMenuButton icon={House} tooltip="Home" collapsed={isCollapsed} active>Home</DemoMenuButton>
-            <DemoMenuButton icon={ChartBar} tooltip="Analytics" collapsed={isCollapsed}>Analytics</DemoMenuButton>
-            <DemoMenuButton icon={Code} tooltip="Compute" collapsed={isCollapsed}>Compute</DemoMenuButton>
-            <DemoMenuButton icon={Database} tooltip="Storage" collapsed={isCollapsed}>Storage</DemoMenuButton>
-          </DemoSidebarGroup>
-        {:else if demo === 'resizable'}
-          <DemoSidebarGroup label="Overview" open>
-            <DemoMenuButton icon={House} active>Home</DemoMenuButton>
-            <DemoMenuButton icon={ChartBar}>Analytics</DemoMenuButton>
-            <DemoMenuButton icon={Database}>Storage</DemoMenuButton>
-          </DemoSidebarGroup>
-        {:else}
-          <DemoSidebarGroup label="Overview" collapsible={demo === 'collapsible'} open={overviewOpen} onToggle={() => (overviewOpen = !overviewOpen)}>
-            <DemoMenuButton icon={House} active tooltip="Home" collapsed={isCollapsed}>Home</DemoMenuButton>
-            <DemoMenuButton icon={ChartBar} tooltip="Analytics" collapsed={isCollapsed}>Analytics{demo === 'full' ? ' & Logs' : ''}</DemoMenuButton>
-            <DemoMenuButton icon={Globe} tooltip="Domains" collapsed={isCollapsed}>Domains</DemoMenuButton>
-          </DemoSidebarGroup>
-
-          {#if demo === 'full'}
-            <hr class="mx-2 h-px min-h-px border-0 bg-kumo-hairline" />
-          {/if}
-
-          {#if demo === 'basic'}
-            <DemoSidebarGroup label="Build">
-              <DemoMenuButton icon={Code}>Compute <CaretRight class="ml-auto size-4 shrink-0 rotate-90 text-kumo-subtle group-data-[state=collapsed]/sidebar:hidden" /></DemoMenuButton>
-              <DemoMenuSub>
-                <DemoMenuSubButton>Workers & Pages</DemoMenuSubButton>
-                <DemoMenuSubButton>Durable Objects</DemoMenuSubButton>
-              </DemoMenuSub>
-              <DemoMenuButton icon={Database}>Storage</DemoMenuButton>
-            </DemoSidebarGroup>
-          {:else}
-            <DemoSidebarGroup label="Build" collapsible={demo === 'collapsible'} open={buildOpen} onToggle={() => (buildOpen = !buildOpen)}>
-              <DemoMenuButton icon={Code} tooltip="Compute" collapsed={isCollapsed}>Compute {#if demo === 'full'}<CaretRight class="ml-auto size-4 shrink-0 rotate-90 text-kumo-subtle transition-transform duration-200" />{/if}</DemoMenuButton>
-              {#if demo === 'full'}
-                <DemoMenuSub>
-                  <DemoMenuSubButton>Workers & Pages</DemoMenuSubButton>
-                  <DemoMenuSubButton>Durable Objects</DemoMenuSubButton>
-                  <DemoMenuSubButton>Containers <DemoBadge>Beta</DemoBadge></DemoMenuSubButton>
-                </DemoMenuSub>
-              {/if}
-              <DemoMenuButton icon={Database} tooltip="Storage" collapsed={isCollapsed}>Storage</DemoMenuButton>
-            </DemoSidebarGroup>
-          {/if}
-
-          {#if demo === 'collapsible' || demo === 'full'}
-            <DemoSidebarGroup label="Protect & Connect" collapsible={demo === 'collapsible'} open={protectOpen} onToggle={() => (protectOpen = !protectOpen)}>
-              <DemoMenuButton icon={ShieldCheck}>Security</DemoMenuButton>
-              <DemoMenuButton icon={Lock}>Zero Trust {#if demo === 'full'}<DemoBadge>Beta</DemoBadge>{/if}</DemoMenuButton>
-            </DemoSidebarGroup>
-          {/if}
-        {/if}
-      </div>
-
-      {#if demo === 'toggle' || demo === 'resizable' || demo === 'full'}
-        <div class="flex min-w-0 flex-col gap-2 border-t border-kumo-hairline px-2 py-2 group-data-[state=collapsed]/sidebar:border-t-0 group-data-[state=collapsed]/sidebar:py-1">
-          {#if demo === 'full'}
-            <DemoMenuButton icon={Gear}>Manage account</DemoMenuButton>
-          {:else}
-            <button class="flex items-center rounded-md p-1.5 text-kumo-subtle transition-colors hover:bg-kumo-overlay hover:text-kumo-default" aria-label="Toggle sidebar" onclick={toggle}>
-              <SidebarSimple class="size-5" />
-            </button>
-          {/if}
-        </div>
-      {/if}
-
-      {#if demo === 'resizable'}
-        <button class="absolute inset-y-0 right-0 z-20 hidden w-1 cursor-col-resize transition-colors hover:bg-kumo-brand/30 sm:block" aria-label="Resize sidebar" onclick={resize}></button>
-      {/if}
-    </aside>
-
-    <main class="flex flex-1 flex-col items-center justify-center gap-2 p-8 text-kumo-subtle">
-      {#if demo === 'toggle'}
-        <button class="rounded-lg border border-kumo-hairline bg-kumo-base px-3 py-1.5 text-sm text-kumo-default transition-colors hover:bg-kumo-tint" onclick={toggle}>
-          {collapsed ? 'Expand' : 'Collapse'}
-        </button>
-        <p class="text-sm">Click the button or the sidebar trigger to toggle</p>
-      {:else if demo === 'resizable'}
-        <p class="text-sm">Click the sidebar edge to resize</p>
-      {:else}
-        Main content area
-      {/if}
-    </main>
+{#snippet brandLogo()}
+  <div class="flex w-full min-w-0 items-center gap-2 px-3 transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) group-data-[state=collapsed]/sidebar:px-2">
+    <Cube class="size-4 shrink-0 text-kumo-brand" weight="duotone" />
+    <span class="flex-1 truncate text-sm font-semibold text-kumo-strong">Company</span>
   </div>
+{/snippet}
+
+{#snippet accountSwitcher()}
+  <DropdownMenu>
+    <DropdownMenu.Trigger class="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-kumo-default outline-none transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-line group-data-[state=collapsed]/sidebar:px-1.5">
+      <ActiveAccountIcon class="size-4 shrink-0 text-kumo-brand" weight="duotone" />
+      <span class="flex min-w-0 flex-1 items-center overflow-hidden text-left">{selectedAccount.name}</span>
+      <span class="w-4 shrink-0 overflow-hidden transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) group-data-[state=collapsed]/sidebar:w-0">
+        <CaretUpDown class="size-4 text-kumo-subtle" />
+      </span>
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content class="w-(--anchor-width)">
+      {#each accounts as account (account.id)}
+        {@const AccountIcon = account.icon}
+        <DropdownMenu.Item class="gap-2 cursor-pointer" onclick={() => (selectedAccount = account)}>
+          <AccountIcon class="mr-2 size-4 text-kumo-brand" weight="duotone" />
+          {account.name}
+          {#if account.id === selectedAccount.id}
+            <Check class="ml-auto size-4" />
+          {/if}
+        </DropdownMenu.Item>
+      {/each}
+    </DropdownMenu.Content>
+  </DropdownMenu>
+{/snippet}
+
+{#snippet computeMenu(includeBadge = false)}
+  <Sidebar.MenuItem>
+    <Sidebar.Collapsible defaultOpen>
+      <Sidebar.CollapsibleTrigger
+        class="group/menu-button relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-[color,background-color,box-shadow,outline] duration-(--sidebar-animation-duration) hover:bg-kumo-tint focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong"
+      >
+        <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
+          <Code class="size-4 shrink-0 opacity-50" />
+          <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
+            Compute
+            <Sidebar.MenuChevron />
+          </span>
+        </span>
+      </Sidebar.CollapsibleTrigger>
+      <Sidebar.CollapsibleContent>
+        <Sidebar.MenuSub>
+          <Sidebar.MenuSubItem>
+            <Sidebar.Collapsible defaultOpen={false}>
+              <Sidebar.CollapsibleTrigger
+                class="relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-colors duration-150 hover:bg-kumo-tint focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong"
+              >
+                <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">
+                  Workers & Pages
+                  <Sidebar.MenuChevron />
+                </span>
+              </Sidebar.CollapsibleTrigger>
+              <Sidebar.CollapsibleContent>
+                <Sidebar.MenuSub>
+                  <Sidebar.MenuSubButton>Overview</Sidebar.MenuSubButton>
+                  <Sidebar.MenuSubButton>Workers</Sidebar.MenuSubButton>
+                  <Sidebar.MenuSubButton>Pages</Sidebar.MenuSubButton>
+                </Sidebar.MenuSub>
+              </Sidebar.CollapsibleContent>
+            </Sidebar.Collapsible>
+          </Sidebar.MenuSubItem>
+          <Sidebar.MenuSubButton>Durable Objects</Sidebar.MenuSubButton>
+          {#if includeBadge}
+            <Sidebar.MenuSubButton>
+              Containers
+              <Sidebar.MenuBadge>Beta</Sidebar.MenuBadge>
+            </Sidebar.MenuSubButton>
+          {/if}
+        </Sidebar.MenuSub>
+      </Sidebar.CollapsibleContent>
+    </Sidebar.Collapsible>
+  </Sidebar.MenuItem>
+{/snippet}
+
+{#snippet accountSurface()}
+  <Sidebar.Content>
+    {#if demo === 'full'}
+      <Sidebar.Group>
+        <Sidebar.Menu>
+          <Sidebar.MenuButton icon={MagnifyingGlass} tooltip="Search" class="ring ring-kumo-line group-data-[state=collapsed]/sidebar:ring-transparent">
+            Quick search...
+          </Sidebar.MenuButton>
+        </Sidebar.Menu>
+      </Sidebar.Group>
+    {/if}
+
+    <Sidebar.Group>
+      {#if demo !== 'toggle' && demo !== 'full' && demo !== 'peeking'}<Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>{/if}
+      <Sidebar.Menu>
+        <Sidebar.MenuButton icon={House} tooltip="Home" active>Home</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={ChartBar} tooltip="Analytics">{demo === 'full' ? 'Analytics & Logs' : 'Analytics'}</Sidebar.MenuButton>
+        {#if demo === 'toggle' || demo === 'resizable' || demo === 'peeking'}
+          {#if demo === 'toggle' || demo === 'peeking'}<Sidebar.MenuButton icon={Code} tooltip="Compute">Compute</Sidebar.MenuButton>{/if}
+          <Sidebar.MenuButton icon={Database} tooltip="Storage">Storage</Sidebar.MenuButton>
+        {:else}
+          <Sidebar.MenuButton icon={Globe} tooltip="Domains" onclick={() => demo === 'full' && (surface = 'domain')}>Domains</Sidebar.MenuButton>
+        {/if}
+      </Sidebar.Menu>
+    </Sidebar.Group>
+
+    {#if demo === 'basic' || demo === 'full'}
+      <Sidebar.Group>
+        <Sidebar.GroupLabel>Build</Sidebar.GroupLabel>
+        <Sidebar.Menu>
+          {@render computeMenu(demo === 'full')}
+          <Sidebar.MenuButton icon={Database}>Storage</Sidebar.MenuButton>
+        </Sidebar.Menu>
+      </Sidebar.Group>
+    {/if}
+
+    {#if demo === 'full'}
+      <Sidebar.Group>
+        <Sidebar.GroupLabel>Protect & Connect</Sidebar.GroupLabel>
+        <Sidebar.Menu>
+          <Sidebar.MenuButton icon={ShieldCheck}>Security</Sidebar.MenuButton>
+          <Sidebar.MenuButton icon={Lock}>
+            Zero Trust
+            <Sidebar.MenuBadge>Beta</Sidebar.MenuBadge>
+          </Sidebar.MenuButton>
+        </Sidebar.Menu>
+      </Sidebar.Group>
+    {/if}
+  </Sidebar.Content>
+{/snippet}
+
+{#snippet domainSurface()}
+  <Sidebar.Content>
+    <Sidebar.Group>
+      <Sidebar.Menu>
+        <Sidebar.MenuButton icon={ArrowLeft} onclick={() => (surface = 'account')}>Back</Sidebar.MenuButton>
+      </Sidebar.Menu>
+    </Sidebar.Group>
+    <Sidebar.Group>
+      <Sidebar.GroupLabel>example.com</Sidebar.GroupLabel>
+      <Sidebar.Menu>
+        <Sidebar.MenuButton icon={Globe} active>Overview</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={ShieldCheck}>Security</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={Lock}>SSL/TLS</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={ChartBar}>Analytics</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={Database}>Caching</Sidebar.MenuButton>
+      </Sidebar.Menu>
+    </Sidebar.Group>
+  </Sidebar.Content>
+{/snippet}
+
+<div class="relative h-[540px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base">
+  <Sidebar.Provider
+    class="min-h-0! h-full"
+    contained={providerProps.contained}
+    bind:open
+    defaultOpen={providerProps.defaultOpen}
+    side={providerProps.side}
+    resizable={providerProps.resizable}
+    defaultWidth={providerProps.defaultWidth}
+    minWidth={providerProps.minWidth}
+    maxWidth={providerProps.maxWidth}
+    peekable={providerProps.peekable}
+  >
+    {#if demo === 'right'}
+      {@render demoMain()}
+      <Sidebar>
+        <Sidebar.Content>
+          <Sidebar.Group>
+            <Sidebar.GroupLabel>Details</Sidebar.GroupLabel>
+            <Sidebar.Menu>
+              <Sidebar.MenuButton icon={Gear} active>Properties</Sidebar.MenuButton>
+              <Sidebar.MenuButton icon={ChartBar}>Metrics</Sidebar.MenuButton>
+              <Sidebar.MenuButton icon={Bell}>Alerts</Sidebar.MenuButton>
+            </Sidebar.Menu>
+          </Sidebar.Group>
+        </Sidebar.Content>
+      </Sidebar>
+    {:else}
+      <Sidebar>
+        {#if demo === 'toggle' || demo === 'resizable' || demo === 'peeking'}
+          <Sidebar.Header>{@render brandLogo()}</Sidebar.Header>
+        {:else if demo === 'full'}
+          <Sidebar.Header>{@render accountSwitcher()}</Sidebar.Header>
+        {:else if demo === 'sliding'}
+          <Sidebar.Header>
+            <button
+              type="button"
+              onclick={() => (surface = surface === 'account' ? 'zone' : 'account')}
+              class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-kumo-default transition-colors hover:bg-kumo-tint"
+            >
+              <ArrowsLeftRight class="size-4 shrink-0 text-kumo-brand" />
+              <span class="flex-1 text-left font-semibold text-kumo-strong">{surface === 'account' ? 'Account Nav' : 'Zone Nav'}</span>
+            </button>
+          </Sidebar.Header>
+        {/if}
+
+        {#if demo === 'sliding'}
+          <Sidebar.SlidingViews activeKey={surface} direction={surface === 'zone' ? 'left' : 'right'}>
+            <Sidebar.SlidingView value="account">
+              <Sidebar.Content>
+                <Sidebar.Group>
+                  <Sidebar.GroupLabel>Account</Sidebar.GroupLabel>
+                  <Sidebar.Menu>
+                    <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={User}>Members</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={ChartBar}>Analytics</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={Gear}>Settings</Sidebar.MenuButton>
+                  </Sidebar.Menu>
+                </Sidebar.Group>
+              </Sidebar.Content>
+            </Sidebar.SlidingView>
+            <Sidebar.SlidingView value="zone">
+              <Sidebar.Content>
+                <Sidebar.Group>
+                  <Sidebar.GroupLabel>Zone</Sidebar.GroupLabel>
+                  <Sidebar.Menu>
+                    <Sidebar.MenuButton icon={Globe} active>Overview</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={ShieldCheck}>Security</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={Lock}>SSL/TLS</Sidebar.MenuButton>
+                    <Sidebar.MenuButton icon={Database}>Caching</Sidebar.MenuButton>
+                  </Sidebar.Menu>
+                </Sidebar.Group>
+              </Sidebar.Content>
+            </Sidebar.SlidingView>
+          </Sidebar.SlidingViews>
+        {:else if demo === 'full'}
+          <Sidebar.SlidingViews activeKey={surface} direction={surface === 'domain' ? 'left' : 'right'}>
+            <Sidebar.SlidingView value="account">{@render accountSurface()}</Sidebar.SlidingView>
+            <Sidebar.SlidingView value="domain">{@render domainSurface()}</Sidebar.SlidingView>
+          </Sidebar.SlidingViews>
+        {:else}
+          {@render accountSurface()}
+        {/if}
+
+        {#if demo === 'toggle' || demo === 'resizable' || demo === 'full' || demo === 'peeking'}
+          <Sidebar.Footer><Sidebar.Trigger /></Sidebar.Footer>
+        {/if}
+
+        {#if demo === 'resizable'}
+          <Sidebar.ResizeHandle />
+        {/if}
+      </Sidebar>
+
+      {#if demo === 'toggle'}
+        {@render demoMain(toggleContent)}
+      {:else if demo === 'resizable'}
+        {@render demoMain(resizableContent)}
+      {:else if demo === 'peeking'}
+        {@render demoMain(peekingContent)}
+      {:else if demo === 'sliding'}
+        {@render demoMain(slidingContent)}
+      {:else}
+        {@render demoMain()}
+      {/if}
+    {/if}
+  </Sidebar.Provider>
 </div>
+
+{#snippet toggleContent()}
+  <button
+    type="button"
+    class="cursor-pointer rounded-lg border border-kumo-line bg-kumo-base px-3 py-1.5 text-base text-kumo-default transition-colors hover:bg-kumo-tint"
+    onclick={() => (open = !open)}
+  >
+    {open ? 'Collapse' : 'Expand'}
+  </button>
+  <p>Click the button or the sidebar trigger to toggle</p>
+{/snippet}
+
+{#snippet resizableContent()}
+  <p>Drag the sidebar edge to resize</p>
+{/snippet}
+
+{#snippet peekingContent()}
+  <div class="flex flex-col items-center gap-2">
+    <span class="font-medium text-kumo-default">State: {open ? 'Expanded' : 'Collapsed'}</span>
+    <p>Collapse, then hover the sidebar to peek</p>
+  </div>
+{/snippet}
+
+{#snippet slidingContent()}
+  <div class="flex flex-col items-center gap-2">
+    <p class="font-medium text-kumo-default">Active: {surface === 'account' ? 'Account' : 'Zone'} surface</p>
+    <p>Click the header button to slide between views</p>
+  </div>
+{/snippet}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarPeekingDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarPeekingDemo.svelte
@@ -1,25 +1,5 @@
 <script lang="ts">
-  import { Sidebar } from 'kumo-svelte';
-  import { ChartBar, Gear, House } from 'phosphor-svelte';
+  import SidebarDemoShell from './SidebarDemoShell.svelte';
 </script>
 
-<div class="h-[320px] overflow-hidden rounded-md border border-kumo-line">
-  <Sidebar.Provider defaultOpen={false} peekable contained>
-    <Sidebar>
-      <Sidebar.Header>
-        <div class="px-3 py-2 text-sm font-semibold text-kumo-strong">Account</div>
-      </Sidebar.Header>
-      <Sidebar.Content>
-        <Sidebar.Group>
-          <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
-          <Sidebar.Menu>
-            <Sidebar.MenuButton icon={House} active tooltip="Home">Home</Sidebar.MenuButton>
-            <Sidebar.MenuButton icon={ChartBar} tooltip="Analytics">Analytics</Sidebar.MenuButton>
-            <Sidebar.MenuButton icon={Gear} tooltip="Settings">Settings</Sidebar.MenuButton>
-          </Sidebar.Menu>
-        </Sidebar.Group>
-      </Sidebar.Content>
-    </Sidebar>
-    <main class="flex-1 bg-kumo-base p-4 text-sm text-kumo-subtle">Hover or focus the collapsed sidebar.</main>
-  </Sidebar.Provider>
-</div>
+<SidebarDemoShell demo="peeking" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarPeekingDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarPeekingDemo.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { Sidebar } from 'kumo-svelte';
+  import { ChartBar, Gear, House } from 'phosphor-svelte';
+</script>
+
+<div class="h-[320px] overflow-hidden rounded-md border border-kumo-line">
+  <Sidebar.Provider defaultOpen={false} peekable contained>
+    <Sidebar>
+      <Sidebar.Header>
+        <div class="px-3 py-2 text-sm font-semibold text-kumo-strong">Account</div>
+      </Sidebar.Header>
+      <Sidebar.Content>
+        <Sidebar.Group>
+          <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
+          <Sidebar.Menu>
+            <Sidebar.MenuButton icon={House} active tooltip="Home">Home</Sidebar.MenuButton>
+            <Sidebar.MenuButton icon={ChartBar} tooltip="Analytics">Analytics</Sidebar.MenuButton>
+            <Sidebar.MenuButton icon={Gear} tooltip="Settings">Settings</Sidebar.MenuButton>
+          </Sidebar.Menu>
+        </Sidebar.Group>
+      </Sidebar.Content>
+    </Sidebar>
+    <main class="flex-1 bg-kumo-base p-4 text-sm text-kumo-subtle">Hover or focus the collapsed sidebar.</main>
+  </Sidebar.Provider>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarSlidingViewsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarSlidingViewsDemo.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Sidebar } from 'kumo-svelte';
+  import { ArrowLeft, ChartBar, Gear, House } from 'phosphor-svelte';
+
+  let view = $state<'overview' | 'settings'>('overview');
+</script>
+
+<div class="h-[340px] overflow-hidden rounded-md border border-kumo-line">
+  <Sidebar.Provider contained>
+    <Sidebar>
+      <Sidebar.SlidingViews activeKey={view}>
+        <Sidebar.SlidingView value="overview">
+          <Sidebar.Header>
+            <div class="px-3 py-2 text-sm font-semibold text-kumo-strong">Dashboard</div>
+          </Sidebar.Header>
+          <Sidebar.Content>
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={ChartBar}>Analytics</Sidebar.MenuButton>
+                <Sidebar.MenuButton icon={Gear} onclick={() => (view = 'settings')}>Settings</Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+          </Sidebar.Content>
+        </Sidebar.SlidingView>
+        <Sidebar.SlidingView value="settings">
+          <Sidebar.Header>
+            <Sidebar.Menu>
+              <Sidebar.MenuButton icon={ArrowLeft} onclick={() => (view = 'overview')}>Back</Sidebar.MenuButton>
+            </Sidebar.Menu>
+          </Sidebar.Header>
+          <Sidebar.Content>
+            <Sidebar.Group>
+              <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
+              <Sidebar.Menu>
+                <Sidebar.MenuButton active>Profile</Sidebar.MenuButton>
+                <Sidebar.MenuButton>Billing</Sidebar.MenuButton>
+              </Sidebar.Menu>
+            </Sidebar.Group>
+          </Sidebar.Content>
+        </Sidebar.SlidingView>
+      </Sidebar.SlidingViews>
+    </Sidebar>
+    <main class="flex-1 bg-kumo-base p-4 text-sm text-kumo-subtle">Select Settings to slide to a nested panel.</main>
+  </Sidebar.Provider>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarSlidingViewsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarSlidingViewsDemo.svelte
@@ -1,47 +1,5 @@
 <script lang="ts">
-  import { Sidebar } from 'kumo-svelte';
-  import { ArrowLeft, ChartBar, Gear, House } from 'phosphor-svelte';
-
-  let view = $state<'overview' | 'settings'>('overview');
+  import SidebarDemoShell from './SidebarDemoShell.svelte';
 </script>
 
-<div class="h-[340px] overflow-hidden rounded-md border border-kumo-line">
-  <Sidebar.Provider contained>
-    <Sidebar>
-      <Sidebar.SlidingViews activeKey={view}>
-        <Sidebar.SlidingView value="overview">
-          <Sidebar.Header>
-            <div class="px-3 py-2 text-sm font-semibold text-kumo-strong">Dashboard</div>
-          </Sidebar.Header>
-          <Sidebar.Content>
-            <Sidebar.Group>
-              <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
-              <Sidebar.Menu>
-                <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
-                <Sidebar.MenuButton icon={ChartBar}>Analytics</Sidebar.MenuButton>
-                <Sidebar.MenuButton icon={Gear} onclick={() => (view = 'settings')}>Settings</Sidebar.MenuButton>
-              </Sidebar.Menu>
-            </Sidebar.Group>
-          </Sidebar.Content>
-        </Sidebar.SlidingView>
-        <Sidebar.SlidingView value="settings">
-          <Sidebar.Header>
-            <Sidebar.Menu>
-              <Sidebar.MenuButton icon={ArrowLeft} onclick={() => (view = 'overview')}>Back</Sidebar.MenuButton>
-            </Sidebar.Menu>
-          </Sidebar.Header>
-          <Sidebar.Content>
-            <Sidebar.Group>
-              <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
-              <Sidebar.Menu>
-                <Sidebar.MenuButton active>Profile</Sidebar.MenuButton>
-                <Sidebar.MenuButton>Billing</Sidebar.MenuButton>
-              </Sidebar.Menu>
-            </Sidebar.Group>
-          </Sidebar.Content>
-        </Sidebar.SlidingView>
-      </Sidebar.SlidingViews>
-    </Sidebar>
-    <main class="flex-1 bg-kumo-base p-4 text-sm text-kumo-subtle">Select Settings to slide to a nested panel.</main>
-  </Sidebar.Provider>
-</div>
+<SidebarDemoShell demo="sliding" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/StatusBannerDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/StatusBannerDemo.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { Banner } from '$lib';
+  import { CheckCircle, Info, Warning, WarningCircle } from 'phosphor-svelte';
+</script>
+
+<div class="w-full space-y-3">
+  <Banner icon={Info} title="Information" description="Neutral system context uses the info status tokens." />
+  <Banner icon={CheckCircle} title="Deployment complete" description="Successful states use success tokens for indicators." />
+  <Banner icon={Warning} variant="alert" title="Usage approaching limit" description="Warnings use attention tokens with tinted surfaces." />
+  <Banner icon={WarningCircle} variant="error" title="Request failed" description="Destructive states use danger tokens for icon and contrast." />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBasicDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBasicDemo.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { Button, Tooltip } from '$lib';
+  import { Button, Tooltip, TooltipProvider } from '$lib';
   import { Plus } from 'phosphor-svelte';
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <Tooltip content="Add"><Button shape="square" aria-label="Add"><Plus class="size-4" /></Button></Tooltip>
+  <TooltipProvider>
+    <Tooltip content="Add"><Button shape="square" aria-label="Add"><Plus class="size-4" /></Button></Tooltip>
+  </TooltipProvider>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBoundaryDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBoundaryDemo.svelte
@@ -5,6 +5,7 @@
   import { buildSeriesData, getIsDarkMode } from './chart-color-demo-data';
 
   let isDarkMode = $state(false);
+  let boundary: HTMLDivElement | undefined = $state();
 
   const data: { name: string; color: string; data: [number, number][] }[] = $derived([
     {
@@ -40,12 +41,12 @@
   });
 </script>
 
-<div class="w-full overflow-hidden rounded-md border border-kumo-line p-3">
+<div bind:this={boundary} class="w-full overflow-hidden rounded-md border border-kumo-line p-3">
   <TimeseriesChart
     {echarts}
     {data}
     {isDarkMode}
-    tooltipBoundary="clipping-ancestors"
+    tooltipBoundary={boundary}
     tooltipMaxItems={4}
     xAxisName="Time (UTC)"
     yAxisName="Requests"

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBoundaryDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipBoundaryDemo.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import { TimeseriesChart, ChartPalette } from 'kumo-svelte';
+  import { buildSeriesData, getIsDarkMode } from './chart-color-demo-data';
+
+  let isDarkMode = $state(false);
+
+  const data: { name: string; color: string; data: [number, number][] }[] = $derived([
+    {
+      name: 'Origin requests',
+      data: buildSeriesData(0, 64, 60_000, 0.8),
+      color: ChartPalette.semantic('Neutral', isDarkMode)
+    },
+    {
+      name: 'Blocked requests',
+      data: buildSeriesData(1, 64, 60_000, 0.25),
+      color: ChartPalette.semantic('Attention', isDarkMode)
+    }
+  ]);
+
+  onMount(() => {
+    const update = () => {
+      isDarkMode = getIsDarkMode();
+    };
+    const observer = new MutationObserver(update);
+
+    update();
+    [document.documentElement, document.body].forEach((node) => {
+      observer.observe(node, { attributes: true, attributeFilter: ['data-mode', 'class'] });
+    });
+
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    mediaQuery?.addEventListener('change', update);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery?.removeEventListener('change', update);
+    };
+  });
+</script>
+
+<div class="w-full overflow-hidden rounded-md border border-kumo-line p-3">
+  <TimeseriesChart
+    {echarts}
+    {data}
+    {isDarkMode}
+    tooltipBoundary="clipping-ancestors"
+    tooltipMaxItems={4}
+    xAxisName="Time (UTC)"
+    yAxisName="Requests"
+  />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipDelayDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipDelayDemo.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import { Button, Tooltip } from '$lib';
+  import { Button, Tooltip, TooltipProvider } from '$lib';
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <div class="flex gap-4">
-    <Tooltip content="Opens after 1 second" delay={1000}><Button variant="secondary">1s open delay</Button></Tooltip>
-    <Tooltip content="Stays open 500ms after leaving" closeDelay={500}><Button variant="secondary">500ms close delay</Button></Tooltip>
-    <Tooltip content="Instant open, stays 1s" delay={0} closeDelay={1000}><Button variant="secondary">Instant + 1s close</Button></Tooltip>
-  </div>
+  <TooltipProvider>
+    <div class="flex gap-4">
+      <Tooltip content="Opens after 1 second" delay={1000}><Button variant="secondary">1s open delay</Button></Tooltip>
+      <Tooltip content="Stays open 500ms after leaving" closeDelay={500}><Button variant="secondary">500ms close delay</Button></Tooltip>
+      <Tooltip content="Instant open, stays 1s" delay={0} closeDelay={1000}><Button variant="secondary">Instant + 1s close</Button></Tooltip>
+    </div>
+  </TooltipProvider>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipFollowCursorDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipFollowCursorDemo.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import { TimeseriesChart, ChartPalette } from 'kumo-svelte';
+  import { buildSeriesData, getIsDarkMode } from './chart-color-demo-data';
+
+  let isDarkMode = $state(false);
+
+  const data: { name: string; color: string; data: [number, number][] }[] = $derived([
+    {
+      name: 'Requests',
+      data: buildSeriesData(0, 72, 60_000, 1),
+      color: ChartPalette.semantic('Neutral', isDarkMode)
+    },
+    {
+      name: 'Edge errors',
+      data: buildSeriesData(1, 72, 60_000, 0.35),
+      color: ChartPalette.semantic('Attention', isDarkMode)
+    },
+    {
+      name: 'Cache hits',
+      data: buildSeriesData(2, 72, 60_000, 0.7),
+      color: ChartPalette.semantic('Success', isDarkMode)
+    }
+  ]);
+
+  onMount(() => {
+    const update = () => {
+      isDarkMode = getIsDarkMode();
+    };
+    const observer = new MutationObserver(update);
+
+    update();
+    [document.documentElement, document.body].forEach((node) => {
+      observer.observe(node, { attributes: true, attributeFilter: ['data-mode', 'class'] });
+    });
+
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    mediaQuery?.addEventListener('change', update);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery?.removeEventListener('change', update);
+    };
+  });
+</script>
+
+<TimeseriesChart
+  {echarts}
+  {data}
+  {isDarkMode}
+  tooltipMode="single"
+  tooltipFollowCursor="x"
+  xAxisName="Time (UTC)"
+  yAxisName="Events"
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipHeroDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipHeroDemo.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { Tooltip } from '$lib';
-  import { Question as HelpCircle } from 'phosphor-svelte';
+  import { Button, Tooltip, TooltipProvider } from '$lib';
+  import { Plus } from 'phosphor-svelte';
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <Tooltip content="Click to learn more">
-    <span class="inline-flex items-center gap-1.5 rounded-full bg-kumo-brand px-3 py-1.5 text-sm font-medium text-white shadow-md transition-transform hover:scale-105 active:scale-95"><HelpCircle class="size-4" />Help</span>
-  </Tooltip>
+  <TooltipProvider>
+    <Tooltip content="Add new item">
+      <Button shape="square" aria-label="Add new item"><Plus class="size-4" /></Button>
+    </Tooltip>
+  </TooltipProvider>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipMultipleDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipMultipleDemo.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import { Button, Tooltip } from '$lib';
-  import { Globe, Plus } from 'phosphor-svelte';
+  import { Button, Tooltip, TooltipProvider } from '$lib';
+  import { Plus, Translate } from 'phosphor-svelte';
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <div class="flex gap-2">
-    <Tooltip content="Add"><Button shape="square" aria-label="Add"><Plus class="size-4" /></Button></Tooltip>
-    <Tooltip content="Change language"><Button shape="square" aria-label="Change language"><Globe class="size-4" /></Button></Tooltip>
-  </div>
+  <TooltipProvider>
+    <div class="flex gap-2">
+      <Tooltip content="Add"><Button shape="square" aria-label="Add"><Plus class="size-4" /></Button></Tooltip>
+      <Tooltip content="Change language"><Button shape="square" aria-label="Change language"><Translate class="size-4" /></Button></Tooltip>
+    </div>
+  </TooltipProvider>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipOverflowDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TooltipOverflowDemo.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { Button, Tooltip, TooltipProvider } from '$lib';
+
+  const longContent =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.';
+</script>
+
+<div class="flex min-h-24 w-full items-center justify-center">
+  <TooltipProvider>
+    <div class="flex w-full justify-between">
+      <Tooltip content={longContent} side="bottom">
+        <Button variant="secondary">Near left edge</Button>
+      </Tooltip>
+      <Tooltip content={longContent} side="bottom">
+        <Button variant="secondary">Centered</Button>
+      </Tooltip>
+      <Tooltip content={longContent} side="bottom">
+        <Button variant="secondary">Near right edge</Button>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
@@ -2,18 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
     "prop": "items",
     "type": "unknown[]",
     "required": true,
@@ -26,12 +14,6 @@ const rows: PropRow[] = [
     "description": "Controlled input value."
   },
   {
-    "prop": "defaultValue",
-    "type": "string | number | string[]",
-    "required": false,
-    "description": "Uncontrolled default input value."
-  },
-  {
     "prop": "open",
     "type": "boolean",
     "required": false,
@@ -39,10 +21,28 @@ const rows: PropRow[] = [
     "description": "Controlled open state."
   },
   {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
+  },
+  {
     "prop": "label",
     "type": "string | Snippet",
     "required": false,
     "description": "Visible label content."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
   },
   {
     "prop": "labelTooltip",
@@ -63,10 +63,10 @@ const rows: PropRow[] = [
     "description": "Validation error message or matcher."
   },
   {
-    "prop": "required",
-    "type": "boolean",
+    "prop": "defaultValue",
+    "type": "string | number | string[]",
     "required": false,
-    "description": "Marks the field as required."
+    "description": "Uncontrolled default input value."
   },
   {
     "prop": "onValueChange",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete__InputGroup.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete__InputGroup.ts
@@ -8,17 +8,17 @@ const rows: PropRow[] = [
     "description": "Additional classes merged onto the root element."
   },
   {
-    "prop": "placeholder",
-    "type": "string",
-    "required": false,
-    "description": "Placeholder text."
-  },
-  {
     "prop": "size",
     "type": "'xs' | 'sm' | 'base' | 'lg'",
     "required": false,
     "default": "\"base\"",
     "description": "Size of the autocomplete input. Matches Input component sizes."
+  },
+  {
+    "prop": "placeholder",
+    "type": "string",
+    "required": false,
+    "description": "Placeholder text."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Button.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Button.ts
@@ -2,6 +2,27 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "shape",
+    "type": "'base' | 'square' | 'circle'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Shape preset."
+  },
+  {
+    "prop": "size",
+    "type": "'xs' | 'sm' | 'base' | 'lg'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Size preset."
+  },
+  {
+    "prop": "variant",
+    "type": "'primary' | 'secondary' | 'ghost' | 'destructive' | 'secondary-destructive' | 'outline'",
+    "required": false,
+    "default": "\"secondary\"",
+    "description": "Visual variant."
+  },
+  {
     "prop": "children",
     "type": "Snippet",
     "required": false,
@@ -31,27 +52,6 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Tooltip content shown when hovering the button."
-  },
-  {
-    "prop": "shape",
-    "type": "'base' | 'square' | 'circle'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Shape preset."
-  },
-  {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
-  },
-  {
-    "prop": "variant",
-    "type": "'primary' | 'secondary' | 'ghost' | 'destructive' | 'secondary-destructive' | 'outline'",
-    "required": false,
-    "default": "\"secondary\"",
-    "description": "Visual variant."
   },
   {
     "prop": "disabled",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Checkbox.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Checkbox.ts
@@ -2,39 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "checked",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Checked state."
-  },
-  {
-    "prop": "indeterminate",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Indeterminate checked state."
-  },
-  {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Disables the component."
-  },
-  {
     "prop": "variant",
     "type": "'default' | 'error'",
     "required": false,
@@ -61,16 +28,43 @@ const rows: PropRow[] = [
     "description": "Renders the control before label content."
   },
   {
-    "prop": "required",
+    "prop": "checked",
     "type": "boolean",
     "required": false,
-    "description": "Marks the field as required."
+    "default": "false",
+    "description": "Checked state."
+  },
+  {
+    "prop": "indeterminate",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Indeterminate checked state."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Disables the component."
   },
   {
     "prop": "name",
     "type": "string",
     "required": false,
     "description": "Form field name."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "value",
@@ -107,6 +101,12 @@ const rows: PropRow[] = [
     "type": "(indeterminate: boolean) => void",
     "required": false,
     "description": "Called when indeterminate changes."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Checkbox__Group.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Checkbox__Group.ts
@@ -2,28 +2,22 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
     "prop": "legend",
     "type": "string",
     "required": false,
     "description": "legend prop."
   },
   {
-    "prop": "description",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Supporting description text."
-  },
-  {
     "prop": "error",
     "type": "string",
     "required": false,
     "description": "Validation error message or matcher."
+  },
+  {
+    "prop": "description",
+    "type": "string | Snippet",
+    "required": false,
+    "description": "Supporting description text."
   },
   {
     "prop": "value",
@@ -40,18 +34,6 @@ const rows: PropRow[] = [
     "description": "Disables the component."
   },
   {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
-  },
-  {
-    "prop": "name",
-    "type": "string",
-    "required": false,
-    "description": "Form field name."
-  },
-  {
     "prop": "controlFirst",
     "type": "boolean",
     "required": false,
@@ -65,10 +47,28 @@ const rows: PropRow[] = [
     "description": "Additional classes merged onto the root element."
   },
   {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
+  },
+  {
+    "prop": "name",
+    "type": "string",
+    "required": false,
+    "description": "Form field name."
+  },
+  {
     "prop": "onValueChange",
     "type": "(value: string[]) => void",
     "required": false,
     "description": "Called when the value changes."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/ClipboardText.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/ClipboardText.ts
@@ -2,10 +2,11 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "class",
-    "type": "string",
+    "prop": "size",
+    "type": "'sm' | 'base' | 'lg'",
     "required": false,
-    "description": "Additional classes merged onto the root element."
+    "description": "Size preset.",
+    "default": "\"lg\""
   },
   {
     "prop": "text",
@@ -20,17 +21,10 @@ const rows: PropRow[] = [
     "description": "Alternate text copied to the clipboard."
   },
   {
-    "prop": "size",
-    "type": "'sm' | 'base' | 'lg'",
+    "prop": "class",
+    "type": "string",
     "required": false,
-    "description": "Size preset.",
-    "default": "\"lg\""
-  },
-  {
-    "prop": "onCopy",
-    "type": "() => void",
-    "required": false,
-    "description": "Called after copying succeeds."
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "tooltip",
@@ -43,6 +37,12 @@ const rows: PropRow[] = [
     "type": "{ copyAction?: string; }",
     "required": false,
     "description": "Accessible labels for internationalization."
+  },
+  {
+    "prop": "onCopy",
+    "type": "() => void",
+    "required": false,
+    "description": "Called after copying succeeds."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/CodeHighlighted.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/CodeHighlighted.ts
@@ -15,11 +15,31 @@ const rows: PropRow[] = [
     "description": "Code language."
   },
   {
+    "prop": "highlightLines",
+    "type": "number[]",
+    "required": false,
+    "default": "[]",
+    "description": "One-indexed line numbers to emphasize."
+  },
+  {
+    "prop": "showLineNumbers",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Displays line numbers."
+  },
+  {
     "prop": "showCopyButton",
     "type": "boolean",
     "required": false,
     "default": "false",
     "description": "Shows the copy button."
+  },
+  {
+    "prop": "labels",
+    "type": "{ copy?: string; copied?: string }",
+    "required": false,
+    "description": "Accessible copy button labels."
   },
   {
     "prop": "class",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Collapsible__Root.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Collapsible__Root.ts
@@ -2,18 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
     "prop": "open",
     "type": "boolean",
     "required": false,
@@ -27,6 +15,12 @@ const rows: PropRow[] = [
     "description": "Initial uncontrolled open state."
   },
   {
+    "prop": "onOpenChange",
+    "type": "(open: boolean) => void",
+    "required": false,
+    "description": "Called when open state changes."
+  },
+  {
     "prop": "disabled",
     "type": "boolean",
     "required": false,
@@ -34,16 +28,22 @@ const rows: PropRow[] = [
     "description": "Disables the component."
   },
   {
-    "prop": "onOpenChange",
-    "type": "(open: boolean) => void",
-    "required": false,
-    "description": "Called when open state changes."
-  },
-  {
     "prop": "onOpenChangeComplete",
     "type": "(open: boolean) => void",
     "required": false,
     "description": "Called after the open-state transition completes."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
@@ -2,16 +2,11 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
+    "prop": "size",
+    "type": "'xs' | 'sm' | 'base' | 'lg'",
     "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    "default": "\"base\"",
+    "description": "Size preset."
   },
   {
     "prop": "items",
@@ -26,24 +21,28 @@ const rows: PropRow[] = [
     "description": "Controlled value."
   },
   {
-    "prop": "multiple",
-    "type": "boolean",
+    "prop": "children",
+    "type": "Snippet",
     "required": false,
-    "default": "false",
-    "description": "Enables multiple selection."
+    "description": "Child snippet rendered by the component."
   },
   {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
+    "prop": "class",
+    "type": "string",
     "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "label",
     "type": "string | Snippet",
     "required": false,
     "description": "Visible label content."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
   },
   {
     "prop": "labelTooltip",
@@ -64,16 +63,17 @@ const rows: PropRow[] = [
     "description": "Validation error message or matcher."
   },
   {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
-  },
-  {
     "prop": "onValueChange",
     "type": "(value: unknown) => void",
     "required": false,
     "description": "Called when the value changes."
+  },
+  {
+    "prop": "multiple",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Enables multiple selection."
   },
   {
     "prop": "onOpenChange",

--- a/packages/kumo-svelte/src/lib/docs/props-data/DeleteResource.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/DeleteResource.ts
@@ -2,16 +2,17 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "size",
+    "type": "'sm' | 'base'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Dialog size preset."
+  },
+  {
     "prop": "open",
     "type": "boolean",
     "required": true,
     "description": "Whether the dialog is open."
-  },
-  {
-    "prop": "onOpenChange",
-    "type": "(open: boolean) => void",
-    "required": true,
-    "description": "Callback fired when the open state changes."
   },
   {
     "prop": "resourceType",
@@ -24,12 +25,6 @@ const rows: PropRow[] = [
     "type": "string",
     "required": true,
     "description": "Name of the resource users must type to confirm deletion."
-  },
-  {
-    "prop": "onDelete",
-    "type": "() => void | Promise<void>",
-    "required": true,
-    "description": "Callback fired when the delete action is confirmed."
   },
   {
     "prop": "isDeleting",
@@ -64,11 +59,16 @@ const rows: PropRow[] = [
     "description": "Error message displayed above the confirmation copy."
   },
   {
-    "prop": "size",
-    "type": "'sm' | 'base'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Dialog size preset."
+    "prop": "onOpenChange",
+    "type": "(open: boolean) => void",
+    "required": true,
+    "description": "Callback fired when the open state changes."
+  },
+  {
+    "prop": "onDelete",
+    "type": "() => void | Promise<void>",
+    "required": true,
+    "description": "Callback fired when the delete action is confirmed."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Dialog.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Dialog.ts
@@ -2,13 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "size",
-    "type": "'sm' | 'base' | 'lg' | 'xl'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Dialog width preset."
-  },
-  {
     "prop": "class",
     "type": "string",
     "required": false,
@@ -21,17 +14,24 @@ const rows: PropRow[] = [
     "description": "Dialog content, typically title, description, close, and action buttons."
   },
   {
-    "prop": "style",
-    "type": "string",
-    "required": false,
-    "description": "Inline styles for the dialog content."
-  },
-  {
     "prop": "container",
     "type": "HTMLElement | string",
     "required": false,
     "default": "document.body",
     "description": "Portal container for custom roots or Shadow DOM."
+  },
+  {
+    "prop": "size",
+    "type": "'sm' | 'base' | 'lg' | 'xl'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Dialog width preset."
+  },
+  {
+    "prop": "style",
+    "type": "string",
+    "required": false,
+    "description": "Inline styles for the dialog content."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__Item.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__Item.ts
@@ -2,6 +2,45 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "href",
+    "type": "string",
+    "required": false,
+    "description": "Deprecated destination URL for legacy link items."
+  },
+  {
+    "prop": "icon",
+    "type": "Component",
+    "required": false,
+    "description": "Icon rendered by the component."
+  },
+  {
+    "prop": "variant",
+    "type": "'default' | 'danger'",
+    "required": false,
+    "description": "Visual variant.",
+    "default": "\"default\""
+  },
+  {
+    "prop": "selected",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Shows a trailing selected check indicator."
+  },
+  {
+    "prop": "inset",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Indents the item content."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "description": "Disables the component."
+  },
+  {
     "prop": "children",
     "type": "Snippet",
     "required": false,
@@ -12,45 +51,6 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "inset",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Indents the item content."
-  },
-  {
-    "prop": "icon",
-    "type": "Component",
-    "required": false,
-    "description": "Icon rendered by the component."
-  },
-  {
-    "prop": "selected",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Shows a trailing selected check indicator."
-  },
-  {
-    "prop": "variant",
-    "type": "'default' | 'danger'",
-    "required": false,
-    "description": "Visual variant.",
-    "default": "\"default\""
-  },
-  {
-    "prop": "href",
-    "type": "string",
-    "required": false,
-    "description": "Deprecated destination URL for legacy link items."
-  },
-  {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "description": "Disables the component."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__RadioItem.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__RadioItem.ts
@@ -2,6 +2,25 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "value",
+    "type": "string",
+    "required": true,
+    "description": "Controlled value."
+  },
+  {
+    "prop": "icon",
+    "type": "Component",
+    "required": false,
+    "description": "Icon rendered by the component."
+  },
+  {
+    "prop": "inset",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Indents the item content."
+  },
+  {
     "prop": "children",
     "type": "Snippet",
     "required": false,
@@ -12,25 +31,6 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "inset",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Indents the item content."
-  },
-  {
-    "prop": "icon",
-    "type": "Component",
-    "required": false,
-    "description": "Icon rendered by the component."
-  },
-  {
-    "prop": "value",
-    "type": "string",
-    "required": true,
-    "description": "Controlled value."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__SubTrigger.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/DropdownMenu__SubTrigger.ts
@@ -2,6 +2,19 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "icon",
+    "type": "Component",
+    "required": false,
+    "description": "Icon rendered by the component."
+  },
+  {
+    "prop": "inset",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Indents the item content."
+  },
+  {
     "prop": "children",
     "type": "Snippet",
     "required": false,
@@ -12,19 +25,6 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "inset",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Indents the item content."
-  },
-  {
-    "prop": "icon",
-    "type": "Component",
-    "required": false,
-    "description": "Icon rendered by the component."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Empty.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Empty.ts
@@ -9,18 +9,6 @@ const rows: PropRow[] = [
     "description": "Size preset."
   },
   {
-    "prop": "contents",
-    "type": "Snippet",
-    "required": false,
-    "description": "Custom empty-state content."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
     "prop": "icon",
     "type": "Snippet",
     "required": false,
@@ -43,6 +31,18 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Shell command displayed in a copyable code block."
+  },
+  {
+    "prop": "contents",
+    "type": "Snippet",
+    "required": false,
+    "description": "Custom empty-state content."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Grid.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Grid.ts
@@ -2,19 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "gap",
-    "type": "'none' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "description": "Gap size between grid items.",
-    "default": "\"base\""
-  },
-  {
-    "prop": "variant",
-    "type": "'2up' | 'side-by-side' | '2-1' | '1-2' | '1-3up' | '3up' | '4up' | '6up' | '1-2-4up'",
-    "required": false,
-    "description": "Responsive column layout variant."
-  },
-  {
     "prop": "children",
     "type": "Snippet",
     "required": false,
@@ -31,6 +18,19 @@ const rows: PropRow[] = [
     "type": "boolean",
     "required": false,
     "description": "Show dividers between grid items on mobile. Only applies with the 4up variant."
+  },
+  {
+    "prop": "gap",
+    "type": "'none' | 'sm' | 'base' | 'lg'",
+    "required": false,
+    "description": "Gap size between grid items.",
+    "default": "\"base\""
+  },
+  {
+    "prop": "variant",
+    "type": "'2up' | 'side-by-side' | '2-1' | '1-2' | '1-3up' | '3up' | '4up' | '6up' | '1-2-4up'",
+    "required": false,
+    "description": "Responsive column layout variant."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Input.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Input.ts
@@ -2,26 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
-  },
-  {
-    "prop": "variant",
-    "type": "'default' | 'error'",
-    "required": false,
-    "default": "\"default\"",
-    "description": "Visual variant."
-  },
-  {
     "prop": "label",
     "type": "string | Snippet",
     "required": false,
@@ -44,6 +24,26 @@ const rows: PropRow[] = [
     "type": "FieldError",
     "required": false,
     "description": "Validation error message or matcher."
+  },
+  {
+    "prop": "size",
+    "type": "'xs' | 'sm' | 'base' | 'lg'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Size preset."
+  },
+  {
+    "prop": "variant",
+    "type": "'default' | 'error'",
+    "required": false,
+    "default": "\"default\"",
+    "description": "Visual variant."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "passwordManagerIgnore",

--- a/packages/kumo-svelte/src/lib/docs/props-data/InputGroup.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/InputGroup.ts
@@ -2,49 +2,10 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
-  },
-  {
-    "prop": "focusMode",
-    "type": "InputGroupFocusMode",
-    "required": false,
-    "default": "\"container\"",
-    "description": "focusMode prop."
-  },
-  {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Disables the component."
-  },
-  {
     "prop": "label",
     "type": "string | Snippet",
     "required": false,
     "description": "Visible label content."
-  },
-  {
-    "prop": "labelTooltip",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Optional help content for the label."
   },
   {
     "prop": "description",
@@ -65,10 +26,49 @@ const rows: PropRow[] = [
     "description": "Marks the field as required."
   },
   {
+    "prop": "labelTooltip",
+    "type": "string | Snippet",
+    "required": false,
+    "description": "Optional help content for the label."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
+  },
+  {
     "prop": "id",
     "type": "string",
     "required": false,
     "description": "Element id."
+  },
+  {
+    "prop": "size",
+    "type": "'xs' | 'sm' | 'base' | 'lg'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Size preset."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Disables the component."
+  },
+  {
+    "prop": "focusMode",
+    "type": "InputGroupFocusMode",
+    "required": false,
+    "default": "\"container\"",
+    "description": "focusMode prop."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/InputGroupButton.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/InputGroupButton.ts
@@ -2,22 +2,16 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
-    "prop": "class",
+    "prop": "tooltip",
     "type": "string",
     "required": false,
-    "description": "Additional classes merged onto the root element."
+    "description": "Tooltip content."
   },
   {
-    "prop": "icon",
-    "type": "Component",
+    "prop": "tooltipSide",
+    "type": "string",
     "required": false,
-    "description": "Icon rendered by the component."
+    "description": "tooltipSide prop."
   },
   {
     "prop": "variant",
@@ -33,6 +27,12 @@ const rows: PropRow[] = [
     "description": "Size preset."
   },
   {
+    "prop": "icon",
+    "type": "Component",
+    "required": false,
+    "description": "Icon rendered by the component."
+  },
+  {
     "prop": "shape",
     "type": "'base' | 'square' | 'circle'",
     "required": false,
@@ -45,16 +45,16 @@ const rows: PropRow[] = [
     "description": "Disables the component."
   },
   {
-    "prop": "tooltip",
-    "type": "string",
+    "prop": "children",
+    "type": "Snippet",
     "required": false,
-    "description": "Tooltip content."
+    "description": "Child snippet rendered by the component."
   },
   {
-    "prop": "tooltipSide",
+    "prop": "class",
     "type": "string",
     "required": false,
-    "description": "tooltipSide prop."
+    "description": "Additional classes merged onto the root element."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Label.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Label.ts
@@ -8,18 +8,6 @@ const rows: PropRow[] = [
     "description": "The label content."
   },
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "htmlFor",
-    "type": "string",
-    "required": false,
-    "description": "The id of the form element this label is associated with."
-  },
-  {
     "prop": "showOptional",
     "type": "boolean",
     "required": false,
@@ -31,6 +19,18 @@ const rows: PropRow[] = [
     "type": "string | Snippet",
     "required": false,
     "description": "Tooltip content displayed next to the label."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
+  },
+  {
+    "prop": "htmlFor",
+    "type": "string",
+    "required": false,
+    "description": "The id of the form element this label is associated with."
   },
   {
     "prop": "asContent",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Link.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Link.ts
@@ -21,16 +21,16 @@ const rows: PropRow[] = [
     "description": "Deprecated routing destination. Use href instead."
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Content rendered inside the link."
-  },
-  {
     "prop": "class",
     "type": "string",
     "required": false,
     "description": "Additional classes merged onto the root element."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Content rendered inside the link."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Meter.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Meter.ts
@@ -2,33 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "value",
-    "type": "number",
-    "required": false,
-    "default": "0",
-    "description": "Controlled value."
-  },
-  {
-    "prop": "min",
-    "type": "number",
-    "required": false,
-    "default": "0",
-    "description": "Minimum value."
-  },
-  {
-    "prop": "max",
-    "type": "number",
-    "required": false,
-    "default": "100",
-    "description": "Maximum value."
-  },
-  {
     "prop": "customValue",
     "type": "string",
     "required": false,
@@ -58,6 +31,33 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Class for the meter indicator."
+  },
+  {
+    "prop": "value",
+    "type": "number",
+    "required": false,
+    "default": "0",
+    "description": "Controlled value."
+  },
+  {
+    "prop": "max",
+    "type": "number",
+    "required": false,
+    "default": "100",
+    "description": "Maximum value."
+  },
+  {
+    "prop": "min",
+    "type": "number",
+    "required": false,
+    "default": "0",
+    "description": "Minimum value."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/PageHeader.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/PageHeader.ts
@@ -2,6 +2,13 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "spacing",
+    "type": "'compact' | 'base' | 'relaxed'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Spacing preset between header rows."
+  },
+  {
     "prop": "breadcrumbContent",
     "type": "Snippet",
     "required": true,
@@ -32,10 +39,10 @@ const rows: PropRow[] = [
     "description": "Initial selected tab value."
   },
   {
-    "prop": "onValueChange",
-    "type": "(value: string) => void",
+    "prop": "class",
+    "type": "string",
     "required": false,
-    "description": "Callback fired when the active tab changes."
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "children",
@@ -44,17 +51,10 @@ const rows: PropRow[] = [
     "description": "Action content rendered on the right side of the tabs row."
   },
   {
-    "prop": "spacing",
-    "type": "'compact' | 'base' | 'relaxed'",
+    "prop": "onValueChange",
+    "type": "(value: string) => void",
     "required": false,
-    "default": "\"base\"",
-    "description": "Spacing preset between header rows."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    "description": "Callback fired when the active tab changes."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Pagination.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Pagination.ts
@@ -2,16 +2,10 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
+    "prop": "setPage",
+    "type": "(page: number) => void",
     "required": false,
-    "description": "Compound component children for custom layouts."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    "description": "Callback fired when the current page changes. In Svelte, bind:page can be used instead."
   },
   {
     "prop": "page",
@@ -19,12 +13,6 @@ const rows: PropRow[] = [
     "required": false,
     "default": "1",
     "description": "Current page number (1-indexed)."
-  },
-  {
-    "prop": "setPage",
-    "type": "(page: number) => void",
-    "required": false,
-    "description": "Callback fired when the current page changes. In Svelte, bind:page can be used instead."
   },
   {
     "prop": "perPage",
@@ -39,6 +27,24 @@ const rows: PropRow[] = [
     "description": "Total number of items across all pages."
   },
   {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
+  },
+  {
+    "prop": "labels",
+    "type": "PaginationLabels",
+    "required": false,
+    "description": "Labels for internationalization of aria-labels."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Compound component children for custom layouts."
+  },
+  {
     "prop": "controls",
     "type": "'full' | 'simple'",
     "required": false,
@@ -50,12 +56,6 @@ const rows: PropRow[] = [
     "type": "(props: { page?: number; perPage?: number; totalCount?: number; pageShowingRange: string }) => unknown",
     "required": false,
     "description": "Deprecated legacy render function for the info text. Prefer Pagination.Info children."
-  },
-  {
-    "prop": "labels",
-    "type": "PaginationLabels",
-    "required": false,
-    "description": "Labels for internationalization of aria-labels."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
@@ -2,16 +2,16 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
     "prop": "legend",
     "type": "string",
     "required": false,
     "description": "legend prop."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
   },
   {
     "prop": "orientation",
@@ -46,23 +46,11 @@ const rows: PropRow[] = [
     "description": "Controlled value."
   },
   {
-    "prop": "defaultValue",
-    "type": "string",
-    "required": false,
-    "description": "Initial uncontrolled value."
-  },
-  {
     "prop": "disabled",
     "type": "boolean",
     "required": false,
     "default": "false",
     "description": "Disables the component."
-  },
-  {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
   },
   {
     "prop": "controlPosition",
@@ -81,6 +69,18 @@ const rows: PropRow[] = [
     "type": "string",
     "required": false,
     "description": "Additional classes merged onto the root element."
+  },
+  {
+    "prop": "defaultValue",
+    "type": "string",
+    "required": false,
+    "description": "Initial uncontrolled value."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
   },
   {
     "prop": "onValueChange",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Select.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Select.ts
@@ -8,59 +8,6 @@ const rows: PropRow[] = [
     "description": "Additional classes merged onto the root element."
   },
   {
-    "prop": "options",
-    "type": "Option[]",
-    "required": false,
-    "default": "[]",
-    "description": "Options rendered by the component."
-  },
-  {
-    "prop": "items",
-    "type": "Record<string, SelectItemValue> | { label: Snippet | string; value: Value }[]",
-    "required": false,
-    "description": "Items rendered by the component."
-  },
-  {
-    "prop": "value",
-    "type": "Value",
-    "required": false,
-    "description": "Controlled value."
-  },
-  {
-    "prop": "defaultValue",
-    "type": "Value",
-    "required": false,
-    "description": "Initial uncontrolled value."
-  },
-  {
-    "prop": "placeholder",
-    "type": "string",
-    "required": false,
-    "default": "\"Select...\"",
-    "description": "Placeholder text."
-  },
-  {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Disables the component."
-  },
-  {
-    "prop": "loading",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Loading state."
-  },
-  {
-    "prop": "multiple",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Enables multiple selection."
-  },
-  {
     "prop": "size",
     "type": "'xs' | 'sm' | 'base' | 'lg'",
     "required": false,
@@ -81,10 +28,50 @@ const rows: PropRow[] = [
     "description": "hideLabel prop."
   },
   {
+    "prop": "placeholder",
+    "type": "string",
+    "required": false,
+    "default": "\"Select...\"",
+    "description": "Placeholder text."
+  },
+  {
+    "prop": "loading",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Loading state."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Disables the component."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Marks the field as required."
+  },
+  {
     "prop": "labelTooltip",
     "type": "string | Snippet",
     "required": false,
     "description": "Optional help content for the label."
+  },
+  {
+    "prop": "value",
+    "type": "Value",
+    "required": false,
+    "description": "Controlled value."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
   },
   {
     "prop": "description",
@@ -99,29 +86,42 @@ const rows: PropRow[] = [
     "description": "Validation error message or matcher."
   },
   {
-    "prop": "name",
-    "type": "string",
+    "prop": "defaultValue",
+    "type": "Value",
     "required": false,
-    "description": "Form field name."
-  },
-  {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Marks the field as required."
-  },
-  {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
+    "description": "Initial uncontrolled value."
   },
   {
     "prop": "renderValue",
     "type": "(value: Value) => unknown",
     "required": false,
     "description": "Custom selected-value renderer."
+  },
+  {
+    "prop": "items",
+    "type": "Record<string, SelectItemValue> | { label: Snippet | string; value: Value }[]",
+    "required": false,
+    "description": "Items rendered by the component."
+  },
+  {
+    "prop": "options",
+    "type": "Option[]",
+    "required": false,
+    "default": "[]",
+    "description": "Options rendered by the component."
+  },
+  {
+    "prop": "multiple",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Enables multiple selection."
+  },
+  {
+    "prop": "name",
+    "type": "string",
+    "required": false,
+    "description": "Form field name."
   },
   {
     "prop": "container",

--- a/packages/kumo-svelte/src/lib/docs/props-data/SensitiveInput.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/SensitiveInput.ts
@@ -2,29 +2,49 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
+    "prop": "autoComplete",
+    "type": "string",
+    "required": false,
+    "default": "\"off\"",
+    "description": "Autocomplete attribute."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Disables the component."
+  },
+  {
+    "prop": "readOnly",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Makes the input read-only."
+  },
+  {
+    "prop": "required",
+    "type": "boolean",
+    "required": false,
+    "description": "Marks the field as required."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
+  },
+  {
+    "prop": "id",
+    "type": "string",
+    "required": false,
+    "description": "Element id."
+  },
+  {
     "prop": "value",
     "type": "string",
     "required": false,
     "description": "Controlled value."
-  },
-  {
-    "prop": "defaultValue",
-    "type": "string",
-    "required": false,
-    "default": "\"\"",
-    "description": "Initial uncontrolled value."
-  },
-  {
-    "prop": "onValueChange",
-    "type": "(value: string) => void",
-    "required": false,
-    "description": "Called when the value changes."
-  },
-  {
-    "prop": "onCopy",
-    "type": "() => void",
-    "required": false,
-    "description": "Called after copying succeeds."
   },
   {
     "prop": "size",
@@ -65,30 +85,23 @@ const rows: PropRow[] = [
     "description": "Validation error message or matcher."
   },
   {
-    "prop": "class",
+    "prop": "defaultValue",
     "type": "string",
     "required": false,
-    "description": "Additional classes merged onto the root element."
+    "default": "\"\"",
+    "description": "Initial uncontrolled value."
   },
   {
-    "prop": "id",
-    "type": "string",
+    "prop": "onValueChange",
+    "type": "(value: string) => void",
     "required": false,
-    "description": "Element id."
+    "description": "Called when the value changes."
   },
   {
-    "prop": "disabled",
-    "type": "boolean",
+    "prop": "onCopy",
+    "type": "() => void",
     "required": false,
-    "default": "false",
-    "description": "Disables the component."
-  },
-  {
-    "prop": "readOnly",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Makes the input read-only."
+    "description": "Called after copying succeeds."
   },
   {
     "prop": "readonly",
@@ -98,22 +111,9 @@ const rows: PropRow[] = [
     "description": "Makes the input read-only."
   },
   {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
-  },
-  {
     "prop": "autocomplete",
     "type": "string",
     "required": false,
-    "description": "Autocomplete attribute."
-  },
-  {
-    "prop": "autoComplete",
-    "type": "string",
-    "required": false,
-    "default": "\"off\"",
     "description": "Autocomplete attribute."
   },
   {

--- a/packages/kumo-svelte/src/lib/docs/props-data/Sidebar.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Sidebar.ts
@@ -2,18 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": true,
-    "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
-  },
-  {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes for the sidebar element."
-  },
-  {
     "prop": "variant",
     "type": "\"sidebar\" | \"floating\" | \"inset\"",
     "default": "\"sidebar\"",
@@ -33,6 +21,18 @@ const rows: PropRow[] = [
     "default": "\"icon\"",
     "required": false,
     "description": "Collapse behavior inherited from Provider."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": true,
+    "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes for the sidebar element."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Sidebar__Provider.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Sidebar__Provider.ts
@@ -12,6 +12,9 @@ const rows: PropRow[] = [
   { prop: 'minWidth', type: 'number', default: '200', description: 'Minimum width in pixels when resizing.' },
   { prop: 'maxWidth', type: 'number', default: '480', description: 'Maximum width in pixels when resizing.' },
   { prop: 'onWidthChange', type: '(width: number) => void', description: 'Callback when width changes during resize.' },
+  { prop: 'contained', type: 'boolean', default: 'false', description: 'Keeps the provider scoped to its parent container instead of using full viewport height.' },
+  { prop: 'peekable', type: 'boolean', default: 'false', description: 'Allows collapsed sidebars to temporarily reveal full content while hovered or focused.' },
+  { prop: 'animationDuration', type: 'number', default: '250', description: 'Transition duration in milliseconds for width and peek animations.' },
   { prop: 'children', type: 'Snippet', required: true, description: 'Content, typically Sidebar plus main content.' },
   { prop: 'class', type: 'string', description: 'Additional classes for the wrapper div.' }
 ];

--- a/packages/kumo-svelte/src/lib/docs/props-data/Switch.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Switch.ts
@@ -2,33 +2,6 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
-  },
-  {
-    "prop": "checked",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Checked state."
-  },
-  {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Disables the component."
-  },
-  {
-    "prop": "size",
-    "type": "'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
-  },
-  {
     "prop": "variant",
     "type": "'default' | 'neutral'",
     "required": false,
@@ -61,10 +34,37 @@ const rows: PropRow[] = [
     "description": "Renders the control before label content."
   },
   {
+    "prop": "size",
+    "type": "'sm' | 'base' | 'lg'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Size preset."
+  },
+  {
+    "prop": "checked",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Checked state."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Disables the component."
+  },
+  {
     "prop": "transitioning",
     "type": "boolean",
     "required": false,
     "description": "transitioning prop."
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the root element."
   },
   {
     "prop": "id",
@@ -79,12 +79,6 @@ const rows: PropRow[] = [
     "description": "Accessible label."
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
     "prop": "onchange",
     "type": "(checked: boolean) => void",
     "required": false,
@@ -95,6 +89,12 @@ const rows: PropRow[] = [
     "type": "(checked: boolean) => void",
     "required": false,
     "description": "Called when checked changes."
+  },
+  {
+    "prop": "children",
+    "type": "Snippet",
+    "required": false,
+    "description": "Child snippet rendered by the component."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Switch__Group.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Switch__Group.ts
@@ -2,28 +2,28 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
-  },
-  {
     "prop": "legend",
     "type": "string",
     "required": false,
     "description": "legend prop."
   },
   {
-    "prop": "description",
-    "type": "string",
+    "prop": "children",
+    "type": "Snippet",
     "required": false,
-    "description": "Supporting description text."
+    "description": "Child snippet rendered by the component."
   },
   {
     "prop": "error",
     "type": "string",
     "required": false,
     "description": "Validation error message or matcher."
+  },
+  {
+    "prop": "description",
+    "type": "string",
+    "required": false,
+    "description": "Supporting description text."
   },
   {
     "prop": "disabled",

--- a/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
@@ -69,6 +69,33 @@ const rows: PropRow[] = [
     "description": "Custom formatter for tooltip values. Takes precedence over yAxisTickLabelFormat."
   },
   {
+    "prop": "tooltipMode",
+    "type": "'all' | 'single'",
+    "required": false,
+    "default": "\"all\"",
+    "description": "Controls whether the native tooltip lists all series at the active timestamp or only the nearest series."
+  },
+  {
+    "prop": "tooltipMaxItems",
+    "type": "number",
+    "required": false,
+    "default": "10",
+    "description": "Maximum number of series rows shown when tooltipMode is 'all'."
+  },
+  {
+    "prop": "tooltipBoundary",
+    "type": "'clipping-ancestors' | Element | Element[]",
+    "required": false,
+    "description": "Constrains tooltip placement to the chart container when provided."
+  },
+  {
+    "prop": "tooltipFollowCursor",
+    "type": "'both' | 'x'",
+    "required": false,
+    "default": "\"both\"",
+    "description": "Controls whether the tooltip follows both cursor axes or locks to the chart top while following x."
+  },
+  {
     "prop": "incomplete",
     "type": "{ before?: number; after?: number }",
     "required": false,

--- a/packages/kumo-svelte/src/lib/docs/props-data/Tooltip.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Tooltip.ts
@@ -2,10 +2,17 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "trigger",
-    "type": "Snippet<[Record<string, unknown>]>",
+    "prop": "side",
+    "type": "'top' | 'right' | 'bottom' | 'left'",
     "required": false,
-    "description": "trigger prop."
+    "description": "Preferred floating side.",
+    "default": "\"top\""
+  },
+  {
+    "prop": "class",
+    "type": "string",
+    "required": false,
+    "description": "Additional classes merged onto the tooltip popup."
   },
   {
     "prop": "children",
@@ -20,10 +27,10 @@ const rows: PropRow[] = [
     "description": "Content to display inside the tooltip popup."
   },
   {
-    "prop": "class",
-    "type": "string",
+    "prop": "trigger",
+    "type": "Snippet<[Record<string, unknown>]>",
     "required": false,
-    "description": "Additional classes merged onto the tooltip popup."
+    "description": "trigger prop."
   },
   {
     "prop": "open",
@@ -36,13 +43,6 @@ const rows: PropRow[] = [
     "type": "(open: boolean) => void",
     "required": false,
     "description": "Called when open state changes."
-  },
-  {
-    "prop": "side",
-    "type": "'top' | 'right' | 'bottom' | 'left'",
-    "required": false,
-    "description": "Preferred floating side.",
-    "default": "\"top\""
   },
   {
     "prop": "align",

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -265,8 +265,8 @@
   );
 
   --color-kumo-info: light-dark(
-    var(--color-blue-300, oklch(80.9% 0.105 251.813)),
-    var(--color-blue-900, oklch(37.9% 0.146 265.522))
+    var(--color-blue-500, oklch(68.5% 0.169 237.323)),
+    var(--color-blue-400, oklch(70.7% 0.165 254.624))
   );
 
   --color-kumo-warning-tint: light-dark(
@@ -275,8 +275,8 @@
   );
 
   --color-kumo-warning: light-dark(
-    var(--color-yellow-300, oklch(90.5% 0.182 98.111)),
-    var(--color-yellow-900, oklch(42.1% 0.095 57.708))
+    var(--color-yellow-500, oklch(79.5% 0.184 86.047)),
+    var(--color-yellow-400, oklch(85.2% 0.199 91.936))
   );
 
   --color-kumo-danger-tint: light-dark(
@@ -286,7 +286,7 @@
 
   --color-kumo-danger: light-dark(
     var(--color-red-500, oklch(63.7% 0.237 25.331)),
-    var(--color-red-900, oklch(39.6% 0.141 25.723))
+    var(--color-red-400, oklch(70.4% 0.191 22.216))
   );
 
   --color-kumo-success-tint: light-dark(
@@ -295,8 +295,18 @@
   );
 
   --color-kumo-success: light-dark(
-    var(--color-green-300, oklch(87.1% 0.15 154.449)),
-    var(--color-green-900, oklch(39.3% 0.095 152.535))
+    var(--color-emerald-600, oklch(59.6% 0.145 163.225)),
+    var(--color-emerald-400, oklch(76.5% 0.177 163.223))
+  );
+
+  --color-kumo-banner-info: light-dark(
+    oklch(93.2% 0.032 255.585 / 0.7),
+    oklch(37.9% 0.146 265.522 / 0.5)
+  );
+
+  --color-kumo-banner-warning: light-dark(
+    var(--color-yellow-100, oklch(97.3% 0.071 103.193)),
+    oklch(55.4% 0.135 66.442 / 0.5)
   );
 
   --color-kumo-badge-red: light-dark(
@@ -420,19 +430,21 @@
     --color-kumo-tip-shadow: var(--color-gray-200, oklch(92.8% 0.006 264.531));
     --color-kumo-tip-stroke: transparent;
     --color-kumo-info-tint: var(--color-blue-100, oklch(93.2% 0.032 255.585));
-    --color-kumo-info: var(--color-blue-300, oklch(80.9% 0.105 251.813));
+    --color-kumo-info: var(--color-blue-500, oklch(68.5% 0.169 237.323));
     --color-kumo-warning-tint: var(
       --color-yellow-100,
       oklch(97.3% 0.071 103.193)
     );
-    --color-kumo-warning: var(--color-yellow-300, oklch(90.5% 0.182 98.111));
+    --color-kumo-warning: var(--color-yellow-500, oklch(79.5% 0.184 86.047));
     --color-kumo-danger-tint: var(--color-red-100, oklch(93.6% 0.032 17.717));
     --color-kumo-danger: var(--color-red-500, oklch(63.7% 0.237 25.331));
     --color-kumo-success-tint: var(
       --color-emerald-100,
       oklch(95% 0.052 163.051)
     );
-    --color-kumo-success: var(--color-green-300, oklch(87.1% 0.15 154.449));
+    --color-kumo-success: var(--color-emerald-600, oklch(59.6% 0.145 163.225));
+    --color-kumo-banner-info: oklch(93.2% 0.032 255.585 / 0.7);
+    --color-kumo-banner-warning: var(--color-yellow-100, oklch(97.3% 0.071 103.193));
     --color-kumo-badge-red: var(--color-red-600, oklch(57.7% 0.245 27.325));
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-orange-subtle: var(
@@ -514,19 +526,21 @@
     --color-kumo-tip-shadow: transparent;
     --color-kumo-tip-stroke: var(--color-neutral-800, oklch(26.9% 0 0));
     --color-kumo-info-tint: var(--color-blue-900, oklch(37.9% 0.146 265.522));
-    --color-kumo-info: var(--color-blue-900, oklch(37.9% 0.146 265.522));
+    --color-kumo-info: var(--color-blue-400, oklch(70.7% 0.165 254.624));
     --color-kumo-warning-tint: var(
       --color-yellow-700,
       oklch(55.4% 0.135 66.442)
     );
-    --color-kumo-warning: var(--color-yellow-900, oklch(42.1% 0.095 57.708));
+    --color-kumo-warning: var(--color-yellow-400, oklch(85.2% 0.199 91.936));
     --color-kumo-danger-tint: var(--color-red-900, oklch(39.6% 0.141 25.723));
-    --color-kumo-danger: var(--color-red-900, oklch(39.6% 0.141 25.723));
+    --color-kumo-danger: var(--color-red-400, oklch(70.4% 0.191 22.216));
     --color-kumo-success-tint: var(
       --color-emerald-900,
       oklch(37.8% 0.077 168.94)
     );
-    --color-kumo-success: var(--color-green-900, oklch(39.3% 0.095 152.535));
+    --color-kumo-success: var(--color-emerald-400, oklch(76.5% 0.177 163.223));
+    --color-kumo-banner-info: oklch(37.9% 0.146 265.522 / 0.5);
+    --color-kumo-banner-warning: oklch(55.4% 0.135 66.442 / 0.5);
     --color-kumo-badge-red: var(--color-red-700, oklch(50.5% 0.213 27.518));
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-orange-subtle: var(

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -10,6 +10,33 @@
   --svelte-orange: oklch(0.6385 0.1991 34.99);
 }
 
+:where(
+    a[href],
+    button,
+    input[type="button"],
+    input[type="checkbox"],
+    input[type="radio"],
+    input[type="submit"],
+    input[type="reset"],
+    label[for],
+    select,
+    summary,
+    [role="button"],
+    [role="link"],
+    [role="menuitem"],
+    [role="menuitemcheckbox"],
+    [role="menuitemradio"],
+    [role="option"],
+    [role="tab"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="switch"]
+  ):where([data-kumo-component], [data-kumo-part]):where(:not(:disabled)):where(:not([disabled])):where(
+    :not([aria-disabled="true"])
+  ):where(:not([data-disabled])) {
+  cursor: pointer;
+}
+
 /* Scroll-fade: gradient masks that appear on the edges of a horizontally
    scrollable container based on scroll position. Activated by the
    data-overflowing attribute set from Tabs overflow measurement. */

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -827,8 +827,8 @@ kbd,
   table-layout: fixed;
   border-collapse: collapse;
   margin: 3rem 0 2rem;
-  font-size: 1rem;
-  line-height: 1.5;
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
 }
 
 .kumo-prose :where(table):not(:where(.not-prose, .not-prose *)) :where(th:first-child, td:first-child) {

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -822,19 +822,44 @@ kbd,
 }
 
 /* Table styling */
-.kumo-prose :where(table) {
+.kumo-prose :where(table):not(:where(.not-prose, .not-prose *)) {
   width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: 3rem 0 2rem;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.kumo-prose :where(table):not(:where(.not-prose, .not-prose *)) :where(th:first-child, td:first-child) {
+  width: 24%;
 }
 
 /* Table header border */
-.kumo-prose :where(thead) {
-  border-bottom-color: var(--color-kumo-hairline);
+.kumo-prose :where(thead):not(:where(.not-prose, .not-prose *)) {
+  border-bottom: 1px solid var(--color-kumo-hairline);
 }
 
 /* Table header cells */
-.kumo-prose :where(thead th) {
+.kumo-prose :where(thead th):not(:where(.not-prose, .not-prose *)) {
   color: var(--text-color-kumo-strong);
   font-weight: 600;
+  padding: 0 0 1.5rem;
+  text-align: left;
+  vertical-align: bottom;
+}
+
+.kumo-prose :where(tbody tr):not(:where(.not-prose, .not-prose *)) {
+  border-bottom: 1px solid var(--color-kumo-hairline);
+}
+
+.kumo-prose :where(tbody tr:last-child):not(:where(.not-prose, .not-prose *)) {
+  border-bottom: 0;
+}
+
+.kumo-prose :where(tbody td):not(:where(.not-prose, .not-prose *)) {
+  padding: 1.25rem 0;
+  vertical-align: middle;
 }
 
 /* Blockquote */

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -824,15 +824,10 @@ kbd,
 /* Table styling */
 .kumo-prose :where(table):not(:where(.not-prose, .not-prose *)) {
   width: 100%;
-  table-layout: fixed;
   border-collapse: collapse;
   margin: 3rem 0 2rem;
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
-}
-
-.kumo-prose :where(table):not(:where(.not-prose, .not-prose *)) :where(th:first-child, td:first-child) {
-  width: 24%;
 }
 
 /* Table header border */
@@ -1008,6 +1003,48 @@ pre.shiki {
   border: 0 !important;
   margin: 0 !important;
   padding: 0 1rem 0 0 !important;
+}
+
+.kumo-shiki .line {
+  min-height: 1.625em;
+  padding-right: 1rem;
+}
+
+.kumo-shiki .line-highlighted {
+  margin-right: -1rem;
+  margin-left: -1rem;
+  padding-right: 2rem;
+  padding-left: 1rem;
+  background-color: var(--kumo-code-highlight-bg, color-mix(in srgb, var(--color-kumo-brand) 12%, transparent)) !important;
+}
+
+.kumo-shiki-line-numbers .kumo-shiki pre {
+  counter-reset: kumo-code-line;
+  padding-left: 0 !important;
+}
+
+.kumo-shiki-line-numbers .kumo-shiki code {
+  padding-right: 0 !important;
+}
+
+.kumo-shiki-line-numbers .kumo-shiki .line {
+  counter-increment: kumo-code-line;
+  display: grid;
+  grid-template-columns: 3.5rem 1fr;
+  min-width: max-content;
+}
+
+.kumo-shiki-line-numbers .kumo-shiki .line::before {
+  content: counter(kumo-code-line);
+  padding-right: 1rem;
+  color: var(--text-color-kumo-placeholder);
+  text-align: right;
+  user-select: none;
+}
+
+.kumo-shiki-line-numbers .kumo-shiki .line-highlighted {
+  margin-left: 0;
+  padding-left: 0;
 }
 
 [data-mode="dark"] .kumo-shiki span:not(.line-highlighted) {

--- a/packages/kumo-svelte/src/routes/blocks/resource-list/+page.md
+++ b/packages/kumo-svelte/src/routes/blocks/resource-list/+page.md
@@ -5,7 +5,6 @@ sourceFile: "blocks/resource-list"
 ---
 
 <script>
-  import Callout from '$lib/docs/Callout.svelte';
   import ComponentExample from '$lib/docs/ComponentExample.svelte';
   import ComponentSection from '$lib/docs/ComponentSection.svelte';
 </script>
@@ -46,9 +45,10 @@ npx kumo-svelte add ResourceListPage
 </script>
 ```
 
-<Callout type="info">
-  <strong>Why blocks?</strong> Blocks give you full ownership of the code, allowing you to customize layouts to fit your specific needs. They're ideal for page-level patterns that often need project-specific modifications.
-</Callout>
+> <strong>Why blocks?</strong> Blocks give you full ownership of the code,
+> allowing you to customize layouts to fit your specific needs.
+> They're ideal for page-level patterns that often need project-specific
+> modifications.
 
 </ComponentSection>
 

--- a/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
@@ -18,7 +18,7 @@ The timeseries chart is a specialized chart for displaying time-based data.
 
 <ComponentSection>
 
-### Basic Line Chart
+## Basic Line Chart
 
 A simple line chart displaying multiple data series over time.
 
@@ -28,7 +28,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Custom X-Axis Label Format
+## Custom X-Axis Label Format
 
   Use the <code>xAxisTickLabelFormat</code> prop to control how x-axis tick
   labels are rendered. The formatter receives the raw timestamp in milliseconds
@@ -40,7 +40,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Gradient Fill
+## Gradient Fill
 
   Set <code>gradient</code> to <code>true</code> to render a vertical gradient
   fill beneath each line series. The fill fades from the series color at the top
@@ -53,7 +53,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Incomplete Data
+## Incomplete Data
 
   Use the <code>incomplete</code> prop to indicate regions where data may be
   incomplete or still being collected.
@@ -64,7 +64,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Time Range Selection
+## Time Range Selection
 
   Enable time range selection by providing the <code>onTimeRangeChange</code>
   callback. Users can click and drag on the chart to select a time range.
@@ -75,18 +75,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Bar Chart
-
-  Set <code>type="bar"</code> to render series as stacked bars instead of lines.
-  All other props — axes, tooltips, colors — work identically.
-
-<ComponentExample demo="BarChartDemo" />
-
-</ComponentSection>
-
-<ComponentSection>
-
-### Tooltip Cursor Tracking
+## Tooltip Cursor Tracking
 
   Use <code>tooltipFollowCursor</code> to choose whether the tooltip follows both cursor axes or only tracks the x position.
   Set <code>tooltipMode="single"</code> when dense charts should show only the series nearest to the pointer.
@@ -97,7 +86,7 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Tooltip Boundary
+## Tooltip Boundary
 
   Set <code>tooltipBoundary</code> to keep the native tooltip within the chart container instead of letting it overflow the visual frame.
 
@@ -107,7 +96,18 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
-### Loading State
+## Bar Chart
+
+  Set <code>type="bar"</code> to render series as stacked bars instead of lines.
+  All other props — axes, tooltips, colors — work identically.
+
+<ComponentExample demo="BarChartDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Loading State
 
   Set <code>loading</code> to <code>true</code> to display an animated sine-wave
   skeleton while data is being fetched. The chart canvas is hidden until loading

--- a/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
@@ -86,6 +86,27 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
+### Tooltip Cursor Tracking
+
+  Use <code>tooltipFollowCursor</code> to choose whether the tooltip follows both cursor axes or only tracks the x position.
+  Set <code>tooltipMode="single"</code> when dense charts should show only the series nearest to the pointer.
+
+<ComponentExample demo="TooltipFollowCursorDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+### Tooltip Boundary
+
+  Set <code>tooltipBoundary</code> to keep the native tooltip within the chart container instead of letting it overflow the visual frame.
+
+<ComponentExample demo="TooltipBoundaryDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
 ### Loading State
 
   Set <code>loading</code> to <code>true</code> to display an animated sine-wave

--- a/packages/kumo-svelte/src/routes/colors/+page.md
+++ b/packages/kumo-svelte/src/routes/colors/+page.md
@@ -4,6 +4,7 @@ description: "Kumo uses semantic color tokens that automatically adapt to light 
 ---
 
 <script>
+  import { Badge } from 'kumo-svelte';
   import Callout from '$lib/docs/Callout.svelte';
   import ComponentExample from '$lib/docs/ComponentExample.svelte';
   import ComponentSection from '$lib/docs/ComponentSection.svelte';
@@ -321,7 +322,7 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
     </thead>
     <tbody>
       <tr>
-        <td><code>kumo-hairline</code><div class="not-prose my-4 rounded-lg border border-kumo-hairline bg-kumo-canvas p-4 text-sm text-kumo-subtle">New</div></td>
+        <td><code>kumo-hairline</code><span class="not-prose ml-2 inline-flex align-middle"><Badge variant="blue">New</Badge></span></td>
         <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
       </tr>
       <tr>

--- a/packages/kumo-svelte/src/routes/colors/+page.md
+++ b/packages/kumo-svelte/src/routes/colors/+page.md
@@ -200,7 +200,7 @@ Surfaces establish depth and layering in the UI. Use them in order from the oute
 
 ### Semantic Status Colors
 
-Each status color comes in two variants: a solid color for icons and indicators, and a `-tint` variant for background fills behind content (i.e. `Badge` or `Banner`).
+Each status color comes in two variants: a solid color for icons and indicators, and a `-tint` variant for background fills behind content such as `Badge` or `Banner`. Pair status text with the same semantic family so contrast stays consistent in light and dark mode.
 
   <table>
     <colgroup>
@@ -234,6 +234,8 @@ Each status color comes in two variants: a solid color for icons and indicators,
   </table>
 
 Use the solid token on icons, status dots, borders and rings. Banners and badges use the `-tint` variant with varying opacity values for the different instances.
+
+<ComponentExample demo="StatusBannerDemo" />
 
 ```svelte
 // Banner with tinted background and solid icon

--- a/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
+++ b/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
@@ -114,6 +114,48 @@ The `size` prop on `Autocomplete.InputGroup` supports four variants matching the
 
 <ComponentSection>
 
+## Filtering
+
+Filtering is case- and accent-insensitive by default, powered by
+`Intl.Collator` under the hood. For string items, no custom `filter` is needed.
+
+When filtering on a property of object items, use `Autocomplete.useFilter()` to
+preserve the built-in accent-insensitive matching:
+
+```svelte
+<script lang="ts">
+  import { Autocomplete } from "kumo-svelte";
+
+  const { contains } = Autocomplete.useFilter();
+
+  const languages = [
+    { value: "pt", label: "Portuguese", emoji: "🇵🇹" },
+    { value: "es", label: "Spanish", emoji: "🇪🇸" }
+  ];
+
+  const filter = (item, query) => contains(item.label, query);
+</script>
+
+<Autocomplete items={languages} {filter}>
+  <!-- ... -->
+</Autocomplete>
+```
+
+To disable filtering entirely (for example, when results come from a server),
+pass `filter={null}`:
+
+```svelte
+<Autocomplete items={results} filter={null}>
+  <!-- ... -->
+</Autocomplete>
+```
+
+</ComponentSection>
+
+<!-- API Reference -->
+
+<ComponentSection>
+
 ## API Reference
 
 ### Autocomplete

--- a/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
+++ b/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
@@ -9,9 +9,6 @@ sourceFile: "components/autocomplete"
   import ComponentExample from '$lib/docs/ComponentExample.svelte';
   import ComponentSection from '$lib/docs/ComponentSection.svelte';
   import PropsTable from '$lib/docs/PropsTable.svelte';
-
-  const barrelImport = `import { Autocomplete } from "kumo-svelte";`;
-  const granularImport = `import { Autocomplete } from "kumo-svelte";`;
 </script>
 
 <!-- Hero Demo -->
@@ -28,11 +25,15 @@ sourceFile: "components/autocomplete"
 
 ### Barrel
 
-<CodeBlock code={barrelImport} lang="svelte" />
+```typescript
+import { Autocomplete } from 'kumo-svelte';
+```
 
 ### Granular
 
-<CodeBlock code={granularImport} lang="svelte" />
+```typescript
+import { Autocomplete } from 'kumo-svelte/components/autocomplete';
+```
 
 </ComponentSection>
 

--- a/packages/kumo-svelte/src/routes/components/badge/+page.md
+++ b/packages/kumo-svelte/src/routes/components/badge/+page.md
@@ -12,23 +12,27 @@ sourceFile: "components/badge"
 
 <ComponentExample demo="BadgeSemanticVariantsDemo" />
 
+<!-- Installation -->
+
+<ComponentSection>
+
 ## Installation
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Badge } from 'kumo-svelte';
-</script>
+```typescript
+import { Badge } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Badge } from 'kumo-svelte';
-</script>
+```typescript
+import { Badge } from 'kumo-svelte/components/badge';
 ```
+
+</ComponentSection>
+
+<ComponentSection>
 
 ## Usage
 
@@ -65,3 +69,5 @@ Use `appearance="dot"` with `success`, `warning`, `error`, or `neutral` variants
 ## API Reference
 
 <PropsTable component="Badge" />
+
+</ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/banner/+page.md
+++ b/packages/kumo-svelte/src/routes/components/banner/+page.md
@@ -43,8 +43,10 @@ import { Banner } from 'kumo-svelte/components/banner';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { Banner } from "kumo-svelte";
 import { Info } from "phosphor-svelte";
+</script>
 
 <Banner
   icon={Info}

--- a/packages/kumo-svelte/src/routes/components/banner/+page.md
+++ b/packages/kumo-svelte/src/routes/components/banner/+page.md
@@ -24,17 +24,14 @@ sourceFile: "components/banner"
 
 ### Barrel
 
-
-```svelte
-import { Banner } from "kumo-svelte";
+```typescript
+import { Banner } from 'kumo-svelte';
 ```
-
 
 ### Granular
 
-
-```svelte
-import { Banner } from "kumo-svelte";
+```typescript
+import { Banner } from 'kumo-svelte/components/banner';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/banner/+page.md
+++ b/packages/kumo-svelte/src/routes/components/banner/+page.md
@@ -78,6 +78,10 @@ import { Info } from "phosphor-svelte";
 
 <ComponentExample demo="BannerErrorDemo" />
 
+#### Secondary
+
+<ComponentExample demo="BannerSecondaryDemo" />
+
 ### With icon
 
 <ComponentExample demo="BannerWithIconDemo" />

--- a/packages/kumo-svelte/src/routes/components/breadcrumbs/+page.md
+++ b/packages/kumo-svelte/src/routes/components/breadcrumbs/+page.md
@@ -14,13 +14,22 @@ sourceFile: "components/breadcrumbs"
   <ComponentExample demo="BreadcrumbsWithIconsDemo" />
 </ComponentSection>
 
+<!-- Installation -->
+
 <ComponentSection>
 
 ## Installation
 
+### Barrel
 
-```svelte
+```typescript
 import { Breadcrumbs } from 'kumo-svelte';
+```
+
+### Granular
+
+```typescript
+import { Breadcrumbs } from 'kumo-svelte/components/breadcrumbs';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/button/+page.md
+++ b/packages/kumo-svelte/src/routes/components/button/+page.md
@@ -24,19 +24,14 @@ sourceFile: "components/button"
 
 ### Barrel
 
-
-```svelte
-<script lang="ts">
-  import { Button } from 'kumo-svelte';
-</script>
+```typescript
+import { Button, LinkButton, RefreshButton } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Button, LinkButton, RefreshButton } from 'kumo-svelte';
-</script>
+```typescript
+import { Button, LinkButton, RefreshButton } from 'kumo-svelte/components/button';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/checkbox/+page.md
+++ b/packages/kumo-svelte/src/routes/components/checkbox/+page.md
@@ -25,15 +25,14 @@ baseUIComponent: "checkbox"
 
 ### Barrel
 
+```typescript
+import { Checkbox, CheckboxGroup, CheckboxItem, CheckboxLegend } from 'kumo-svelte';
+```
 
-```svelte
-<script lang="ts">
-  import { Checkbox } from 'kumo-svelte';
+### Granular
 
-  let checked = $state(false);
-</script>
-
-<Checkbox label="Accept terms" bind:checked />
+```typescript
+import { Checkbox, CheckboxGroup, CheckboxItem, CheckboxLegend } from 'kumo-svelte/components/checkbox';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/clipboard-text/+page.md
+++ b/packages/kumo-svelte/src/routes/components/clipboard-text/+page.md
@@ -25,20 +25,14 @@ sourceFile: "components/clipboard-text"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { ClipboardText } from 'kumo-svelte';
-</script>
-
-<ClipboardText text="Copy this text" />
+```typescript
+import { ClipboardText } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { ClipboardText } from 'kumo-svelte';
-</script>
+```typescript
+import { ClipboardText } from 'kumo-svelte/components/clipboard-text';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/cloudflare-logo/+page.md
+++ b/packages/kumo-svelte/src/routes/components/cloudflare-logo/+page.md
@@ -127,7 +127,7 @@ A pre-built "Powered by Cloudflare" badge component for footers and attribution.
 Use <code>generateCloudflareLogoSvg()</code> to get copy-paste ready SVG markup for non-React contexts.
 
 
-```svelte
+```ts
 import { generateCloudflareLogoSvg } from "kumo-svelte";
 
 // Generate glyph SVG (cloud only)

--- a/packages/kumo-svelte/src/routes/components/cloudflare-logo/+page.md
+++ b/packages/kumo-svelte/src/routes/components/cloudflare-logo/+page.md
@@ -24,24 +24,14 @@ sourceFile: "components/cloudflare-logo"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { CloudflareLogo } from 'kumo-svelte';
-</script>
-
-<CloudflareLogo />
+```typescript
+import { CloudflareLogo, PoweredByCloudflare } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import {
-    CloudflareLogo,
-    PoweredByCloudflare,
-    generateCloudflareLogoSvg
-  } from 'kumo-svelte';
-</script>
+```typescript
+import { CloudflareLogo, PoweredByCloudflare } from 'kumo-svelte/components/cloudflare-logo';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
+++ b/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
@@ -14,24 +14,22 @@ sourceFile: "components/code-highlighted"
   <ComponentExample demo="CodeHighlightedBasicDemo" />
 </ComponentSection>
 
+<!-- Installation -->
+
 <ComponentSection>
 
 ## Installation
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { CodeHighlighted } from 'kumo-svelte';
-</script>
+```typescript
+import { CodeHighlighted } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { CodeHighlighted } from 'kumo-svelte';
-</script>
+```typescript
+import { CodeHighlighted } from 'kumo-svelte/components/code-highlighted';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
+++ b/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
@@ -20,6 +20,8 @@ sourceFile: "components/code-highlighted"
 
 ## Installation
 
+CodeHighlighted is available from the main package and from the granular code-highlighted entry point.
+
 ### Barrel
 
 ```typescript
@@ -52,27 +54,108 @@ import { CodeHighlighted } from 'kumo-svelte/components/code-highlighted';
 
 <ComponentSection>
 
+## Overview
+
+A Shiki-powered syntax highlighter. Supports common languages with TextMate grammars, dual light/dark themes, and Kumo-styled copy controls.
+
+</ComponentSection>
+
+<ComponentSection>
+
 ## Examples
 
-### TypeScript
+### Languages
+
+CodeHighlighted supports common Shiki languages. Only use the languages you need.
+
+#### Basic
 
 <ComponentExample demo="CodeHighlightedBasicDemo" />
 
-### Copy Button
-
-<ComponentExample demo="CodeHighlightedCopyButtonDemo" />
-
-### Language Variants
-
-Use supported Shiki languages for framework, data, shell, and config examples.
+#### TypeScript, Svelte, Bash, JSON, and CSS
 
 <ComponentExample demo="CodeHighlightedLanguageVariantsDemo" />
 
-### Language Aliases
+### Copy Button
 
-Common aliases such as `js`, `ts`, `md`, and `yml` normalize to the matching highlighter language.
+Add a copy-to-clipboard button with `showCopyButton`.
+
+<ComponentExample demo="CodeHighlightedCopyButtonDemo" />
+
+### Highlight Lines
+
+Emphasize specific lines with `highlightLines`. Line numbers are 1-indexed.
+
+<ComponentExample demo="CodeHighlightedHighlightLinesDemo" />
+
+### Custom Highlight Color
+
+Customize the highlight color with the `--kumo-code-highlight-bg` CSS variable.
+
+<ComponentExample demo="CodeHighlightedCustomHighlightColorDemo" />
+
+### Line Numbers
+
+Display line numbers with `showLineNumbers`.
+
+<ComponentExample demo="CodeHighlightedLineNumbersDemo" />
+
+### Full Featured
+
+Combine line numbers, highlighted lines, and a copy button for a complete code display.
+
+<ComponentExample demo="CodeHighlightedFullFeaturedDemo" />
+
+### Shared Blocks
+
+Render multiple code blocks together for related snippets.
+
+<ComponentExample demo="CodeHighlightedSharedBlocksDemo" />
+
+### Internationalization
+
+Customize copy button labels with the `labels` prop.
+
+<ComponentExample demo="CodeHighlightedLabelsDemo" />
+
+### Svelte Example
 
 <ComponentExample demo="CodeHighlightedAliasesDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Themes
+
+CodeHighlighted uses fixed themes for visual consistency across Kumo Svelte applications:
+
+- Light mode: `github-light`
+- Dark mode: `vesper`
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Bundle Size
+
+Shiki is used only by CodeHighlighted and docs code blocks. Applications that do not render CodeHighlighted avoid the syntax-highlighting work for this component.
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Migration from Code and CodeBlock
+
+Use CodeHighlighted for syntax-highlighted blocks. Keep `Code` for inline code and simple text snippets.
+
+```svelte
+<!-- Before -->
+<CodeBlock code="const x = 1;" lang="ts" />
+
+<!-- After -->
+<CodeHighlighted code="const x = 1;" lang="ts" />
+```
 
 </ComponentSection>
 

--- a/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
+++ b/packages/kumo-svelte/src/routes/components/code-highlighted/+page.md
@@ -64,6 +64,18 @@ sourceFile: "components/code-highlighted"
 
 <ComponentExample demo="CodeHighlightedCopyButtonDemo" />
 
+### Language Variants
+
+Use supported Shiki languages for framework, data, shell, and config examples.
+
+<ComponentExample demo="CodeHighlightedLanguageVariantsDemo" />
+
+### Language Aliases
+
+Common aliases such as `js`, `ts`, `md`, and `yml` normalize to the matching highlighter language.
+
+<ComponentExample demo="CodeHighlightedAliasesDemo" />
+
 </ComponentSection>
 
 <ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/collapsible/+page.md
+++ b/packages/kumo-svelte/src/routes/components/collapsible/+page.md
@@ -25,29 +25,14 @@ baseUIComponent: "collapsible"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import {
-    Collapsible
-  } from 'kumo-svelte';
-</script>
-
-<Collapsible.Root open>
-  <Collapsible.DefaultTrigger>Show details</Collapsible.DefaultTrigger>
-  <Collapsible.DefaultPanel>
-    Content with border-left accent styling.
-  </Collapsible.DefaultPanel>
-</Collapsible.Root>
+```typescript
+import { Collapsible } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import {
-    Collapsible
-  } from 'kumo-svelte';
-</script>
+```typescript
+import { Collapsible } from 'kumo-svelte/components/collapsible';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/collapsible/+page.md
+++ b/packages/kumo-svelte/src/routes/components/collapsible/+page.md
@@ -109,12 +109,6 @@ Use `Collapsible.Trigger` for full control:
 
 <ComponentExample demo="CollapsibleCustomTriggerDemo" />
 
-### Keep Mounted
-
-Use `keepMounted` on `DefaultPanel` (or `Panel`) to preserve internal state — such as form inputs — when the panel is collapsed:
-
-<ComponentExample demo="CollapsibleKeepMountedDemo" />
-
 ### Accordion Pattern
 
 Control which item is open to create an accordion where only one item can be expanded at a time:
@@ -131,7 +125,7 @@ Control which item is open to create an accordion where only one item can be exp
 
 | Component | Description |
 |-----------|-------------|
-| `Collapsible.Root` | Manages open state. Pass `open` and `onOpenChange` for controlled mode, or use `bind:open`. |
+| `Collapsible.Root` | Manages open state. Pass `open` and `onOpenChange` for controlled mode. |
 | `Collapsible.Trigger` | Button that toggles visibility. |
 | `Collapsible.Panel` | Container for collapsible content. |
 | `Collapsible.DefaultTrigger` | Pre-styled trigger with text label and animated caret icon. |

--- a/packages/kumo-svelte/src/routes/components/combobox/+page.md
+++ b/packages/kumo-svelte/src/routes/components/combobox/+page.md
@@ -25,19 +25,14 @@ baseUIComponent: "combobox"
 
 ### Barrel
 
-
-```svelte
-<script lang="ts">
-  import { Combobox } from 'kumo-svelte';
-</script>
+```typescript
+import { Combobox } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Combobox } from 'kumo-svelte';
-</script>
+```typescript
+import { Combobox } from 'kumo-svelte/components/combobox';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/combobox/+page.md
+++ b/packages/kumo-svelte/src/routes/components/combobox/+page.md
@@ -186,6 +186,46 @@ Display validation errors with the error prop.
 
 <ComponentSection>
 
+## Filtering
+
+Filtering is case- and accent-insensitive by default, powered by
+`Intl.Collator` under the hood. For string items, no custom `filter` is needed.
+
+When filtering on a property of object items, use `Combobox.useFilter()` to
+preserve the built-in accent-insensitive matching:
+
+```svelte
+<script lang="ts">
+  import { Combobox } from "kumo-svelte";
+
+  const { contains } = Combobox.useFilter();
+
+  const languages = [
+    { value: "pt", label: "Portuguese", emoji: "🇵🇹" },
+    { value: "es", label: "Spanish", emoji: "🇪🇸" }
+  ];
+
+  const filter = (item, query) => contains(item.label, query);
+</script>
+
+<Combobox items={languages} {filter}>
+  <!-- ... -->
+</Combobox>
+```
+
+To disable filtering entirely (for example, when results come from a server),
+pass `filter={null}`:
+
+```svelte
+<Combobox items={results} filter={null}>
+  <!-- ... -->
+</Combobox>
+```
+
+</ComponentSection>
+
+<ComponentSection>
+
 ## Customizing Dropdown Height
 
 

--- a/packages/kumo-svelte/src/routes/components/command-palette/+page.md
+++ b/packages/kumo-svelte/src/routes/components/command-palette/+page.md
@@ -25,18 +25,14 @@ baseUIComponent: "command"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { CommandPalette } from 'kumo-svelte';
-</script>
+```typescript
+import { CommandPalette } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { CommandPalette } from 'kumo-svelte/components/command-palette';
-</script>
+```typescript
+import { CommandPalette } from 'kumo-svelte/components/command-palette';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/date-picker/+page.md
+++ b/packages/kumo-svelte/src/routes/components/date-picker/+page.md
@@ -23,21 +23,14 @@ sourceFile: "components/date-picker"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { DatePicker, type DateRange } from 'kumo-svelte';
-</script>
+```typescript
+import { DatePicker } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import {
-    DatePicker,
-    type DateRange
-  } from 'kumo-svelte';
-</script>
+```typescript
+import { DatePicker } from 'kumo-svelte/components/date-picker';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/dialog/+page.md
+++ b/packages/kumo-svelte/src/routes/components/dialog/+page.md
@@ -25,15 +25,14 @@ baseUIComponent: "dialog"
 
 ### Barrel
 
-```svelte
-import { Dialog } from "kumo-svelte";
+```typescript
+import { Dialog } from 'kumo-svelte';
 ```
-
 
 ### Granular
 
-```svelte
-import { Dialog } from "kumo-svelte";
+```typescript
+import { Dialog } from 'kumo-svelte/components/dialog';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/dropdown/+page.md
+++ b/packages/kumo-svelte/src/routes/components/dropdown/+page.md
@@ -25,14 +25,14 @@ bitsUIComponent: "dropdown-menu"
 
 ### Barrel
 
-```svelte
-import { DropdownMenu } from "kumo-svelte";
+```typescript
+import { DropdownMenu } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { DropdownMenu } from "kumo-svelte";
+```typescript
+import { DropdownMenu } from 'kumo-svelte/components/dropdown-menu';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/empty/+page.md
+++ b/packages/kumo-svelte/src/routes/components/empty/+page.md
@@ -22,8 +22,16 @@ sourceFile: "components/empty"
 
 ## Installation
 
-```svelte
-import { Empty } from "kumo-svelte";
+### Barrel
+
+```typescript
+import { Empty } from 'kumo-svelte';
+```
+
+### Granular
+
+```typescript
+import { Empty } from 'kumo-svelte/components/empty';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/empty/+page.md
+++ b/packages/kumo-svelte/src/routes/components/empty/+page.md
@@ -43,8 +43,10 @@ import { Empty } from 'kumo-svelte/components/empty';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { Empty } from "kumo-svelte";
 import { Package } from "phosphor-svelte";
+</script>
 
 <Empty
   title="No packages found"

--- a/packages/kumo-svelte/src/routes/components/flow/+page.md
+++ b/packages/kumo-svelte/src/routes/components/flow/+page.md
@@ -24,14 +24,14 @@ sourceFile: "components/flow"
 
 ### Barrel
 
-```svelte
-import { Flow } from "kumo-svelte";
+```typescript
+import { Flow, FlowAnchor, FlowList, FlowNode, FlowParallel, FlowRoot } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { Flow } from "kumo-svelte";
+```typescript
+import { Flow, FlowAnchor, FlowList, FlowNode, FlowParallel, FlowRoot } from 'kumo-svelte/components/flow';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/flow/+page.md
+++ b/packages/kumo-svelte/src/routes/components/flow/+page.md
@@ -52,7 +52,9 @@ The Flow components work together to create directed flow diagrams. Use
 
 
 ```svelte
+<script lang="ts">
 import { Flow } from "kumo-svelte";
+</script>
 
     <Flow>
       <Flow.Node>Step 1</Flow.Node>

--- a/packages/kumo-svelte/src/routes/components/grid/+page.md
+++ b/packages/kumo-svelte/src/routes/components/grid/+page.md
@@ -22,8 +22,16 @@ sourceFile: "components/grid"
 
 ## Installation
 
-```svelte
-import { Grid } from "kumo-svelte";
+### Barrel
+
+```typescript
+import { Grid, GridItem } from 'kumo-svelte';
+```
+
+### Granular
+
+```typescript
+import { Grid, GridItem } from 'kumo-svelte/components/grid';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/input-area/+page.md
+++ b/packages/kumo-svelte/src/routes/components/input-area/+page.md
@@ -24,13 +24,52 @@ sourceFile: "components/input"
 
 ### Barrel
 
+```typescript
+import { InputArea } from 'kumo-svelte';
+```
+
+### Granular
+
+```typescript
+import { InputArea } from 'kumo-svelte/components/input-area';
+```
+
+</ComponentSection>
+
+<!-- Usage -->
+
+<ComponentSection>
+
+## Usage
+
+### With Built-in Field (Recommended)
+
+Use the `label` prop to enable the built-in Field wrapper with label,
+description, and error support.
+
 ```svelte
 <script lang="ts">
-  import { InputArea, Label } from 'kumo-svelte';
+import { InputArea } from 'kumo-svelte';
 </script>
 
-<Label>Description</Label>
-<InputArea placeholder="Describe the rollout..." />
+<InputArea
+  label="Description"
+  placeholder="Enter a description..."
+  description="Provide details about your project"
+/>
+```
+
+### Bare InputArea (Custom Layouts)
+
+For custom form layouts, use InputArea without `label`. Must provide
+`aria-label` or `aria-labelledby` for accessibility.
+
+```svelte
+<script lang="ts">
+import { InputArea } from 'kumo-svelte';
+</script>
+
+<InputArea placeholder="Add notes..." aria-label="Notes" rows={3} />
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/input-group/+page.md
+++ b/packages/kumo-svelte/src/routes/components/input-group/+page.md
@@ -14,23 +14,22 @@ sourceFile: "components/input-group"
   <ComponentExample demo="InputGroupDemo" />
 </ComponentSection>
 
+<!-- Installation -->
+
 <ComponentSection>
 
 ## Installation
 
 ### Barrel
 
-
-```svelte
-import { InputGroup } from "kumo-svelte";
+```typescript
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupSuffix } from 'kumo-svelte';
 ```
-
 
 ### Granular
 
-
-```svelte
-import { InputGroup } from "kumo-svelte";
+```typescript
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupSuffix } from 'kumo-svelte/components/input-group';
 ```
 
 </ComponentSection>
@@ -49,8 +48,8 @@ Pass the `label` prop to InputGroup to enable the built-in Field wrapper with
 
 
 ```svelte
-<script>
-  import { MagnifyingGlass } from "phosphor-svelte";
+<script lang="ts">
+import { MagnifyingGlass } from "phosphor-svelte";
   import { InputGroup } from "kumo-svelte";
 </script>
 
@@ -70,8 +69,8 @@ For custom form layouts, use InputGroup without `label`. Must provide
 
 
 ```svelte
-<script>
-  import { MagnifyingGlass } from "phosphor-svelte";
+<script lang="ts">
+import { MagnifyingGlass } from "phosphor-svelte";
   import { InputGroup } from "kumo-svelte";
 </script>
 
@@ -164,7 +163,7 @@ Various input states including error, disabled, and with description. Pass `labe
 
 ## API Reference
 
-### `InputGroup`
+### InputGroup
 
 
 The root container that provides context to all child components. Accepts
@@ -173,7 +172,7 @@ The root container that provides context to all child components. Accepts
 
 <PropsTable component="InputGroup" />
 
-### `InputGroup.Input`
+### InputGroup.Input
 
 
 The text input element. Inherits `size`, `disabled`, and `error` from
@@ -182,7 +181,7 @@ The text input element. Inherits `size`, `disabled`, and `error` from
 
 <PropsTable component="InputGroup.Input" />
 
-### `InputGroup.Addon`
+### InputGroup.Addon
 
 
 Container for icons, text, or compact buttons positioned at the start or end
@@ -190,7 +189,7 @@ Container for icons, text, or compact buttons positioned at the start or end
 
 <PropsTable component="InputGroup.Addon" />
 
-### `InputGroup.Button`
+### InputGroup.Button
 
 
 Button for secondary actions like toggle, copy, or help. Renders inside an
@@ -198,7 +197,7 @@ Button for secondary actions like toggle, copy, or help. Renders inside an
 
 <PropsTable component="InputGroup.Button" />
 
-### `InputGroup.Suffix`
+### InputGroup.Suffix
 
 
 Inline text that flows seamlessly next to the typed value (e.g.,

--- a/packages/kumo-svelte/src/routes/components/input/+page.md
+++ b/packages/kumo-svelte/src/routes/components/input/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/input"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Input } from 'kumo-svelte';
-</script>
+```typescript
+import { Input, Textarea } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Input } from 'kumo-svelte';
-</script>
+```typescript
+import { Input, Textarea } from 'kumo-svelte/components/input';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/label/+page.md
+++ b/packages/kumo-svelte/src/routes/components/label/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/label"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Label } from 'kumo-svelte';
-</script>
+```typescript
+import { Label } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Label } from 'kumo-svelte';
-</script>
+```typescript
+import { Label } from 'kumo-svelte/components/label';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/layer-card/+page.md
+++ b/packages/kumo-svelte/src/routes/components/layer-card/+page.md
@@ -24,14 +24,14 @@ sourceFile: "components/layer-card"
 
 ### Barrel
 
-```svelte
-import { LayerCard } from "kumo-svelte";
+```typescript
+import { LayerCard } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { LayerCard } from "kumo-svelte";
+```typescript
+import { LayerCard } from 'kumo-svelte/components/layer-card';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/layer-card/+page.md
+++ b/packages/kumo-svelte/src/routes/components/layer-card/+page.md
@@ -43,7 +43,9 @@ import { LayerCard } from 'kumo-svelte/components/layer-card';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { LayerCard } from "kumo-svelte";
+</script>
 
     <LayerCard class="w-[250px]">
       <LayerCard.Secondary>Documentation</LayerCard.Secondary>
@@ -59,7 +61,9 @@ import { LayerCard } from "kumo-svelte";
 
 
 ```svelte
+<script lang="ts">
 import { LayerCard } from "kumo-svelte";
+</script>
 
     <LayerCard class="w-[250px] p-4">
       Learn how to use Kumo components

--- a/packages/kumo-svelte/src/routes/components/link/+page.md
+++ b/packages/kumo-svelte/src/routes/components/link/+page.md
@@ -23,18 +23,14 @@ sourceFile: "components/link"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Link } from 'kumo-svelte';
-</script>
+```typescript
+import { Link, LinkExternalIcon } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Link, LinkExternalIcon } from 'kumo-svelte';
-</script>
+```typescript
+import { Link, LinkExternalIcon } from 'kumo-svelte/components/link';
 ```
 
 </ComponentSection>
@@ -51,7 +47,7 @@ The default Link component renders an underlined anchor with primary color styli
 
 ```svelte
 <script lang="ts">
-  import { Link } from 'kumo-svelte';
+import { Link } from 'kumo-svelte';
 </script>
 
 <p>
@@ -65,7 +61,7 @@ Use `LinkExternalIcon` to indicate links that open in a new tab.
 
 ```svelte
 <script lang="ts">
-  import { Link, LinkExternalIcon } from 'kumo-svelte';
+import { Link, LinkExternalIcon } from 'kumo-svelte';
 </script>
 
 <Link
@@ -84,7 +80,7 @@ with `href`.
 
 ```svelte
 <script lang="ts">
-  import { Link } from 'kumo-svelte';
+import { Link } from 'kumo-svelte';
 </script>
 
 <Link href="/dashboard" variant="inline">Dashboard</Link>
@@ -116,12 +112,6 @@ The `current` variant inherits color from its parent, useful for links within
 colored contexts like alerts.
 
 <ComponentExample demo="LinkCurrentVariantDemo" />
-
-### Plain Variant
-
-Use the `plain` variant for compact navigation surfaces where underlines would add visual noise.
-
-<ComponentExample demo="LinkPlainVariantDemo" />
 
 </ComponentSection>
 

--- a/packages/kumo-svelte/src/routes/components/link/+page.md
+++ b/packages/kumo-svelte/src/routes/components/link/+page.md
@@ -117,6 +117,12 @@ colored contexts like alerts.
 
 <ComponentExample demo="LinkCurrentVariantDemo" />
 
+### Plain Variant
+
+Use the `plain` variant for compact navigation surfaces where underlines would add visual noise.
+
+<ComponentExample demo="LinkPlainVariantDemo" />
+
 </ComponentSection>
 
 <!-- API Reference -->

--- a/packages/kumo-svelte/src/routes/components/loader/+page.md
+++ b/packages/kumo-svelte/src/routes/components/loader/+page.md
@@ -24,22 +24,14 @@ sourceFile: "components/loader"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Loader } from 'kumo-svelte';
-</script>
-
-<Loader />
+```typescript
+import { Loader } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Loader } from 'kumo-svelte';
-</script>
-
-<Loader />
+```typescript
+import { Loader } from 'kumo-svelte/components/loader';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/menu-bar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/menu-bar/+page.md
@@ -43,8 +43,10 @@ import { MenuBar } from 'kumo-svelte/components/menu-bar';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { MenuBar } from "kumo-svelte";
 import { TextB } from "phosphor-svelte";
+</script>
 
 <MenuBar
   options={[

--- a/packages/kumo-svelte/src/routes/components/menu-bar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/menu-bar/+page.md
@@ -24,14 +24,14 @@ sourceFile: "components/menubar"
 
 ### Barrel
 
-```svelte
-import { MenuBar } from "kumo-svelte";
+```typescript
+import { MenuBar } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { MenuBar } from "kumo-svelte";
+```typescript
+import { MenuBar } from 'kumo-svelte/components/menu-bar';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/meter/+page.md
+++ b/packages/kumo-svelte/src/routes/components/meter/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/meter"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Meter } from 'kumo-svelte';
-</script>
+```typescript
+import { Meter } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Meter } from 'kumo-svelte';
-</script>
+```typescript
+import { Meter } from 'kumo-svelte/components/meter';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/pagination/+page.md
+++ b/packages/kumo-svelte/src/routes/components/pagination/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/pagination"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Pagination } from 'kumo-svelte';
-</script>
+```typescript
+import { Pagination, PaginationControls, PaginationInfo, PaginationPageSize, PaginationSeparator } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Pagination } from 'kumo-svelte';
-</script>
+```typescript
+import { Pagination, PaginationControls, PaginationInfo, PaginationPageSize, PaginationSeparator } from 'kumo-svelte/components/pagination';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/popover/+page.md
+++ b/packages/kumo-svelte/src/routes/components/popover/+page.md
@@ -25,14 +25,14 @@ baseUIComponent: "popover"
 
 ### Barrel
 
-```svelte
-import { Popover } from "kumo-svelte";
+```typescript
+import { Popover, PopoverClose, PopoverContent, PopoverDescription, PopoverRoot, PopoverTitle, PopoverTrigger } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { Popover } from "kumo-svelte/components/popover";
+```typescript
+import { Popover, PopoverClose, PopoverContent, PopoverDescription, PopoverRoot, PopoverTitle, PopoverTrigger } from 'kumo-svelte/components/popover';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/radio/+page.md
+++ b/packages/kumo-svelte/src/routes/components/radio/+page.md
@@ -25,14 +25,14 @@ baseUIComponent: "radio-group"
 
 ### Barrel
 
-```svelte
-import { Radio } from "kumo-svelte";
+```typescript
+import { Radio, RadioGroup, RadioItem, RadioLegend } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { Radio } from "kumo-svelte";
+```typescript
+import { Radio, RadioGroup, RadioItem, RadioLegend } from 'kumo-svelte/components/radio';
 ```
 
 </ComponentSection>
@@ -44,12 +44,14 @@ import { Radio } from "kumo-svelte";
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { Radio } from "kumo-svelte";
+</script>
 
-    <Radio.Group legend="Choose an option" defaultValue="a">
-      <Radio.Item label="Option A" value="a" />
-      <Radio.Item label="Option B" value="b" />
-    </Radio.Group>
+<Radio.Group legend="Choose an option" defaultValue="a">
+  <Radio.Item label="Option A" value="a" />
+  <Radio.Item label="Option B" value="b" />
+</Radio.Group>
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/select/+page.md
+++ b/packages/kumo-svelte/src/routes/components/select/+page.md
@@ -25,19 +25,14 @@ baseUIComponent: "select"
 
 ### Barrel
 
-
-```svelte
-<script lang="ts">
-  import { Select } from 'kumo-svelte';
-</script>
+```typescript
+import { Select } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Select } from 'kumo-svelte';
-</script>
+```typescript
+import { Select } from 'kumo-svelte/components/select';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/sensitive-input/+page.md
+++ b/packages/kumo-svelte/src/routes/components/sensitive-input/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/sensitive-input"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { SensitiveInput } from 'kumo-svelte';
-</script>
+```typescript
+import { SensitiveInput } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { SensitiveInput } from 'kumo-svelte';
-</script>
+```typescript
+import { SensitiveInput } from 'kumo-svelte/components/sensitive-input';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/sidebar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/sidebar/+page.md
@@ -28,11 +28,6 @@ sourceFile: "components/sidebar"
     </Sidebar.Content>
   </Sidebar>
 </Sidebar.Provider>`;
-
-  const installBarrel = `import { Sidebar } from "kumo-svelte";`;
-
-  const installGranular = `import { Sidebar } from "kumo-svelte/components/sidebar";`;
-
   const usageCode = `<script lang="ts">
   import { Sidebar } from 'kumo-svelte';
   import { Code, Gear, House } from 'phosphor-svelte';
@@ -166,11 +161,15 @@ sourceFile: "components/sidebar"
 
 ### Barrel
 
-<CodeBlock code={installBarrel} lang="ts" />
+```typescript
+import { Sidebar } from 'kumo-svelte';
+```
 
 ### Granular
 
-<CodeBlock code={installGranular} lang="ts" />
+```typescript
+import { Sidebar } from 'kumo-svelte/components/sidebar';
+```
 
 </ComponentSection>
 
@@ -268,47 +267,47 @@ sourceFile: "components/sidebar"
 
 ## API Reference
 
-### `Sidebar`
+### Sidebar
 
 The main sidebar container. Renders as `<aside>` on desktop and as a dialog sheet on mobile.
 
 <PropsTable component="Sidebar" />
 
-### `Sidebar.Provider`
+### Sidebar.Provider
 
 Context provider managing expand/collapse state and mobile detection.
 
 <PropsTable component="Sidebar.Provider" />
 
-### `Sidebar.Content`
+### Sidebar.Content
 
 Scrollable middle section (`flex-1 overflow-y-auto`). Use `Header` / `Footer` to pin content above or below this scroll area.
 
-### `Sidebar.MenuButton`
+### Sidebar.MenuButton
 
 Primary interactive element. Supports icons, active state, links, and auto-tooltip when collapsed.
 
 <PropsTable component="Sidebar.MenuButton" />
 
-### `Sidebar.MenuSubButton`
+### Sidebar.MenuSubButton
 
 Button inside a sub-menu for nested navigation.
 
 <PropsTable component="Sidebar.MenuSubButton" />
 
-### `Sidebar.Trigger`
+### Sidebar.Trigger
 
 Button that toggles provider open state.
 
-### `Sidebar.ResizeHandle`
+### Sidebar.ResizeHandle
 
 Keyboard and pointer resize control for resizable sidebars.
 
-### `Sidebar.SlidingViews`
+### Sidebar.SlidingViews
 
 Container for keyed sliding sidebar panels.
 
-### `Sidebar.SlidingView`
+### Sidebar.SlidingView
 
 Panel rendered when its `value` matches the parent `activeKey`.
 

--- a/packages/kumo-svelte/src/routes/components/sidebar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/sidebar/+page.md
@@ -1,6 +1,6 @@
 ---
 title: "Sidebar"
-description: "A composable sidebar navigation component with collapsible groups, icon-only mode, and responsive mobile support."
+description: "A composable sidebar navigation component with contained layouts, peeking, sliding views, resizing, icon-only mode, and responsive mobile support."
 sourceFile: "components/sidebar"
 ---
 
@@ -85,14 +85,20 @@ sourceFile: "components/sidebar"
   </Sidebar>
 </Sidebar.Provider>`;
 
-  const collapsibleCode = `<Sidebar.Group collapsible defaultOpen>
-  <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
-  <Sidebar.GroupContent>
-    <Sidebar.Menu>
-      <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
-    </Sidebar.Menu>
-  </Sidebar.GroupContent>
-</Sidebar.Group>`;
+  const collapsibleCode = `<Sidebar.MenuItem>
+  <Sidebar.Collapsible defaultOpen>
+    <Sidebar.CollapsibleTrigger>
+      <Sidebar.MenuButton icon={Code}>
+        Compute <Sidebar.MenuChevron />
+      </Sidebar.MenuButton>
+    </Sidebar.CollapsibleTrigger>
+    <Sidebar.CollapsibleContent>
+      <Sidebar.MenuSub>
+        <Sidebar.MenuSubButton>Workers</Sidebar.MenuSubButton>
+      </Sidebar.MenuSub>
+    </Sidebar.CollapsibleContent>
+  </Sidebar.Collapsible>
+</Sidebar.MenuItem>`;
 
   const toggleCode = `<Sidebar.MenuButton icon={House} tooltip="Home" active>
   Home
@@ -107,7 +113,6 @@ sourceFile: "components/sidebar"
     <AccountSwitcher />
   </Sidebar.Header>
   <Sidebar.Content>
-    <Sidebar.Input placeholder="Quick search..." shortcut="⌘K" />
     <Sidebar.Group>
       <Sidebar.Menu>
         <Sidebar.MenuButton icon={Lock}>
@@ -126,6 +131,23 @@ sourceFile: "components/sidebar"
   <Sidebar>
     <Sidebar.Content>...</Sidebar.Content>
     <Sidebar.ResizeHandle />
+  </Sidebar>
+</Sidebar.Provider>`;
+
+  const peekingCode = `<Sidebar.Provider defaultOpen={false} peekable contained>
+  <Sidebar>
+    <Sidebar.Content>
+      <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
+    </Sidebar.Content>
+  </Sidebar>
+</Sidebar.Provider>`;
+
+  const slidingCode = `<Sidebar.Provider contained>
+  <Sidebar>
+    <Sidebar.SlidingViews activeKey={view}>
+      <Sidebar.SlidingView value="overview">...</Sidebar.SlidingView>
+      <Sidebar.SlidingView value="settings">...</Sidebar.SlidingView>
+    </Sidebar.SlidingViews>
   </Sidebar>
 </Sidebar.Provider>`;
 
@@ -204,13 +226,15 @@ sourceFile: "components/sidebar"
 
 <ComponentExample demo="SidebarBasicDemo" code={basicCode} vrSection="basic" vrTitle="Basic" />
 
-### Collapsible Groups
+### Collapsible Sub-Menus
 
 <p class="mb-3 text-sm text-kumo-strong">
-  Add <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">collapsible</code> to a <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Group</code> and wrap the <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Menu</code> in <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">GroupContent</code> to enable animated expand/collapse via the group label.
+  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Collapsible</code>,
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">CollapsibleTrigger</code>, and
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">CollapsibleContent</code> around nested menus.
 </p>
 
-<ComponentExample demo="SidebarCollapsibleGroupDemo" code={collapsibleCode} vrSection="collapsible-groups" vrTitle="Collapsible Groups" />
+<ComponentExample demo="SidebarCollapsibleGroupDemo" code={collapsibleCode} vrSection="collapsible-sub-menus" vrTitle="Collapsible Sub-Menus" />
 
 ### Toggle & Collapsed State
 
@@ -235,6 +259,23 @@ sourceFile: "components/sidebar"
 </p>
 
 <ComponentExample demo="SidebarResizableDemo" code={resizableCode} vrSection="resizable" vrTitle="Resizable" />
+
+### Peeking
+
+<p class="mb-3 text-sm text-kumo-strong">
+  Set <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">peekable</code> on the provider so a collapsed icon sidebar can temporarily reveal its full width on hover or focus.
+</p>
+
+<ComponentExample demo="SidebarPeekingDemo" code={peekingCode} vrSection="peeking" vrTitle="Peeking" />
+
+### Sliding Views
+
+<p class="mb-3 text-sm text-kumo-strong">
+  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">SlidingViews</code> and
+  <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">SlidingView</code> to switch between nested sidebar panels without replacing the provider.
+</p>
+
+<ComponentExample demo="SidebarSlidingViewsDemo" code={slidingCode} vrSection="sliding-views" vrTitle="Sliding Views" />
 
 ### Right Side
 
@@ -280,14 +321,20 @@ Button inside a sub-menu for nested navigation.
 
 <PropsTable component="Sidebar.MenuSubButton" />
 
-### `Sidebar.GroupContent`
+### `Sidebar.Trigger`
 
-Animation wrapper only needed for `collapsible` groups. For non-collapsible groups, place `Menu` directly inside `Group`.
+Button that toggles provider open state.
 
-### `Sidebar.Input`
+### `Sidebar.ResizeHandle`
 
-Search trigger button styled as an input. Typically opens a command palette.
+Keyboard and pointer resize control for resizable sidebars.
 
-<PropsTable component="Sidebar.Input" />
+### `Sidebar.SlidingViews`
+
+Container for keyed sliding sidebar panels.
+
+### `Sidebar.SlidingView`
+
+Panel rendered when its `value` matches the parent `activeKey`.
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/sidebar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/sidebar/+page.md
@@ -85,21 +85,6 @@ sourceFile: "components/sidebar"
   </Sidebar>
 </Sidebar.Provider>`;
 
-  const collapsibleCode = `<Sidebar.MenuItem>
-  <Sidebar.Collapsible defaultOpen>
-    <Sidebar.CollapsibleTrigger>
-      <Sidebar.MenuButton icon={Code}>
-        Compute <Sidebar.MenuChevron />
-      </Sidebar.MenuButton>
-    </Sidebar.CollapsibleTrigger>
-    <Sidebar.CollapsibleContent>
-      <Sidebar.MenuSub>
-        <Sidebar.MenuSubButton>Workers</Sidebar.MenuSubButton>
-      </Sidebar.MenuSub>
-    </Sidebar.CollapsibleContent>
-  </Sidebar.Collapsible>
-</Sidebar.MenuItem>`;
-
   const toggleCode = `<Sidebar.MenuButton icon={House} tooltip="Home" active>
   Home
 </Sidebar.MenuButton>
@@ -226,16 +211,6 @@ sourceFile: "components/sidebar"
 
 <ComponentExample demo="SidebarBasicDemo" code={basicCode} vrSection="basic" vrTitle="Basic" />
 
-### Collapsible Sub-Menus
-
-<p class="mb-3 text-sm text-kumo-strong">
-  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">Collapsible</code>,
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">CollapsibleTrigger</code>, and
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">CollapsibleContent</code> around nested menus.
-</p>
-
-<ComponentExample demo="SidebarCollapsibleGroupDemo" code={collapsibleCode} vrSection="collapsible-sub-menus" vrTitle="Collapsible Sub-Menus" />
-
 ### Toggle & Collapsed State
 
 <p class="mb-3 text-sm text-kumo-strong">
@@ -244,14 +219,6 @@ sourceFile: "components/sidebar"
 
 <ComponentExample demo="SidebarToggleDemo" code={toggleCode} vrSection="toggle" vrTitle="Toggle & Collapsed State" />
 
-### Full Example
-
-<p class="mb-3 text-sm text-kumo-strong">
-  Kitchen sink: header with account switcher, search input, badges, collapsible sub-menus, and a footer action.
-</p>
-
-<ComponentExample demo="SidebarFullDemo" code={fullCode} vrSection="full-example" vrTitle="Full Example" />
-
 ### Resizable
 
 <p class="mb-3 text-sm text-kumo-strong">
@@ -259,6 +226,14 @@ sourceFile: "components/sidebar"
 </p>
 
 <ComponentExample demo="SidebarResizableDemo" code={resizableCode} vrSection="resizable" vrTitle="Resizable" />
+
+### Right Side
+
+<p class="mb-3 text-sm text-kumo-strong">
+  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">side="right"</code> for a sidebar on the right edge. Place <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;main&gt;</code> before <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;Sidebar&gt;</code> in the DOM.
+</p>
+
+<ComponentExample demo="SidebarRightDemo" code={rightCode} vrSection="right-side" vrTitle="Right Side" />
 
 ### Peeking
 
@@ -277,13 +252,13 @@ sourceFile: "components/sidebar"
 
 <ComponentExample demo="SidebarSlidingViewsDemo" code={slidingCode} vrSection="sliding-views" vrTitle="Sliding Views" />
 
-### Right Side
+### Full Example
 
 <p class="mb-3 text-sm text-kumo-strong">
-  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">side="right"</code> for a sidebar on the right edge. Place <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;main&gt;</code> before <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">&lt;Sidebar&gt;</code> in the DOM.
+  Kitchen sink: header with account switcher, search input, badges, collapsible sub-menus, and a footer action.
 </p>
 
-<ComponentExample demo="SidebarRightDemo" code={rightCode} vrSection="right-side" vrTitle="Right Side" />
+<ComponentExample demo="SidebarFullDemo" code={fullCode} vrSection="full-example" vrTitle="Full Example" />
 
 </ComponentSection>
 

--- a/packages/kumo-svelte/src/routes/components/skeleton-line/+page.md
+++ b/packages/kumo-svelte/src/routes/components/skeleton-line/+page.md
@@ -22,12 +22,16 @@ sourceFile: "primitives/skeleton-line"
 
 ## Installation
 
-```svelte
-<script lang="ts">
-  import { SkeletonLine } from 'kumo-svelte';
-</script>
+### Barrel
 
-<SkeletonLine />
+```typescript
+import { SkeletonLine } from 'kumo-svelte';
+```
+
+### Granular
+
+```typescript
+import { SkeletonLine } from 'kumo-svelte/components/loader';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/switch/+page.md
+++ b/packages/kumo-svelte/src/routes/components/switch/+page.md
@@ -25,22 +25,14 @@ baseUIComponent: "switch"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Switch } from 'kumo-svelte';
-
-  let checked = $state(false);
-</script>
-
-<Switch label="Enable feature" bind:checked />
+```typescript
+import { Switch, SwitchGroup, SwitchItem, SwitchLegend } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Switch } from 'kumo-svelte';
-</script>
+```typescript
+import { Switch, SwitchGroup, SwitchItem, SwitchLegend } from 'kumo-svelte/components/switch';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/table-of-contents/+page.md
+++ b/packages/kumo-svelte/src/routes/components/table-of-contents/+page.md
@@ -26,14 +26,14 @@ sourceFile: "components/table-of-contents"
 
 ### Barrel
 
-```svelte
-import { TableOfContents } from "kumo-svelte";
+```typescript
+import { TableOfContents } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { TableOfContents } from "kumo-svelte";
+```typescript
+import { TableOfContents } from 'kumo-svelte/components/table-of-contents';
 ```
 
 </ComponentSection>
@@ -47,7 +47,9 @@ import { TableOfContents } from "kumo-svelte";
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { TableOfContents } from "kumo-svelte";
+</script>
 
     <TableOfContents>
       <TableOfContents.Title>On this page</TableOfContents.Title>
@@ -155,28 +157,28 @@ import Link from "next/link";
 
 ## API Reference
 
-### `TableOfContents`
+### TableOfContents
 
 
 Root nav container with a default `aria-label` of "Table of contents".
 
 <PropsTable component="TableOfContents" />
 
-### `TableOfContents.Title`
+### TableOfContents.Title
 
 
 Optional uppercase heading displayed above the list (renders a `<p>`).
 
 <PropsTable component="TableOfContents.Title" />
 
-### `TableOfContents.List`
+### TableOfContents.List
 
 
 List container with a left border rail.
 
 <PropsTable component="TableOfContents.List" />
 
-### `TableOfContents.Item`
+### TableOfContents.Item
 
 
 Individual navigation link. Set `active` for the current section. Use the
@@ -184,7 +186,7 @@ Individual navigation link. Set `active` for the current section. Use the
 
 <PropsTable component="TableOfContents.Item" />
 
-### `TableOfContents.Group`
+### TableOfContents.Group
 
 
 Groups items under a labeled section with indented children. Pass `href` to make the label a clickable link, or omit for a plain title.

--- a/packages/kumo-svelte/src/routes/components/table/+page.md
+++ b/packages/kumo-svelte/src/routes/components/table/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/table"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Table } from 'kumo-svelte';
-</script>
+```typescript
+import { Table, TableBody, TableCell, TableCheckCell, TableCheckHead, TableFooter, TableHead, TableHeader, TableResizeHandle, TableRow } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Table } from 'kumo-svelte/components/table';
-</script>
+```typescript
+import { Table, TableBody, TableCell, TableCheckCell, TableCheckHead, TableFooter, TableHead, TableHeader, TableResizeHandle, TableRow } from 'kumo-svelte/components/table';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/tabs/+page.md
+++ b/packages/kumo-svelte/src/routes/components/tabs/+page.md
@@ -25,14 +25,14 @@ bitsUIComponent: "tabs"
 
 ### Barrel
 
-```svelte
-import { Tabs } from "kumo-svelte";
+```typescript
+import { Tabs } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { Tabs } from "kumo-svelte";
+```typescript
+import { Tabs } from 'kumo-svelte/components/tabs';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/tabs/+page.md
+++ b/packages/kumo-svelte/src/routes/components/tabs/+page.md
@@ -44,7 +44,9 @@ import { Tabs } from 'kumo-svelte/components/tabs';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { Tabs } from "kumo-svelte";
+</script>
 
 <Tabs
   tabs={[

--- a/packages/kumo-svelte/src/routes/components/text/+page.md
+++ b/packages/kumo-svelte/src/routes/components/text/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/text"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Text } from 'kumo-svelte';
-</script>
+```typescript
+import { Text } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Text } from 'kumo-svelte';
-</script>
+```typescript
+import { Text } from 'kumo-svelte/components/text';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/toast/+page.md
+++ b/packages/kumo-svelte/src/routes/components/toast/+page.md
@@ -24,18 +24,14 @@ sourceFile: "components/toast"
 
 ### Barrel
 
-```svelte
-<script lang="ts">
-  import { Toasty, useKumoToastManager } from 'kumo-svelte';
-</script>
+```typescript
+import { Toasty } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-<script lang="ts">
-  import { Toasty, useKumoToastManager } from 'kumo-svelte';
-</script>
+```typescript
+import { Toasty } from 'kumo-svelte/components/toasty';
 ```
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/tooltip/+page.md
+++ b/packages/kumo-svelte/src/routes/components/tooltip/+page.md
@@ -25,14 +25,14 @@ baseUIComponent: "tooltip"
 
 ### Barrel
 
-```svelte
-import { Tooltip, TooltipProvider } from "kumo-svelte";
+```typescript
+import { Tooltip, TooltipProvider } from 'kumo-svelte';
 ```
 
 ### Granular
 
-```svelte
-import { Tooltip, TooltipProvider } from "kumo-svelte";
+```typescript
+import { Tooltip, TooltipProvider } from 'kumo-svelte/components/tooltip';
 ```
 
 </ComponentSection>
@@ -68,6 +68,15 @@ For delay grouping across multiple tooltips, see [TooltipProvider](#tooltipprovi
 ### Multiple Tooltips
 
 <ComponentExample demo="TooltipMultipleDemo" />
+
+### Long Content / Overflow
+
+Tooltips with long content automatically constrain their width to the available
+viewport space using `--available-width` from Bits UI's floating positioning.
+Hover over the edge buttons to see the tooltip wrap instead of overflowing the
+viewport.
+
+<ComponentExample demo="TooltipOverflowDemo" />
 
 ### Delay Control
 

--- a/packages/kumo-svelte/src/routes/components/tooltip/+page.md
+++ b/packages/kumo-svelte/src/routes/components/tooltip/+page.md
@@ -44,7 +44,9 @@ import { Tooltip, TooltipProvider } from 'kumo-svelte/components/tooltip';
 ## Usage
 
 ```svelte
+<script lang="ts">
 import { Tooltip, Button } from "kumo-svelte";
+</script>
 
 <Tooltip content="Tooltip text">
   <Button>Hover me</Button>

--- a/packages/kumo-svelte/src/routes/contributing/+page.md
+++ b/packages/kumo-svelte/src/routes/contributing/+page.md
@@ -1,6 +1,7 @@
 ---
 title: "Contributing"
 description: "Learn how to contribute to Kumo, from setup and workflows to PR and release guidelines. Everything you need for setup, development, quality checks, and PR process is documented here."
+contentLayout: "wide"
 ---
 
 <script>
@@ -11,16 +12,19 @@ description: "Learn how to contribute to Kumo, from setup and workflows to PR an
   import PropsTable from '$lib/docs/PropsTable.svelte';
 </script>
 
-
-## Before You Start
-
-For non-trivial changes, start with alignment before coding:
-
-- Comment on an existing issue or open one first.
-- Confirm scope, API direction, and migration impact.
-- For small fixes/docs tweaks, you can go straight to a PR.
-
----
+<section class="not-prose border-b border-kumo-hairline pb-8 md:pb-9">
+  <h2 id="before-you-start" class="mb-6 text-3xl leading-tight font-semibold tracking-normal text-kumo-default md:mb-8 md:text-[40px]">
+    <a href="#before-you-start">Before You Start</a>
+  </h2>
+  <p class="mb-5 text-lg leading-normal text-kumo-default md:mb-6 md:text-2xl">
+    For non-trivial changes, start with alignment before coding:
+  </p>
+  <ul class="m-0 flex list-disc flex-col gap-3 pl-8 text-lg leading-normal text-kumo-default md:gap-4 md:pl-12 md:text-2xl">
+    <li class="pl-2">Comment on an existing issue or open one first.</li>
+    <li class="pl-2">Confirm scope, API direction, and migration impact.</li>
+    <li class="pl-2">For small fixes/docs tweaks, you can go straight to a PR.</li>
+  </ul>
+</section>
 
 ## 1. Get Set Up Once
 

--- a/packages/kumo-svelte/src/routes/contributing/+page.md
+++ b/packages/kumo-svelte/src/routes/contributing/+page.md
@@ -60,9 +60,9 @@ If you do not have write access, contact your manager or Kumo maintainers.
 
 Use this to decide where your change belongs:
 
-- **Component**: reusable UI primitive in `packages/kumo/src/components/`
-- **Block**: installable composition pattern in `packages/kumo/src/blocks/`
-- **Docs only**: docs/demo/navigation updates in `packages/kumo-docs-astro/`
+- **Component**: reusable UI primitive in `packages/kumo-svelte/src/lib/components/`
+- **Block**: documented composition pattern in `packages/kumo-svelte/src/routes/blocks/` with any supporting code kept near the local docs/component surface
+- **Docs only**: docs pages, demo snippets, and navigation updates in `packages/kumo-svelte/src/routes/` or `packages/kumo-svelte/src/lib/docs/`
 
 When adding a new **component**, scaffold it (do not create files manually):
 
@@ -92,15 +92,15 @@ This gives you a fast loop while verifying your change in the actual docs enviro
 
 Typical internal change flow:
 
-1. Build the feature in `packages/kumo/src/...`.
-2. Add or update demos in `packages/kumo-docs-astro/src/components/demos/`.
-3. Add/update tests in `packages/kumo`.
-4. Add or update docs pages in `packages/kumo-docs-astro/src/pages/`.
+1. Build the feature in `packages/kumo-svelte/src/lib/...`.
+2. Add or update demos in `packages/kumo-svelte/src/lib/docs/demo-snippets/`.
+3. Add/update tests in `packages/kumo-svelte`.
+4. Add or update docs pages in `packages/kumo-svelte/src/routes/`.
 
 If your demos should appear in registry metadata, keep demo naming exact:
 
 - File: `&#123;Component&#125;Demo.svelte`
-- Export names must end with `Demo`
+- Demo component names should end with `Demo`
 
 Implementation expectations:
 
@@ -139,7 +139,7 @@ Windsurf and hooks catch additional issues, but you should still run checks loca
 
 ## 6. Handle Changesets Correctly
 
-If your change touches `packages/kumo/` and should ship, add a changeset:
+If your change touches `packages/kumo-svelte/` and should ship, add a changeset:
 
 ```bash
 pnpm changeset
@@ -177,7 +177,7 @@ PR review is required before merge.
 
 - PRs publish prerelease artifacts via `pkg.pr.new` links in CI comments.
 - Every PR should include tests for behavior changes.
-- Most Kumo tests are Vitest-based and live under `packages/kumo`.
+- Most Kumo Svelte tests are Vitest-based and live under `packages/kumo-svelte`.
 
 ---
 
@@ -200,10 +200,10 @@ Common pitfalls to avoid:
 
 - Do not scaffold components manually; use `new:component`.
 - Do not rely on raw Tailwind color classes (`bg-blue-500`, etc.).
-- Do not skip changesets for releasable `packages/kumo` changes.
+- Do not skip changesets for releasable `packages/kumo-svelte` changes.
 
 ---
 
 ## Related Docs
 
-Follow the [changeset guide](https://github.com/cloudflare/kumo/blob/main/.changeset/README.md) to document releasable library changes and see the [AGENTS.md](https://github.com/cloudflare/kumo/blob/main/packages/kumo/AGENTS.md) for conventions and patterns.
+Follow the local `.changeset/README.md` to document releasable library changes and see this repo's `AGENTS.md` files for conventions and patterns.

--- a/packages/kumo-svelte/tests/imports/deep-import-validation.test.ts
+++ b/packages/kumo-svelte/tests/imports/deep-import-validation.test.ts
@@ -1,0 +1,47 @@
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '../..');
+const distRoot = join(packageRoot, 'dist');
+const componentsRoot = join(packageRoot, 'src/lib/components');
+
+async function discoverComponentIndexes() {
+  const entries = await readdir(componentsRoot, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(componentsRoot, name, 'index.ts')))
+    .sort();
+}
+
+describe('deep import validation', () => {
+  it('keeps every component index covered by the wildcard component export', async () => {
+    const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+      exports: Record<string, unknown>;
+    };
+    const components = await discoverComponentIndexes();
+
+    expect(packageJson.exports['./components/*']).toEqual({
+      types: './dist/components/*/index.d.ts',
+      svelte: './dist/components/*/index.js',
+      default: './dist/components/*/index.js'
+    });
+
+    expect(components).toEqual(expect.arrayContaining(['code-highlighted', 'link', 'select', 'tooltip']));
+  });
+
+  it('emits representative built component deep paths when dist is present', async () => {
+    if (!existsSync(distRoot)) return;
+
+    for (const component of ['code-highlighted', 'link', 'select', 'tooltip']) {
+      expect(existsSync(join(distRoot, 'components', component, 'index.js'))).toBe(true);
+      expect(existsSync(join(distRoot, 'components', component, 'index.d.ts'))).toBe(true);
+    }
+  });
+});

--- a/packages/kumo-svelte/tests/imports/export-path-validation.test.ts
+++ b/packages/kumo-svelte/tests/imports/export-path-validation.test.ts
@@ -1,0 +1,48 @@
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '../..');
+const distRoot = join(packageRoot, 'dist');
+const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+  exports: Record<string, unknown>;
+};
+
+const isBuilt = existsSync(join(distRoot, 'index.js'));
+
+async function discoverBuiltComponents() {
+  const componentsRoot = join(distRoot, 'components');
+  if (!existsSync(componentsRoot)) return [];
+
+  const entries = await readdir(componentsRoot, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+}
+
+describe.skipIf(!isBuilt)('export path validation', () => {
+  it('points root package exports at built files', () => {
+    expect(existsSync(join(distRoot, 'index.js'))).toBe(true);
+    expect(existsSync(join(distRoot, 'index.d.ts'))).toBe(true);
+    expect(existsSync(join(distRoot, 'styles.css'))).toBe(true);
+    expect(existsSync(join(packageRoot, 'ai/component-registry.json'))).toBe(true);
+  });
+
+  it('builds every source component index exposed by the wildcard component export', async () => {
+    const builtComponents = await discoverBuiltComponents();
+
+    expect(packageJson.exports).toHaveProperty('./components/*');
+    expect(builtComponents).toEqual(expect.arrayContaining(['button', 'pagination', 'sidebar']));
+
+    for (const component of builtComponents) {
+      expect(existsSync(join(distRoot, 'components', component, 'index.js'))).toBe(true);
+      expect(existsSync(join(distRoot, 'components', component, 'index.d.ts'))).toBe(true);
+    }
+  });
+
+  it('does not emit nested node_modules into dist', () => {
+    expect(existsSync(join(distRoot, 'node_modules'))).toBe(false);
+  });
+});

--- a/packages/kumo-svelte/tests/imports/main-entry.test.ts
+++ b/packages/kumo-svelte/tests/imports/main-entry.test.ts
@@ -1,0 +1,38 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '../..');
+
+describe('main entry point exports', () => {
+  it('exports representative public components from the source entry', async () => {
+    const source = await readFile(join(packageRoot, 'src/lib/index.ts'), 'utf-8');
+
+    expect(source).toContain('Button');
+    expect(source).toContain('Sidebar');
+    expect(source).toContain('Pagination');
+    expect(source).toContain('TimeseriesChart');
+  });
+
+  it('keeps built package entry export names aligned with source when dist is present', async () => {
+    const distEntry = join(packageRoot, 'dist/index.js');
+    if (!existsSync(distEntry)) return;
+
+    const source = await readFile(join(packageRoot, 'src/lib/index.ts'), 'utf-8');
+    const built = await readFile(distEntry, 'utf-8');
+
+    for (const exportName of ['Button', 'Sidebar', 'Pagination', 'TimeseriesChart']) {
+      expect(source).toContain(exportName);
+      expect(built).toContain(exportName);
+    }
+  });
+
+  it('keeps the package registry export addressable', async () => {
+    const registry = JSON.parse(await readFile(join(packageRoot, 'ai/component-registry.json'), 'utf-8'));
+    expect(registry).toBeDefined();
+  });
+});

--- a/packages/kumo-svelte/tests/imports/package-json-validation.test.ts
+++ b/packages/kumo-svelte/tests/imports/package-json-validation.test.ts
@@ -1,0 +1,60 @@
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '../..');
+const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+  name: string;
+  type: string;
+  files: string[];
+  exports: Record<string, unknown>;
+};
+
+async function discoverComponents() {
+  const componentsRoot = join(packageRoot, 'src/lib/components');
+  const entries = await readdir(componentsRoot, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(componentsRoot, name, 'index.ts')))
+    .sort();
+}
+
+describe('package.json validation', () => {
+  it('is configured as the Svelte package entry point', () => {
+    expect(packageJson.name).toBe('kumo-svelte');
+    expect(packageJson.type).toBe('module');
+    expect(packageJson.files).toEqual(expect.arrayContaining(['dist', 'src']));
+    expect(packageJson.exports).toHaveProperty('.');
+    expect(packageJson.exports).toHaveProperty('./components/*');
+    expect(packageJson.exports).toHaveProperty('./styles.css');
+    expect(packageJson.exports).toHaveProperty('./ai/component-registry.json');
+  });
+
+  it('keeps wildcard component exports aligned with component indexes', async () => {
+    const components = await discoverComponents();
+    expect(components).toContain('button');
+    expect(components).toContain('sidebar');
+    expect(components).toContain('pagination');
+
+    const componentExport = packageJson.exports['./components/*'];
+    expect(componentExport).toEqual({
+      types: './dist/components/*/index.d.ts',
+      svelte: './dist/components/*/index.js',
+      default: './dist/components/*/index.js'
+    });
+  });
+
+  it('does not publish per-component exports that can drift from the wildcard source of truth', () => {
+    const explicitComponentExports = Object.keys(packageJson.exports).filter((key) =>
+      key.startsWith('./components/') && key !== './components/*'
+    );
+
+    expect(explicitComponentExports).toEqual([]);
+  });
+});

--- a/packages/kumo-svelte/tests/setup.ts
+++ b/packages/kumo-svelte/tests/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/svelte';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/kumo-svelte/vite.config.ts
+++ b/packages/kumo-svelte/vite.config.ts
@@ -23,5 +23,10 @@ export default defineConfig({
     __DOCS_VERSION__: JSON.stringify(packageJson.version ?? 'dev'),
     __BUILD_DATE__: JSON.stringify(buildDate)
   },
-  plugins: [kumoRegistryPlugin(), tailwindcss(), sveltekit()]
+  plugins: [kumoRegistryPlugin(), tailwindcss(), sveltekit()],
+  resolve: process.env.VITEST
+    ? {
+        conditions: ['browser']
+      }
+    : undefined
 });

--- a/packages/kumo-svelte/vitest.config.ts
+++ b/packages/kumo-svelte/vitest.config.ts
@@ -1,0 +1,30 @@
+import { mergeConfig, defineConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      name: 'unit',
+      environment: 'happy-dom',
+      include: ['src/**/*.{test,spec}.{ts,js}', 'tests/**/*.{test,spec}.{ts,js}'],
+      exclude: ['**/*.browser.{test,spec}.{ts,js}'],
+      setupFiles: ['./tests/setup.ts'],
+      globals: true,
+      css: true,
+      testTimeout: 10_000,
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html'],
+        include: ['src/**/*.{ts,svelte}'],
+        exclude: [
+          '**/*.test.{ts,js}',
+          '**/*.spec.{ts,js}',
+          '**/*.stories.svelte',
+          '**/index.ts',
+          'src/routes/**'
+        ]
+      }
+    }
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,18 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.2.9
+        version: 5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      happy-dom:
+        specifier: ^20.0.10
+        version: 20.9.0
       mdsx:
         specifier: ^0.0.7
         version: 0.0.7(svelte@5.55.7)
@@ -118,11 +127,25 @@ importers:
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.0.15
+        version: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.91.0
         version: 4.91.0(@cloudflare/workers-types@4.20260515.1)
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -1237,14 +1260,50 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1276,8 +1335,43 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1292,11 +1386,18 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -1305,6 +1406,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1337,6 +1442,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1368,6 +1477,9 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -1379,6 +1491,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1421,6 +1536,12 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   echarts@6.0.0:
     resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
@@ -1432,8 +1553,15 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1466,6 +1594,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1524,6 +1656,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -1544,6 +1680,10 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -1581,6 +1721,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1839,6 +1982,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   miniflare@4.20260511.0:
     resolution: {integrity: sha512-GjTfjtdrDb4LTUcA1S/iz/YKMvSxlbgAfgXpyhM1PQV/xzUYRpKWayq3R1vOQg53Y/g0epaBFaZLA2QbnS/meA==}
     engines: {node: '>=22.0.0'}
@@ -2024,6 +2171,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -2032,6 +2183,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2044,6 +2198,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -2136,6 +2294,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2161,6 +2322,12 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -2171,6 +2338,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -2225,9 +2396,20 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.3:
+    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2359,9 +2541,59 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerd@1.20260511.1:
@@ -2416,6 +2648,16 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -3297,16 +3539,58 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.1
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.7)':
+    dependencies:
+      svelte: 5.55.7
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.7)
+      svelte: 5.55.7
+    optionalDependencies:
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+      vitest: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/cookie@0.6.0': {}
 
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -3338,7 +3622,54 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn@8.16.0: {}
 
@@ -3346,15 +3677,23 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@5.2.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   axobject-query@4.1.0: {}
 
@@ -3387,6 +3726,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3409,6 +3750,8 @@ snapshots:
 
   content-type@2.0.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
@@ -3418,6 +3761,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
 
   debug@4.4.3:
     dependencies:
@@ -3447,6 +3792,10 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   echarts@6.0.0:
     dependencies:
       tslib: 2.3.0
@@ -3462,7 +3811,11 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@7.0.1: {}
+
   error-stack-parser-es@1.0.5: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -3538,6 +3891,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  expect-type@1.3.0: {}
+
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
@@ -3599,6 +3954,18 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.9.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -3627,6 +3994,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   is-extglob@2.1.1: {}
@@ -3652,6 +4021,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -3986,6 +4357,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  min-indent@1.0.1: {}
+
   miniflare@4.20260511.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -4106,11 +4479,19 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   property-information@7.1.0: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  react-is@17.0.2: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -4122,6 +4503,11 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   regex-recursion@6.0.2:
     dependencies:
@@ -4263,6 +4649,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sirv@3.0.2:
@@ -4284,6 +4672,10 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -4294,6 +4686,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-object@1.0.14:
     dependencies:
@@ -4365,10 +4761,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4474,9 +4876,44 @@ snapshots:
     optionalDependencies:
       vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
 
+  vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
+
+  whatwg-mimetype@3.0.0: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260511.1:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,14 +98,20 @@ importers:
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/svelte':
-        specifier: ^5.2.9
-        version: 5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
       happy-dom:
         specifier: ^20.0.10
         version: 20.9.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       mdsx:
         specifier: ^0.0.7
         version: 0.0.7(svelte@5.55.7)
@@ -128,8 +134,8 @@ importers:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
       vitest:
-        specifier: ^4.0.15
-        version: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.91.0
         version: 4.91.0(@cloudflare/workers-types@4.20260515.1)
@@ -138,6 +144,21 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -150,6 +171,10 @@ packages:
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -255,6 +280,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -576,6 +637,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1287,6 +1357,12 @@ packages:
       vitest:
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1425,6 +1501,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bits-ui@2.18.1:
     resolution: {integrity: sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==}
     engines: {node: '>=20'}
@@ -1492,8 +1571,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1503,6 +1590,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1556,6 +1646,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
@@ -1666,6 +1760,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -1704,6 +1802,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -1732,6 +1833,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
@@ -1884,6 +1994,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1905,6 +2019,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdsx@0.0.7:
     resolution: {integrity: sha512-Ftgb6Yq47WMaYoFznJ+jNxnn82sDUvot9Nw2uSaolbkghUV6Le1stDzEVHClaKA1hMJnc+jbMagK/HM7nT6FJg==}
@@ -2052,6 +2169,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2178,6 +2298,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -2225,6 +2349,10 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2261,6 +2389,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -2379,6 +2511,9 @@ packages:
     resolution: {integrity: sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -2411,6 +2546,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2418,6 +2560,14 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2454,6 +2604,10 @@ packages:
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -2582,9 +2736,25 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2627,6 +2797,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2651,6 +2828,26 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -2660,6 +2857,10 @@ snapshots:
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -2833,6 +3034,30 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3004,6 +3229,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.0':
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3563,14 +3790,18 @@ snapshots:
     dependencies:
       svelte: 5.55.7
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))':
+  '@testing-library/svelte@5.3.1(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.7)
       svelte: 5.55.7
     optionalDependencies:
       vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
-      vitest: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -3705,6 +3936,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bits-ui@2.18.1(@internationalized/date@3.12.1)(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@6.0.3)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7):
     dependencies:
       '@floating-ui/core': 1.7.5
@@ -3762,11 +3997,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3812,6 +4061,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -3984,6 +4235,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-void-elements@3.0.0: {}
 
   human-id@4.1.3: {}
@@ -4007,6 +4264,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -4032,6 +4291,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.26.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-with-bigint@3.5.8: {}
 
@@ -4143,6 +4428,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  lru-cache@11.5.1: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -4198,6 +4485,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   mdsx@0.0.7(svelte@5.55.7):
     dependencies:
@@ -4433,6 +4722,10 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4486,6 +4779,8 @@ snapshots:
       react-is: 17.0.2
 
   property-information@7.1.0: {}
+
+  punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
@@ -4544,6 +4839,8 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   reusify@1.1.0: {}
@@ -4592,6 +4889,10 @@ snapshots:
       mri: 1.2.0
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scule@1.3.0: {}
 
@@ -4751,6 +5052,8 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tailwind-merge@3.6.0: {}
@@ -4772,11 +5075,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -4805,6 +5122,8 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici@7.24.8: {}
+
+  undici@7.26.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -4876,7 +5195,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
@@ -4901,10 +5220,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       happy-dom: 20.9.0
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -4946,6 +5282,10 @@ snapshots:
       - utf-8-validate
 
   ws@8.20.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- add Svelte Vitest infrastructure and wire package tests into root test and PR CI
- add component/import validation tests for Button, Pagination, Sidebar, and package exports
- close Sidebar parity gaps for collapsed menu-button tooltips and mobile dialog semantics
- refresh `PARITY_OMISSIONS.md` after auditing refreshed `cloudflare/kumo` main

## Validation

- `pnpm test`
- `pnpm --filter kumo-svelte test`
- `pnpm --filter kumo-svelte check`
- `pnpm --filter kumo-svelte build` (rerun outside sandbox after known `tsx` IPC `EPERM`)
- `git diff --check`
