### PR TITLE
Port Kumo 2.5 parity updates

### DIFF
--- a/.changeset/quiet-clouds-travel.md
+++ b/.changeset/quiet-clouds-travel.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": minor
+---
+
+Port upstream Kumo 2.5.0 parity updates for sidebar mobile drawers, collapsible auto-scroll, proportional tab fades, transparent chart backgrounds, Flow connector rendering, and the docs LLM index.

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1206,6 +1206,12 @@
           "optional": true,
           "description": "Called when open state changes."
         },
+        "autoScrollOnOpen": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Scrolls newly expanded sidebar content into view after opening."
+        },
         "onOpenChangeComplete": {
           "type": "(open: boolean) => void",
           "optional": true,
@@ -4077,6 +4083,11 @@
           "required": true,
           "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
         },
+        "contentClass": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes for the desktop content container."
+        },
         "class": {
           "type": "string",
           "optional": true,
@@ -4084,7 +4095,6 @@
         }
       },
       "colors": [
-        "bg-kumo-base",
         "bg-kumo-brand",
         "bg-kumo-hairline",
         "bg-kumo-line",
@@ -4292,6 +4302,12 @@
               "optional": true,
               "default": "250",
               "description": "Transition duration in milliseconds for width and peek animations."
+            },
+            "mobileBreakpoint": {
+              "type": "number",
+              "optional": true,
+              "default": "768",
+              "description": "Viewport width below which the sidebar renders as a mobile navigation drawer."
             },
             "children": {
               "type": "Snippet",

--- a/packages/kumo-svelte/src/lib/components/chart/Chart.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/Chart.svelte
@@ -73,6 +73,8 @@
 
   const prepareChartOptions = (rawOptions: KumoChartOption, suppressAnimation = false): EChartsOption => {
     const optionsWithTheme = {
+      backgroundColor: 'transparent',
+      color: effectiveDarkMode ? CHART_DARK_COLORS : CHART_LIGHT_COLORS,
       ...rawOptions,
       ...(suppressAnimation ? { animation: false } : {}),
       textStyle: {
@@ -123,8 +125,7 @@
   const initChart = () => {
     if (!el) return;
     chart?.dispose();
-    const theme = effectiveDarkMode ? { darkMode: true, color: CHART_DARK_COLORS } : { color: CHART_LIGHT_COLORS };
-    const nextChart = echarts.init(el, theme, { renderer: 'canvas' });
+    const nextChart = echarts.init(el, effectiveDarkMode ? 'dark' : undefined, { renderer: 'canvas' });
     chart = nextChart;
     updateOptions();
   };

--- a/packages/kumo-svelte/src/lib/components/flow/Connectors.svelte
+++ b/packages/kumo-svelte/src/lib/components/flow/Connectors.svelte
@@ -22,7 +22,7 @@
   });
 </script>
 
-<svg width="100%" height="100%" aria-hidden="true" class="text-kumo-inactive overflow-visible">
+<svg width="100%" height="100%" overflow="visible" aria-hidden="true" class="text-kumo-inactive overflow-visible">
   <defs>
     {#if markerId}
       <marker

--- a/packages/kumo-svelte/src/lib/components/flow/connectors.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/connectors.ts
@@ -1,4 +1,4 @@
-import type { FlowOrientation } from './context';
+import type { FlowOrientation } from "./context";
 
 export interface Connector {
   x1: number;
@@ -31,15 +31,15 @@ export function createRoundedPath(
     arrowheadOffset = 8,
     isBottom = false,
     single = false,
-    orientation = 'vertical'
-  }: PathProps = {}
+    orientation = "vertical",
+  }: PathProps = {},
 ) {
   const cornerRadius = Math.min(
     maxCornerRadius,
-    Math.abs(orientation === 'horizontal' ? (y2 - y1) / 2 : (x2 - x1) / 2)
+    Math.abs(orientation === "horizontal" ? (y2 - y1) / 2 : (x2 - x1) / 2),
   );
 
-  if (orientation === 'horizontal') {
+  if (orientation === "horizontal") {
     if (Math.abs(y2 - y1) <= FLAT_THRESHOLD) {
       return `M ${x1} ${y1} L ${x2 - arrowheadOffset} ${y2}`;
     }
@@ -58,7 +58,7 @@ export function createRoundedPath(
       `Q ${verticalX} ${y1} ${verticalX} ${verticalStart}`,
       single
         ? `L ${verticalX} ${verticalEnd} Q ${verticalX} ${y2} ${secondHorizontalStart} ${y2}`
-        : `L ${verticalX} ${y2}`
+        : `L ${verticalX} ${y2}`,
     ];
 
     const topCurveCommands = [
@@ -66,12 +66,14 @@ export function createRoundedPath(
         ? `L ${firstHorizontalEnd} ${y1} Q ${verticalX} ${y1} ${verticalX} ${verticalStart}`
         : `L ${verticalX} ${y1}`,
       `L ${verticalX} ${verticalEnd}`,
-      `Q ${verticalX} ${y2} ${secondHorizontalStart} ${y2}`
+      `Q ${verticalX} ${y2} ${secondHorizontalStart} ${y2}`,
     ];
 
-    return [`M ${x1} ${y1}`, isBottom ? bottomCurveCommands : topCurveCommands, `L ${pathEndX} ${y2}`].join(
-      ' '
-    );
+    return [
+      `M ${x1} ${y1}`,
+      ...(isBottom ? bottomCurveCommands : topCurveCommands),
+      `L ${pathEndX} ${y2}`,
+    ].join(" ");
   }
 
   if (Math.abs(x2 - x1) <= FLAT_THRESHOLD) {
@@ -90,16 +92,18 @@ export function createRoundedPath(
   const bottomCurveCommands = [
     `L ${x1} ${firstVerticalEnd}`,
     `Q ${x1} ${horizontalY} ${horizontalStart} ${horizontalY}`,
-    `L ${x2} ${horizontalY}`
+    `L ${x2} ${horizontalY}`,
   ];
 
   const topCurveCommands = [
     `L ${x1} ${horizontalY}`,
     `L ${horizontalEnd} ${horizontalY}`,
-    `Q ${x2} ${horizontalY} ${x2} ${secondVerticalStart}`
+    `Q ${x2} ${horizontalY} ${x2} ${secondVerticalStart}`,
   ];
 
-  return [`M ${x1} ${y1}`, isBottom ? bottomCurveCommands : topCurveCommands, `L ${x2} ${pathEndY}`].join(
-    ' '
-  );
+  return [
+    `M ${x1} ${y1}`,
+    ...(isBottom ? bottomCurveCommands : topCurveCommands),
+    `L ${x2} ${pathEndY}`,
+  ].join(" ");
 }

--- a/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
-import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import FlowPanningTestHost from './FlowPanningTestHost.svelte';
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoundedPath } from "./connectors";
+import FlowPanningTestHost from "./FlowPanningTestHost.svelte";
 
 const resizeObservers: TestResizeObserver[] = [];
 
@@ -31,7 +32,7 @@ function setRect(element: Element, rect: Partial<DOMRect>) {
     ...rect,
   } as DOMRect;
 
-  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(nextRect);
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue(nextRect);
 }
 
 async function measure() {
@@ -43,38 +44,38 @@ async function measure() {
 
 beforeEach(() => {
   resizeObservers.length = 0;
-  vi.stubGlobal('ResizeObserver', TestResizeObserver);
-  document.body.style.cursor = '';
-  document.body.style.userSelect = '';
+  vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
 });
 
-describe('Flow canvas panning', () => {
-  it('pans with the wheel and clamps to measured bounds', async () => {
+describe("Flow canvas panning", () => {
+  it("pans with the wheel and clamps to measured bounds", async () => {
     render(FlowPanningTestHost);
 
-    const wrapper = screen.getByTestId('flow-wrapper');
-    const contents = screen.getByTestId('flow-contents');
+    const wrapper = screen.getByTestId("flow-wrapper");
+    const contents = screen.getByTestId("flow-contents");
     setRect(wrapper, { width: 300, height: 200 });
     setRect(contents, { width: 800, height: 500 });
     await measure();
 
     await fireEvent.wheel(wrapper, { deltaX: 700, deltaY: 400 });
-    expect(contents.style.transform).toBe('translate(-500px, -300px)');
+    expect(contents.style.transform).toBe("translate(-500px, -300px)");
 
     await fireEvent.wheel(wrapper, { deltaX: -1000, deltaY: -1000 });
-    expect(contents.style.transform).toBe('translate(0px, 0px)');
+    expect(contents.style.transform).toBe("translate(0px, 0px)");
   });
 
-  it('drag-pans the canvas while ignoring drags that start on nodes', async () => {
+  it("drag-pans the canvas while ignoring drags that start on nodes", async () => {
     render(FlowPanningTestHost);
 
-    const wrapper = screen.getByTestId('flow-wrapper');
-    const contents = screen.getByTestId('flow-contents');
+    const wrapper = screen.getByTestId("flow-wrapper");
+    const contents = screen.getByTestId("flow-contents");
     setRect(wrapper, { width: 300, height: 200 });
     setRect(contents, { width: 800, height: 500 });
     await measure();
 
-    await fireEvent.pointerDown(screen.getByTestId('start'), {
+    await fireEvent.pointerDown(screen.getByTestId("start"), {
       button: 0,
       clientX: 100,
       clientY: 100,
@@ -85,7 +86,7 @@ describe('Flow canvas panning', () => {
       clientY: 50,
       pointerId: 1,
     });
-    expect(contents.style.transform).toBe('translate(0px, 0px)');
+    expect(contents.style.transform).toBe("translate(0px, 0px)");
 
     await fireEvent.pointerDown(wrapper, {
       button: 0,
@@ -93,18 +94,31 @@ describe('Flow canvas panning', () => {
       clientY: 100,
       pointerId: 2,
     });
-    expect(document.body.style.cursor).toBe('grabbing');
-    expect(document.body.style.userSelect).toBe('none');
+    expect(document.body.style.cursor).toBe("grabbing");
+    expect(document.body.style.userSelect).toBe("none");
 
     await fireEvent.pointerMove(wrapper, {
       clientX: 40,
       clientY: 10,
       pointerId: 2,
     });
-    expect(contents.style.transform).toBe('translate(-60px, -90px)');
+    expect(contents.style.transform).toBe("translate(-60px, -90px)");
 
     await fireEvent.pointerUp(wrapper, { pointerId: 2 });
-    expect(document.body.style.cursor).toBe('');
-    expect(document.body.style.userSelect).toBe('');
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+});
+
+describe("createRoundedPath", () => {
+  it("serializes connector command arrays without comma separators", () => {
+    const verticalPath = createRoundedPath({ x1: 0, y1: 0, x2: 80, y2: 120 });
+    const horizontalPath = createRoundedPath(
+      { x1: 0, y1: 0, x2: 120, y2: 80 },
+      { orientation: "horizontal" },
+    );
+
+    expect(verticalPath).not.toContain(",");
+    expect(horizontalPath).not.toContain(",");
   });
 });

--- a/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/Sidebar.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Dialog as DialogPrimitive } from 'bits-ui';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
   import { TooltipProvider } from '$lib/components/tooltip';
@@ -8,11 +7,15 @@
   interface Props {
     children?: Snippet;
     class?: string;
+    contentClass?: string;
     [key: string]: unknown;
   }
 
-  let { children, class: className, ...rest }: Props = $props();
+  let { children, class: className, contentClass, ...rest }: Props = $props();
   const sidebar = getSidebarContext('Sidebar');
+  let mobileNode: HTMLElement | null = $state(null);
+  let mobileTrigger: HTMLElement | null = null;
+  let shouldRestoreFocus = false;
   const isAlwaysExpanded = $derived(sidebar.collapsible === 'none');
   const isVisible = $derived(sidebar.open || sidebar.isPeeking || isAlwaysExpanded);
   const railWidth = $derived(isAlwaysExpanded || sidebar.open ? 'var(--sidebar-width)' : sidebar.collapsible === 'icon' ? 'var(--sidebar-width-icon)' : '0px');
@@ -28,12 +31,45 @@
       !sidebar.open && sidebar.side === 'left' && 'left-0',
       !sidebar.open && sidebar.side === 'right' && 'right-0',
       sidebar.open && 'relative',
-      sidebar.isMobile && 'fixed inset-y-0 max-w-[85vw] shadow-xl md:static md:max-w-none md:shadow-none',
-      sidebar.isMobile && !sidebar.open && 'hidden md:flex',
-      sidebar.isMobile && sidebar.side === 'left' && 'left-0',
-      sidebar.isMobile && sidebar.side === 'right' && 'right-0'
+      contentClass
     )
   );
+
+  function closeMobile(restoreFocus: boolean) {
+    shouldRestoreFocus = restoreFocus;
+    sidebar.setOpenMobile(false);
+  }
+
+  function handleMobileKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') closeMobile(true);
+  }
+
+  function handleMobileFocusout(event: FocusEvent) {
+    if (mobileNode && !mobileNode.contains(event.relatedTarget as Node | null)) {
+      closeMobile(false);
+    }
+  }
+
+  $effect(() => {
+    if (!sidebar.isMobile || !sidebar.openMobile) return;
+
+    mobileTrigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    shouldRestoreFocus = false;
+
+    requestAnimationFrame(() => {
+      const firstFocusable = mobileNode?.querySelector<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      (firstFocusable ?? mobileNode)?.focus();
+    });
+  });
+
+  $effect(() => {
+    if (sidebar.openMobile || !shouldRestoreFocus || !mobileTrigger) return;
+    mobileTrigger.focus();
+    mobileTrigger = null;
+    shouldRestoreFocus = false;
+  });
 </script>
 
 {#snippet sidebarContent()}
@@ -43,39 +79,48 @@
 {/snippet}
 
 {#if sidebar.isMobile}
-  <DialogPrimitive.Root open={sidebar.openMobile} onOpenChange={(open) => sidebar.setOpenMobile(open)}>
-    <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay
-        data-sidebar-backdrop
-        data-kumo-component="Sidebar"
-        data-kumo-part="mobile-backdrop"
-        class="fixed inset-0 z-40 bg-black/50 transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0"
-      />
-      <DialogPrimitive.Content
-        data-sidebar-popup
-        aria-label="Sidebar"
-        class={cn(
-          'fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col bg-kumo-base p-0 duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0',
-          sidebar.side === 'left' && 'left-0 data-ending-style:-translate-x-full data-starting-style:-translate-x-full',
-          sidebar.side === 'right' && 'right-0 data-ending-style:translate-x-full data-starting-style:translate-x-full'
-        )}
-        style="transition-property: transform, opacity; transition-timing-function: var(--default-transition-timing-function);"
-      >
-        <div
-          data-state="expanded"
-          data-side={sidebar.side}
-          data-variant={sidebar.variant}
-          data-collapsible={sidebar.collapsible}
-          data-mobile="true"
-          data-sidebar="sidebar"
-          class={cn('group/sidebar flex h-full w-full flex-col bg-kumo-base text-kumo-default', className)}
-          {...rest}
-        >
-          {@render sidebarContent()}
-        </div>
-      </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
-  </DialogPrimitive.Root>
+  <div
+    data-sidebar-backdrop
+    data-kumo-component="Sidebar"
+    data-kumo-part="mobile-backdrop"
+    class={cn(
+      sidebar.contained ? 'absolute inset-0 z-40 bg-kumo-recessed' : 'fixed inset-0 z-40 bg-kumo-recessed',
+      'transition-opacity duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
+      sidebar.openMobile ? 'opacity-80' : 'pointer-events-none opacity-0'
+    )}
+    onclick={() => closeMobile(true)}
+    aria-hidden="true"
+  ></div>
+
+  <nav
+    bind:this={mobileNode}
+    tabindex="-1"
+    aria-label="Navigation"
+    aria-hidden={sidebar.openMobile ? undefined : 'true'}
+    inert={sidebar.openMobile ? undefined : true}
+    data-state={sidebar.openMobile ? 'expanded' : 'collapsed'}
+    data-side={sidebar.side}
+    data-variant={sidebar.variant}
+    data-collapsible={sidebar.collapsible}
+    data-mobile="true"
+    data-sidebar="sidebar"
+    class={cn(
+      sidebar.contained
+        ? 'group/sidebar absolute inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden'
+        : 'group/sidebar fixed inset-y-0 z-50 flex w-(--sidebar-width) flex-col overflow-hidden',
+      'border-r border-kumo-line bg-(--sidebar-bg) text-kumo-default transition-transform duration-(--sidebar-animation-duration) ease-(--sidebar-easing) motion-reduce:transition-none',
+      sidebar.side === 'left' && 'left-0',
+      sidebar.side === 'right' && 'right-0',
+      sidebar.side === 'left' && (sidebar.openMobile ? 'translate-x-0' : '-translate-x-full'),
+      sidebar.side === 'right' && (sidebar.openMobile ? 'translate-x-0' : 'translate-x-full'),
+      className
+    )}
+    onkeydown={handleMobileKeydown}
+    onfocusout={handleMobileFocusout}
+    {...rest}
+  >
+    {@render sidebarContent()}
+  </nav>
 {:else}
   <aside
     data-state={sidebar.state}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsible.svelte
@@ -2,8 +2,24 @@
   import type { Snippet } from 'svelte';
   import { setContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface Props { children?: Snippet; class?: string; defaultOpen?: boolean; open?: boolean; onOpenChange?: (open: boolean) => void; [key: string]: unknown; }
-  let { children, class: className, defaultOpen = false, open = $bindable(defaultOpen), onOpenChange, ...rest }: Props = $props();
+  interface Props {
+    children?: Snippet;
+    class?: string;
+    defaultOpen?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    autoScrollOnOpen?: boolean;
+    [key: string]: unknown;
+  }
+  let {
+    children,
+    class: className,
+    defaultOpen = false,
+    open = $bindable(defaultOpen),
+    onOpenChange,
+    autoScrollOnOpen = false,
+    ...rest
+  }: Props = $props();
   const contentId = `kumo-sidebar-collapsible-${Math.random().toString(36).slice(2)}`;
   const context = {
     get open() {
@@ -11,6 +27,9 @@
     },
     get contentId() {
       return contentId;
+    },
+    get autoScrollOnOpen() {
+      return autoScrollOnOpen;
     },
     toggle() {
       open = !open;

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleContent.svelte
@@ -2,22 +2,41 @@
   import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface CollapsibleContext { get open(): boolean; get contentId(): string; toggle(): void; }
+  import { getSidebarContext } from './context';
+  interface CollapsibleContext { get open(): boolean; get contentId(): string; get autoScrollOnOpen(): boolean; toggle(): void; }
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
   const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');
+  const sidebar = getSidebarContext('Sidebar.CollapsibleContent');
+  let contentEl: HTMLDivElement | null = $state(null);
+  const isOpen = $derived(Boolean(collapsible?.open && sidebar.state !== 'collapsed'));
+
+  $effect(() => {
+    if (!isOpen || !collapsible?.autoScrollOnOpen || !contentEl) return;
+
+    const timeout = window.setTimeout(() => {
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      contentEl?.scrollIntoView({
+        block: 'nearest',
+        behavior: prefersReducedMotion ? 'auto' : 'smooth'
+      });
+    }, sidebar.animationDuration);
+
+    return () => window.clearTimeout(timeout);
+  });
 </script>
 
 <div
+  bind:this={contentEl}
   id={collapsible?.contentId}
   data-sidebar="collapsible-content"
-  data-open={collapsible?.open ? '' : undefined}
+  data-open={isOpen ? '' : undefined}
   role="region"
-  aria-hidden={collapsible?.open ? undefined : 'true'}
-  inert={collapsible?.open ? undefined : true}
+  aria-hidden={isOpen ? undefined : 'true'}
+  inert={isOpen ? undefined : true}
   class={cn(
     'grid overflow-hidden transition-[grid-template-rows,opacity] duration-(--sidebar-animation-duration) motion-reduce:transition-none',
-    collapsible?.open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
+    isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
     className
   )}
   {...rest}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarCollapsibleTrigger.svelte
@@ -2,7 +2,7 @@
   import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  interface CollapsibleContext { get open(): boolean; get contentId(): string; toggle(): void; }
+  interface CollapsibleContext { get open(): boolean; get contentId(): string; get autoScrollOnOpen(): boolean; toggle(): void; }
   interface Props { children?: Snippet; class?: string; [key: string]: unknown; }
   let { children, class: className, ...rest }: Props = $props();
   const collapsible = getContext<CollapsibleContext>('kumo-sidebar-collapsible');

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
@@ -8,13 +8,14 @@
 <div
   data-sidebar="content"
   class={cn(
-    'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-[11px] py-[13px] transition-[padding] duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:px-3.5 group-data-[state=collapsed]/sidebar:overflow-x-hidden!',
+    'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-[11px] py-3 transition-[padding] duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:px-3.5 group-data-[state=collapsed]/sidebar:overflow-x-hidden!',
+    'group-data-[mobile=true]/sidebar:px-3.5',
     className
   )}
   role="presentation"
   {...rest}
 >
-  <div class="flex min-w-0 flex-col gap-2 group-data-[state=collapsed]/sidebar:min-w-0!">
+  <div class="flex min-w-0! flex-col">
     {@render children?.()}
   </div>
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
@@ -9,12 +9,13 @@
   data-sidebar="group-label"
   class={cn(
     'grid grid-rows-[0fr] overflow-hidden border-b border-kumo-line my-3 transition-[grid-template-rows,margin,border-color] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) [[data-sidebar=group]:first-child_&]:my-0 [[data-sidebar=group]:first-child_&]:border-transparent group-not-data-[state=collapsed]/sidebar:grid-rows-[1fr] group-not-data-[state=collapsed]/sidebar:my-0 group-not-data-[state=collapsed]/sidebar:border-transparent',
+    'group-data-[mobile=true]/sidebar:my-0 group-data-[mobile=true]/sidebar:grid-rows-[1fr] group-data-[mobile=true]/sidebar:border-transparent group-data-[mobile=true]/sidebar:transition-none',
     className
   )}
   {...rest}
 >
-  <div class="min-h-0">
-    <div class="truncate px-3 mt-4 mb-2 text-sm font-medium text-kumo-subtle [[data-sidebar=group]:first-child_&]:mt-2">
+  <div class="min-h-0 min-w-0">
+    <div class="truncate px-3 mt-6 mb-2 text-sm font-medium text-kumo-subtle [[data-sidebar=group]:first-child_&]:mt-2">
       {@render children?.()}
     </div>
   </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarHeader.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarHeader.svelte
@@ -5,6 +5,6 @@
   let { children, class: className, ...rest }: Props = $props();
 </script>
 
-<div data-sidebar="header" class={cn('flex h-[58px] items-center gap-1 overflow-hidden border-b border-kumo-line px-3.5', className)} {...rest}>
+<div data-sidebar="header" class={cn('flex h-[58px] shrink-0 items-center gap-1 overflow-hidden border-b border-kumo-line px-3', className)} {...rest}>
   {@render children?.()}
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuButton.svelte
@@ -11,11 +11,12 @@
     active?: boolean;
     size?: 'base' | 'sm';
     href?: string;
+    target?: string;
     tooltip?: string;
     [key: string]: unknown;
   }
 
-  let { children, class: className, icon: Icon, active = false, size = 'base', href, tooltip, ...rest }: Props = $props();
+  let { children, class: className, icon: Icon, active = false, size = 'base', href, target, tooltip, ...rest }: Props = $props();
   const menuItem = getSidebarMenuItemContext();
   let sidebar = $state<ReturnType<typeof getSidebarContext> | undefined>();
 
@@ -27,14 +28,14 @@
 
   const classes = $derived(
     cn(
-      'group/menu-button relative flex w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg text-kumo-default outline-none transition-[color,background-color,box-shadow,outline] duration-(--sidebar-animation-duration)',
+      'group/menu-button relative flex w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg text-kumo-default outline-none transition-[color,box-shadow,outline] duration-(--sidebar-animation-duration)',
       'before:absolute before:inset-x-0 before:-inset-y-px',
       size === 'base' && 'min-h-8.5 px-3 py-0 text-sm font-medium',
       size === 'sm' && 'min-h-7 px-2 py-0 text-sm',
-      !active && 'hover:bg-kumo-tint',
-      active && 'bg-kumo-tint',
-      'has-[[data-active]]:bg-transparent has-[[data-active]]:hover:bg-kumo-tint',
-      'focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong',
+      !active && 'hover:bg-(--sidebar-active-bg)',
+      active && 'bg-(--sidebar-active-bg)',
+      'has-[[data-active]]:bg-transparent has-[[data-active]]:hover:bg-(--sidebar-active-bg)',
+      'focus:outline-none focus-visible:bg-(--sidebar-active-bg) focus-visible:text-kumo-strong',
       className
     )
   );
@@ -46,6 +47,7 @@
     <a
       class={cn(classes, 'no-underline!')}
       {href}
+      {target}
       data-active={active || undefined}
       data-sidebar="menu-button"
       data-kumo-component="Sidebar"
@@ -55,7 +57,7 @@
       {...rest}
     >
       <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
-        {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
+        {#if Icon}<Icon class={cn('shrink-0 opacity-40', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
         <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
           {@render children?.()}
         </span>
@@ -74,7 +76,7 @@
       {...rest}
     >
       <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
-        {#if Icon}<Icon class={cn('shrink-0 opacity-50', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
+        {#if Icon}<Icon class={cn('shrink-0 opacity-40', size === 'base' ? 'size-4' : 'size-3.5')} />{/if}
         <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
           {@render children?.()}
         </span>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuChevron.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuChevron.svelte
@@ -5,4 +5,12 @@
   let { class: className, open = false, ...rest }: Props = $props();
 </script>
 
-<CaretRight data-sidebar="menu-chevron" class={cn('ml-auto size-4 shrink-0 text-kumo-subtle transition-transform duration-200 group-data-[state=collapsed]/sidebar:hidden', open && 'rotate-90', className)} {...rest} />
+<CaretRight
+  data-sidebar="menu-chevron"
+  class={cn(
+    'ml-auto size-4 shrink-0 opacity-40 transition-[transform,rotate,opacity] duration-200 group-hover/menu-button:opacity-100 group-data-[state=collapsed]/sidebar:hidden',
+    open && 'rotate-90',
+    className
+  )}
+  {...rest}
+/>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSub.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSub.svelte
@@ -5,7 +5,7 @@
   let { children, class: className, ...rest }: Props = $props();
 </script>
 
-<ul data-sidebar="menu-sub" class={cn('relative m-0 flex min-w-0 list-none flex-col gap-y-px overflow-hidden p-0 pl-7 pr-0 group-data-[state=collapsed]/sidebar:hidden', className)} {...rest}>
+<ul data-sidebar="menu-sub" class={cn('relative m-0 flex min-w-0 list-none flex-col gap-y-px overflow-hidden p-0 pl-7 pr-0', className)} {...rest}>
   <div class="absolute inset-y-px left-[19px] z-10 w-px bg-kumo-line"></div>
   {@render children?.()}
 </ul>

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarMenuSubButton.svelte
@@ -5,17 +5,25 @@
   interface Props { children?: Snippet; class?: string; active?: boolean; href?: string; [key: string]: unknown; }
   let { children, class: className, active = false, href, ...rest }: Props = $props();
   const menuSubItem = getSidebarMenuSubItemContext();
-  const classes = $derived(cn('relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-colors duration-150 hover:bg-kumo-tint focus:outline-none focus-visible:bg-kumo-tint focus-visible:text-kumo-strong', active && 'bg-kumo-tint', className));
+  const classes = $derived(
+    cn(
+      'group/menu-button relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-[color] duration-150',
+      !active && 'hover:bg-(--sidebar-active-bg)',
+      active && 'bg-(--sidebar-active-bg)',
+      'focus:outline-none focus-visible:bg-(--sidebar-active-bg) focus-visible:text-kumo-strong',
+      className
+    )
+  );
 </script>
 
 {#snippet control()}
   {#if href}
     <a class={cn(classes, 'no-underline!')} {href} data-active={active || undefined} data-sidebar="menu-sub-button" data-kumo-component="Sidebar" data-kumo-part="menu-sub-button-link" {...rest}>
-      <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
+      <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
     </a>
   {:else}
     <button type="button" class={classes} data-active={active || undefined} data-sidebar="menu-sub-button" data-kumo-component="Sidebar" data-kumo-part="menu-sub-button" {...rest}>
-      <span class="flex min-w-0 flex-1 items-center gap-2 truncate text-left">{@render children?.()}</span>
+      <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">{@render children?.()}</span>
     </button>
   {/if}
 {/snippet}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarProvider.svelte
@@ -27,6 +27,7 @@
     contained?: boolean;
     peekable?: boolean;
     animationDuration?: number;
+    mobileBreakpoint?: number;
   }
 
   let {
@@ -45,7 +46,8 @@
     onWidthChange,
     contained = false,
     peekable = false,
-    animationDuration = 250
+    animationDuration = 250,
+    mobileBreakpoint = 768
   }: Props = $props();
 
   let width: number = $state(256);
@@ -59,7 +61,7 @@
   const sidebarWidth = $derived(resizable ? `${width}px` : '16.25rem');
 
   onMount(() => {
-    const media = window.matchMedia('(max-width: 767px)');
+    const media = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`);
     const update = () => {
       isMobile = media.matches;
       if (!media.matches) openMobile = false;
@@ -82,7 +84,9 @@
 
   function setOpenMobile(nextOpen: boolean) {
     openMobile = nextOpen;
+    open = nextOpen;
     if (nextOpen) isPeeking = false;
+    onOpenChange?.(nextOpen);
   }
 
   function setWidth(nextWidth: number) {
@@ -101,6 +105,12 @@
   function stopPeek() {
     isPeeking = false;
   }
+
+  $effect(() => {
+    if (isMobile && openMobile !== open) {
+      openMobile = open;
+    }
+  });
 
   setSidebarContext({
     get state() {
@@ -131,6 +141,9 @@
     },
     get animationDuration() {
       return animationDuration;
+    },
+    get mobileBreakpoint() {
+      return mobileBreakpoint;
     },
     get width() {
       return width;
@@ -175,9 +188,10 @@
   style:--sidebar-animation-duration={`${animationDuration}ms`}
   style:--sidebar-easing="cubic-bezier(0.77, 0, 0.175, 1)"
   style:--sidebar-bg="var(--color-kumo-base)"
+  style:--sidebar-active-bg="var(--color-kumo-tint)"
   class={cn(
-    'group/sidebar-wrapper isolate flex w-full',
-    !contained && 'min-h-svh',
+    'group/sidebar-wrapper relative isolate flex w-full',
+    !contained && !isMobile && 'min-h-svh',
     variant === 'inset' && 'bg-kumo-recessed',
     isResizing && 'select-none',
     className

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarSlidingViews.svelte
@@ -14,6 +14,6 @@
   });
 </script>
 
-<div data-sidebar="sliding-views" data-direction={direction} class={cn('relative min-h-0 flex-1 overflow-hidden', className)} {...rest}>
+<div data-sidebar="sliding-views" data-direction={direction} class={cn('relative min-h-0 max-w-(--sidebar-width) flex-1 overflow-hidden', className)} {...rest}>
   {@render children?.()}
 </div>

--- a/packages/kumo-svelte/src/lib/components/sidebar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/sidebar/context.ts
@@ -1,9 +1,9 @@
-import { getContext, setContext } from 'svelte';
+import { getContext, setContext } from "svelte";
 
-export type SidebarState = 'expanded' | 'collapsed' | 'peeking';
-export type SidebarSide = 'left' | 'right';
-export type SidebarVariant = 'sidebar' | 'floating' | 'inset';
-export type SidebarCollapsible = 'icon' | 'offcanvas' | 'none';
+export type SidebarState = "expanded" | "collapsed" | "peeking";
+export type SidebarSide = "left" | "right";
+export type SidebarVariant = "sidebar" | "floating" | "inset";
+export type SidebarCollapsible = "icon" | "offcanvas" | "none";
 
 export interface SidebarContextValue {
   get state(): SidebarState;
@@ -17,6 +17,7 @@ export interface SidebarContextValue {
   get collapsible(): SidebarCollapsible;
   get contained(): boolean;
   get animationDuration(): number;
+  get mobileBreakpoint(): number;
   get width(): number;
   get resizable(): boolean;
   get isResizing(): boolean;
@@ -39,9 +40,9 @@ export interface SidebarMenuSubItemContextValue {
   get insideMenuSubItem(): boolean;
 }
 
-const SIDEBAR_CONTEXT = Symbol('kumo-sidebar');
-const SIDEBAR_MENU_ITEM_CONTEXT = Symbol('kumo-sidebar-menu-item');
-const SIDEBAR_MENU_SUB_ITEM_CONTEXT = Symbol('kumo-sidebar-menu-sub-item');
+const SIDEBAR_CONTEXT = Symbol("kumo-sidebar");
+const SIDEBAR_MENU_ITEM_CONTEXT = Symbol("kumo-sidebar-menu-item");
+const SIDEBAR_MENU_SUB_ITEM_CONTEXT = Symbol("kumo-sidebar-menu-sub-item");
 
 export function setSidebarContext(context: SidebarContextValue) {
   setContext(SIDEBAR_CONTEXT, context);
@@ -49,22 +50,31 @@ export function setSidebarContext(context: SidebarContextValue) {
 
 export function getSidebarContext(component: string) {
   const context = getContext<SidebarContextValue | undefined>(SIDEBAR_CONTEXT);
-  if (!context) throw new Error(`${component} must be used inside <Sidebar.Provider>.`);
+  if (!context)
+    throw new Error(`${component} must be used inside <Sidebar.Provider>.`);
   return context;
 }
 
-export function setSidebarMenuItemContext(context: SidebarMenuItemContextValue) {
+export function setSidebarMenuItemContext(
+  context: SidebarMenuItemContextValue,
+) {
   setContext(SIDEBAR_MENU_ITEM_CONTEXT, context);
 }
 
 export function getSidebarMenuItemContext() {
-  return getContext<SidebarMenuItemContextValue | undefined>(SIDEBAR_MENU_ITEM_CONTEXT);
+  return getContext<SidebarMenuItemContextValue | undefined>(
+    SIDEBAR_MENU_ITEM_CONTEXT,
+  );
 }
 
-export function setSidebarMenuSubItemContext(context: SidebarMenuSubItemContextValue) {
+export function setSidebarMenuSubItemContext(
+  context: SidebarMenuSubItemContextValue,
+) {
   setContext(SIDEBAR_MENU_SUB_ITEM_CONTEXT, context);
 }
 
 export function getSidebarMenuSubItemContext() {
-  return getContext<SidebarMenuSubItemContextValue | undefined>(SIDEBAR_MENU_SUB_ITEM_CONTEXT);
+  return getContext<SidebarMenuSubItemContextValue | undefined>(
+    SIDEBAR_MENU_SUB_ITEM_CONTEXT,
+  );
 }

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
@@ -199,6 +199,17 @@
     shouldSuppressClick = false;
   }
 
+  function handleTriggerClick(event: MouseEvent) {
+    const trigger = event.currentTarget;
+    if (!(trigger instanceof HTMLElement)) return;
+
+    trigger.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest'
+    });
+  }
+
   $effect(() => {
     if (normalizedItems.length === 0) return;
     value ??= selectedValue ?? normalizedItems[0]?.value;
@@ -233,7 +244,12 @@
     bind:value
     onValueChange={handleValueChange}
     {activationMode}
-    class={cn('relative isolate min-w-0 font-medium', className, classNameAlias)}
+    class={cn(
+      'relative isolate min-w-0 font-medium',
+      isSegmented && (isSm ? 'rounded-md' : 'rounded-lg') + ' ring ring-kumo-hairline/70',
+      className,
+      classNameAlias
+    )}
     {...rest}
   >
     {#if isSegmented}
@@ -250,7 +266,7 @@
       class={cn(
         'relative flex min-w-0 shrink items-stretch',
         isSegmented &&
-          'kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 ring ring-kumo-hairline/70 [--scroll-fade-width:3rem]',
+          'kumo-tabs-list overflow-x-auto rounded-lg bg-kumo-recessed px-0.5 [--scroll-fade-width:3rem] scroll-px-(--scroll-fade-width)',
         isSegmented && (isSm ? 'h-6.5 rounded-md' : 'h-9'),
         isOverflowing && 'cursor-grab active:cursor-grabbing',
         isUnderline && 'gap-4 border-b border-kumo-hairline pb-2',
@@ -265,13 +281,14 @@
           disabled={tab.disabled}
           data-kumo-component="Tabs"
           data-kumo-part="tab"
+          onclick={handleTriggerClick}
           class={cn(
             'relative z-2 flex items-center rounded bg-transparent whitespace-nowrap focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand',
             isOverflowing ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer',
             isSm ? 'text-xs' : 'text-base',
             isSegmented &&
-              'my-0.5 rounded-md text-kumo-subtle hover:text-kumo-default data-[state=active]:text-kumo-default focus-visible:ring-inset',
-            isSegmented && (isSm ? 'px-2' : 'px-2.5'),
+              'my-0.5 text-kumo-subtle hover:text-kumo-default data-[state=active]:text-kumo-default focus-visible:ring-inset',
+            isSegmented && (isSm ? 'px-2 rounded-sm' : 'px-2.5 rounded-md'),
             isUnderline &&
               'text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default data-[state=active]:hover:bg-kumo-tint data-[state=active]:font-medium data-[state=active]:text-kumo-default',
             isUnderline && (isSm ? 'px-1.5 py-2.5' : 'px-2 py-3'),

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarAutoScrollDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarAutoScrollDemo.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import SidebarDemoShell from './SidebarDemoShell.svelte';
+</script>
+
+<SidebarDemoShell demo="auto-scroll" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarDemoShell.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarDemoShell.svelte
@@ -22,7 +22,7 @@
     User
   } from 'phosphor-svelte';
 
-  type Demo = 'basic' | 'collapsible' | 'toggle' | 'full' | 'resizable' | 'right' | 'peeking' | 'sliding';
+  type Demo = 'basic' | 'collapsible' | 'toggle' | 'full' | 'resizable' | 'right' | 'peeking' | 'auto-scroll' | 'sliding' | 'mobile';
 
   interface Props {
     demo?: Demo;
@@ -47,7 +47,8 @@
     defaultWidth: 240,
     minWidth: 180,
     maxWidth: 400,
-    peekable: demo === 'full' || demo === 'peeking'
+    peekable: demo === 'full' || demo === 'peeking',
+    mobileBreakpoint: demo === 'mobile' ? 9999 : 768
   });
 
   const ActiveAccountIcon = $derived(selectedAccount.icon);
@@ -64,7 +65,7 @@
 {/snippet}
 
 {#snippet brandLogo()}
-  <div class="flex w-full min-w-0 items-center gap-2 px-3 transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) group-data-[state=collapsed]/sidebar:px-2">
+  <div class="flex w-full min-w-0 items-center gap-2 px-3 transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) group-data-[state=collapsed]/sidebar:px-2 group-data-[mobile=true]/sidebar:px-3">
     <Cube class="size-4 shrink-0 text-kumo-brand" weight="duotone" />
     <span class="flex-1 truncate text-sm font-semibold text-kumo-strong">Company</span>
   </div>
@@ -72,7 +73,7 @@
 
 {#snippet accountSwitcher()}
   <DropdownMenu>
-    <DropdownMenu.Trigger class="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-kumo-default outline-none transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-line group-data-[state=collapsed]/sidebar:px-1.5">
+    <DropdownMenu.Trigger class="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium text-kumo-default outline-none transition-[padding] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) hover:bg-kumo-tint focus-visible:ring-1 focus-visible:ring-kumo-line group-data-[state=collapsed]/sidebar:px-1.5 group-data-[mobile=true]/sidebar:px-3">
       <ActiveAccountIcon class="size-4 shrink-0 text-kumo-brand" weight="duotone" />
       <span class="flex min-w-0 flex-1 items-center overflow-hidden text-left">{selectedAccount.name}</span>
       <span class="w-4 shrink-0 overflow-hidden transition-[width] duration-(--sidebar-animation-duration) ease-(--sidebar-easing) group-data-[state=collapsed]/sidebar:w-0">
@@ -213,13 +214,70 @@
   </Sidebar.Content>
 {/snippet}
 
-<div class="relative h-[540px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base">
+{#snippet autoScrollSurface()}
+  <Sidebar.Content>
+    <Sidebar.Group>
+      <Sidebar.GroupLabel>Overview</Sidebar.GroupLabel>
+      <Sidebar.Menu>
+        <Sidebar.MenuButton icon={House} active>Home</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={ChartBar}>Analytics</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={Globe}>Domains</Sidebar.MenuButton>
+      </Sidebar.Menu>
+    </Sidebar.Group>
+
+    <Sidebar.Group>
+      <Sidebar.GroupLabel>Platform</Sidebar.GroupLabel>
+      <Sidebar.Menu>
+        <Sidebar.MenuButton icon={Database}>Storage</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={ShieldCheck}>Security</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={Lock}>Zero Trust</Sidebar.MenuButton>
+        <Sidebar.MenuButton icon={Gear}>Settings</Sidebar.MenuButton>
+      </Sidebar.Menu>
+    </Sidebar.Group>
+
+    <Sidebar.Group>
+      <Sidebar.GroupLabel>Build</Sidebar.GroupLabel>
+      <Sidebar.Menu>
+        <Sidebar.MenuItem>
+          <Sidebar.Collapsible autoScrollOnOpen>
+            <Sidebar.CollapsibleTrigger
+              class="group/menu-button relative flex min-h-8.5 w-full min-w-0 cursor-pointer items-center gap-2.5 rounded-lg px-3 py-0 text-sm font-medium text-kumo-default outline-none transition-[color,box-shadow,outline] duration-(--sidebar-animation-duration) hover:bg-(--sidebar-active-bg) focus:outline-none focus-visible:bg-(--sidebar-active-bg) focus-visible:text-kumo-strong"
+            >
+              <span class="flex min-w-0 flex-1 items-center gap-3 translate-x-[-3px] transition-transform duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:translate-x-0">
+                <Code class="size-4 shrink-0 opacity-40" />
+                <span class="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left">
+                  Workers
+                  <Sidebar.MenuChevron />
+                </span>
+              </span>
+            </Sidebar.CollapsibleTrigger>
+            <Sidebar.CollapsibleContent>
+              <Sidebar.MenuSub>
+                <Sidebar.MenuSubButton>Overview</Sidebar.MenuSubButton>
+                <Sidebar.MenuSubButton>Deployments</Sidebar.MenuSubButton>
+                <Sidebar.MenuSubButton>Observability</Sidebar.MenuSubButton>
+                <Sidebar.MenuSubButton>Settings</Sidebar.MenuSubButton>
+              </Sidebar.MenuSub>
+            </Sidebar.CollapsibleContent>
+          </Sidebar.Collapsible>
+        </Sidebar.MenuItem>
+        <Sidebar.MenuButton icon={Cube}>
+          Containers
+          <Sidebar.MenuBadge>Beta</Sidebar.MenuBadge>
+        </Sidebar.MenuButton>
+      </Sidebar.Menu>
+    </Sidebar.Group>
+  </Sidebar.Content>
+{/snippet}
+
+<div class={demo === 'auto-scroll' ? 'relative h-[420px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base' : 'relative h-[540px] w-full overflow-hidden rounded-lg border border-kumo-line bg-kumo-base'}>
   <Sidebar.Provider
     class="min-h-0! h-full"
     contained={providerProps.contained}
     bind:open
     defaultOpen={providerProps.defaultOpen}
     side={providerProps.side}
+    mobileBreakpoint={providerProps.mobileBreakpoint}
     resizable={providerProps.resizable}
     defaultWidth={providerProps.defaultWidth}
     minWidth={providerProps.minWidth}
@@ -242,7 +300,7 @@
       </Sidebar>
     {:else}
       <Sidebar>
-        {#if demo === 'toggle' || demo === 'resizable' || demo === 'peeking'}
+        {#if demo === 'toggle' || demo === 'resizable' || demo === 'peeking' || demo === 'auto-scroll' || demo === 'mobile'}
           <Sidebar.Header>{@render brandLogo()}</Sidebar.Header>
         {:else if demo === 'full'}
           <Sidebar.Header>{@render accountSwitcher()}</Sidebar.Header>
@@ -293,11 +351,13 @@
             <Sidebar.SlidingView value="account">{@render accountSurface()}</Sidebar.SlidingView>
             <Sidebar.SlidingView value="domain">{@render domainSurface()}</Sidebar.SlidingView>
           </Sidebar.SlidingViews>
+        {:else if demo === 'auto-scroll'}
+          {@render autoScrollSurface()}
         {:else}
           {@render accountSurface()}
         {/if}
 
-        {#if demo === 'toggle' || demo === 'resizable' || demo === 'full' || demo === 'peeking'}
+        {#if demo === 'toggle' || demo === 'resizable' || demo === 'full' || demo === 'peeking' || demo === 'auto-scroll' || demo === 'mobile'}
           <Sidebar.Footer><Sidebar.Trigger /></Sidebar.Footer>
         {/if}
 
@@ -312,8 +372,12 @@
         {@render demoMain(resizableContent)}
       {:else if demo === 'peeking'}
         {@render demoMain(peekingContent)}
+      {:else if demo === 'auto-scroll'}
+        {@render demoMain(autoScrollContent)}
       {:else if demo === 'sliding'}
         {@render demoMain(slidingContent)}
+      {:else if demo === 'mobile'}
+        {@render demoMain(mobileContent)}
       {:else}
         {@render demoMain()}
       {/if}
@@ -348,4 +412,20 @@
     <p class="font-medium text-kumo-default">Active: {surface === 'account' ? 'Account' : 'Zone'} surface</p>
     <p>Click the header button to slide between views</p>
   </div>
+{/snippet}
+
+{#snippet autoScrollContent()}
+  <p>Open Workers near the bottom of the list</p>
+{/snippet}
+
+{#snippet mobileContent()}
+  <button
+    type="button"
+    class="cursor-pointer rounded-lg border border-kumo-line bg-kumo-base px-3 py-1.5 text-base text-kumo-default transition-colors hover:bg-kumo-tint"
+    onclick={() => (open = !open)}
+  >
+    {open ? 'Close sidebar' : 'Open sidebar'}
+  </button>
+  <p>Click the button to open the mobile sidebar</p>
+  <p class="text-sm text-kumo-subtle">Press Escape or click the backdrop to close</p>
 {/snippet}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarMobileDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SidebarMobileDemo.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import SidebarDemoShell from './SidebarDemoShell.svelte';
+</script>
+
+<SidebarDemoShell demo="mobile" />

--- a/packages/kumo-svelte/src/lib/docs/props-data/Collapsible.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Collapsible.ts
@@ -1,62 +1,70 @@
-import type { PropRow } from '../prop-types';
+import type { PropRow } from "../prop-types";
 
 const rows: PropRow[] = [
   {
-    "prop": "trigger",
-    "type": "Snippet",
-    "required": false,
-    "description": "trigger prop."
+    prop: "trigger",
+    type: "Snippet",
+    required: false,
+    description: "trigger prop.",
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
+    prop: "children",
+    type: "Snippet",
+    required: false,
+    description: "Child snippet rendered by the component.",
   },
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    prop: "class",
+    type: "string",
+    required: false,
+    description: "Additional classes merged onto the root element.",
   },
   {
-    "prop": "open",
-    "type": "boolean",
-    "required": false,
-    "description": "Controlled open state."
+    prop: "open",
+    type: "boolean",
+    required: false,
+    description: "Controlled open state.",
   },
   {
-    "prop": "defaultOpen",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Initial uncontrolled open state."
+    prop: "defaultOpen",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Initial uncontrolled open state.",
   },
   {
-    "prop": "title",
-    "type": "string",
-    "required": false,
-    "description": "Title content."
+    prop: "title",
+    type: "string",
+    required: false,
+    description: "Title content.",
   },
   {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Disables the component."
+    prop: "disabled",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Disables the component.",
   },
   {
-    "prop": "onOpenChange",
-    "type": "(open: boolean) => void",
-    "required": false,
-    "description": "Called when open state changes."
+    prop: "onOpenChange",
+    type: "(open: boolean) => void",
+    required: false,
+    description: "Called when open state changes.",
   },
   {
-    "prop": "onOpenChangeComplete",
-    "type": "(open: boolean) => void",
-    "required": false,
-    "description": "Called after the open-state transition completes."
-  }
+    prop: "autoScrollOnOpen",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description:
+      "Scrolls newly expanded sidebar content into view after opening.",
+  },
+  {
+    prop: "onOpenChangeComplete",
+    type: "(open: boolean) => void",
+    required: false,
+    description: "Called after the open-state transition completes.",
+  },
 ];
 
 export default rows;

--- a/packages/kumo-svelte/src/lib/docs/props-data/Sidebar.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Sidebar.ts
@@ -1,39 +1,46 @@
-import type { PropRow } from '../prop-types';
+import type { PropRow } from "../prop-types";
 
 const rows: PropRow[] = [
   {
-    "prop": "variant",
-    "type": "\"sidebar\" | \"floating\" | \"inset\"",
-    "default": "\"sidebar\"",
-    "required": false,
-    "description": "Sidebar layout variant inherited from Provider."
+    prop: "variant",
+    type: '"sidebar" | "floating" | "inset"',
+    default: '"sidebar"',
+    required: false,
+    description: "Sidebar layout variant inherited from Provider.",
   },
   {
-    "prop": "side",
-    "type": "\"left\" | \"right\"",
-    "default": "\"left\"",
-    "required": false,
-    "description": "Side of the viewport or layout where the sidebar renders."
+    prop: "side",
+    type: '"left" | "right"',
+    default: '"left"',
+    required: false,
+    description: "Side of the viewport or layout where the sidebar renders.",
   },
   {
-    "prop": "collapsible",
-    "type": "\"icon\" | \"offcanvas\" | \"none\"",
-    "default": "\"icon\"",
-    "required": false,
-    "description": "Collapse behavior inherited from Provider."
+    prop: "collapsible",
+    type: '"icon" | "offcanvas" | "none"',
+    default: '"icon"',
+    required: false,
+    description: "Collapse behavior inherited from Provider.",
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": true,
-    "description": "Sidebar content — Header, Content, Footer, groups, menus, and related slots."
+    prop: "children",
+    type: "Snippet",
+    required: true,
+    description:
+      "Sidebar content — Header, Content, Footer, groups, menus, and related slots.",
   },
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes for the sidebar element."
-  }
+    prop: "contentClass",
+    type: "string",
+    required: false,
+    description: "Additional classes for the desktop content container.",
+  },
+  {
+    prop: "class",
+    type: "string",
+    required: false,
+    description: "Additional classes for the sidebar element.",
+  },
 ];
 
 export default rows;

--- a/packages/kumo-svelte/src/lib/docs/props-data/Sidebar__Provider.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Sidebar__Provider.ts
@@ -1,22 +1,104 @@
-import type { PropRow } from '../prop-types';
+import type { PropRow } from "../prop-types";
 
 const rows: PropRow[] = [
-  { prop: 'defaultOpen', type: 'boolean', default: 'true', description: 'Initial open state when uncontrolled.' },
-  { prop: 'open', type: 'boolean', description: 'Controlled open state.' },
-  { prop: 'onOpenChange', type: '(open: boolean) => void', description: 'Callback when open state changes.' },
-  { prop: 'variant', type: '"sidebar" | "floating" | "inset"', default: '"sidebar"', description: 'Sidebar layout variant.' },
-  { prop: 'side', type: '"left" | "right"', default: '"left"', description: 'Which side the sidebar is on.' },
-  { prop: 'collapsible', type: '"icon" | "offcanvas" | "none"', default: '"icon"', description: 'Collapse behavior for the sidebar.' },
-  { prop: 'resizable', type: 'boolean', default: 'false', description: 'Enable drag-to-resize on the sidebar edge.' },
-  { prop: 'defaultWidth', type: 'number', default: '256', description: 'Initial width in pixels when resizable.' },
-  { prop: 'minWidth', type: 'number', default: '200', description: 'Minimum width in pixels when resizing.' },
-  { prop: 'maxWidth', type: 'number', default: '480', description: 'Maximum width in pixels when resizing.' },
-  { prop: 'onWidthChange', type: '(width: number) => void', description: 'Callback when width changes during resize.' },
-  { prop: 'contained', type: 'boolean', default: 'false', description: 'Keeps the provider scoped to its parent container instead of using full viewport height.' },
-  { prop: 'peekable', type: 'boolean', default: 'false', description: 'Allows collapsed sidebars to temporarily reveal full content while hovered or focused.' },
-  { prop: 'animationDuration', type: 'number', default: '250', description: 'Transition duration in milliseconds for width and peek animations.' },
-  { prop: 'children', type: 'Snippet', required: true, description: 'Content, typically Sidebar plus main content.' },
-  { prop: 'class', type: 'string', description: 'Additional classes for the wrapper div.' }
+  {
+    prop: "defaultOpen",
+    type: "boolean",
+    default: "true",
+    description: "Initial open state when uncontrolled.",
+  },
+  { prop: "open", type: "boolean", description: "Controlled open state." },
+  {
+    prop: "onOpenChange",
+    type: "(open: boolean) => void",
+    description: "Callback when open state changes.",
+  },
+  {
+    prop: "variant",
+    type: '"sidebar" | "floating" | "inset"',
+    default: '"sidebar"',
+    description: "Sidebar layout variant.",
+  },
+  {
+    prop: "side",
+    type: '"left" | "right"',
+    default: '"left"',
+    description: "Which side the sidebar is on.",
+  },
+  {
+    prop: "collapsible",
+    type: '"icon" | "offcanvas" | "none"',
+    default: '"icon"',
+    description: "Collapse behavior for the sidebar.",
+  },
+  {
+    prop: "resizable",
+    type: "boolean",
+    default: "false",
+    description: "Enable drag-to-resize on the sidebar edge.",
+  },
+  {
+    prop: "defaultWidth",
+    type: "number",
+    default: "256",
+    description: "Initial width in pixels when resizable.",
+  },
+  {
+    prop: "minWidth",
+    type: "number",
+    default: "200",
+    description: "Minimum width in pixels when resizing.",
+  },
+  {
+    prop: "maxWidth",
+    type: "number",
+    default: "480",
+    description: "Maximum width in pixels when resizing.",
+  },
+  {
+    prop: "onWidthChange",
+    type: "(width: number) => void",
+    description: "Callback when width changes during resize.",
+  },
+  {
+    prop: "contained",
+    type: "boolean",
+    default: "false",
+    description:
+      "Keeps the provider scoped to its parent container instead of using full viewport height.",
+  },
+  {
+    prop: "peekable",
+    type: "boolean",
+    default: "false",
+    description:
+      "Allows collapsed sidebars to temporarily reveal full content while hovered or focused.",
+  },
+  {
+    prop: "animationDuration",
+    type: "number",
+    default: "250",
+    description:
+      "Transition duration in milliseconds for width and peek animations.",
+  },
+  {
+    prop: "mobileBreakpoint",
+    type: "number",
+    default: "768",
+    description:
+      "Viewport width below which the sidebar renders as a mobile navigation drawer.",
+  },
+  {
+    prop: "children",
+    type: "Snippet",
+    required: true,
+    description: "Content, typically Sidebar plus main content.",
+  },
+  {
+    prop: "class",
+    type: "string",
+    description: "Additional classes for the wrapper div.",
+  },
 ];
 
 export default rows;

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -31,46 +31,56 @@
     [role="checkbox"],
     [role="radio"],
     [role="switch"]
-  ):where([data-kumo-component], [data-kumo-part]):where(:not(:disabled)):where(:not([disabled])):where(
-    :not([aria-disabled="true"])
-  ):where(:not([data-disabled])) {
+  ):where([data-kumo-component], [data-kumo-part]):where(:not(:disabled)):where(
+    :not([disabled])
+  ):where(:not([aria-disabled="true"])):where(:not([data-disabled])) {
   cursor: pointer;
 }
 
 /* Scroll-fade: gradient masks that appear on the edges of a horizontally
    scrollable container based on scroll position. Activated by the
    data-overflowing attribute set from Tabs overflow measurement. */
+@property --fade-left-n {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --fade-right-n {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
 @keyframes scroll-fade-x-left {
+  from {
+    --fade-left-n: 0;
+  }
+
   to {
-    mask-size:
-      var(--scroll-fade-width, 3rem) 100%,
-      100% 100%,
-      var(--scroll-fade-width, 3rem) 100%;
+    --fade-left-n: 1;
   }
 }
 
 @keyframes scroll-fade-x-right {
+  from {
+    --fade-right-n: 1;
+  }
+
   to {
-    mask-size:
-      var(--scroll-fade-width, 3rem) 100%,
-      100% 100%,
-      0 100%;
+    --fade-right-n: 0;
   }
 }
 
 [data-overflowing] {
   @supports (animation-timeline: scroll()) {
-    mask-image:
-      linear-gradient(to right, white, transparent),
-      linear-gradient(white, white),
-      linear-gradient(to right, transparent, white);
-    mask-size:
-      0 100%,
-      100% 100%,
-      var(--scroll-fade-width, 3rem) 100%;
-    mask-repeat: no-repeat;
-    mask-composite: exclude;
-    mask-position: left, center, right;
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      white calc(var(--fade-left-n) * var(--scroll-fade-width, 3rem)),
+      white calc(100% - var(--fade-right-n) * var(--scroll-fade-width, 3rem)),
+      transparent
+    );
 
     animation-name: scroll-fade-x-left, scroll-fade-x-right;
     animation-timing-function: linear, linear;
@@ -79,7 +89,6 @@
       0 var(--scroll-fade-range, 3rem),
       calc(100% - var(--scroll-fade-range, 3rem)) 100%;
     animation-fill-mode: both;
-    animation-composition: replace;
   }
 }
 
@@ -471,7 +480,10 @@
     );
     --color-kumo-success: var(--color-emerald-600, oklch(59.6% 0.145 163.225));
     --color-kumo-banner-info: oklch(93.2% 0.032 255.585 / 0.7);
-    --color-kumo-banner-warning: var(--color-yellow-100, oklch(97.3% 0.071 103.193));
+    --color-kumo-banner-warning: var(
+      --color-yellow-100,
+      oklch(97.3% 0.071 103.193)
+    );
     --color-kumo-badge-red: var(--color-red-600, oklch(57.7% 0.245 27.325));
     --color-kumo-badge-orange: var(--color-orange-650, oklch(81.5% 0.197 76));
     --color-kumo-badge-orange-subtle: var(
@@ -1015,7 +1027,10 @@ pre.shiki {
   margin-left: -1rem;
   padding-right: 2rem;
   padding-left: 1rem;
-  background-color: var(--kumo-code-highlight-bg, color-mix(in srgb, var(--color-kumo-brand) 12%, transparent)) !important;
+  background-color: var(
+    --kumo-code-highlight-bg,
+    color-mix(in srgb, var(--color-kumo-brand) 12%, transparent)
+  ) !important;
 }
 
 .kumo-shiki-line-numbers .kumo-shiki pre {

--- a/packages/kumo-svelte/src/routes/components/sidebar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/sidebar/+page.md
@@ -122,6 +122,17 @@ sourceFile: "components/sidebar"
   </Sidebar>
 </Sidebar.Provider>`;
 
+  const autoScrollCode = `<Sidebar.Collapsible autoScrollOnOpen>
+  <Sidebar.CollapsibleTrigger>
+    <Sidebar.MenuButton icon={Code}>
+      Workers <Sidebar.MenuChevron />
+    </Sidebar.MenuButton>
+  </Sidebar.CollapsibleTrigger>
+  <Sidebar.CollapsibleContent>
+    <Sidebar.MenuSub>...</Sidebar.MenuSub>
+  </Sidebar.CollapsibleContent>
+</Sidebar.Collapsible>`;
+
   const slidingCode = `<Sidebar.Provider contained>
   <Sidebar>
     <Sidebar.SlidingViews activeKey={view}>
@@ -145,6 +156,12 @@ sourceFile: "components/sidebar"
     </Sidebar.Content>
   </Sidebar>
 </Sidebar.Provider>`;
+
+  const mobileCode = `<Sidebar.Provider mobileBreakpoint={9999}>
+  <Sidebar>
+    <Sidebar.Content>...</Sidebar.Content>
+  </Sidebar>
+</Sidebar.Provider>`;
 </script>
 
 <!-- Demo -->
@@ -162,13 +179,13 @@ sourceFile: "components/sidebar"
 ### Barrel
 
 ```typescript
-import { Sidebar } from 'kumo-svelte';
+import { Sidebar } from "kumo-svelte";
 ```
 
 ### Granular
 
 ```typescript
-import { Sidebar } from 'kumo-svelte/components/sidebar';
+import { Sidebar } from "kumo-svelte/components/sidebar";
 ```
 
 </ComponentSection>
@@ -242,6 +259,14 @@ import { Sidebar } from 'kumo-svelte/components/sidebar';
 
 <ComponentExample demo="SidebarPeekingDemo" code={peekingCode} vrSection="peeking" vrTitle="Peeking" />
 
+### Auto Scroll
+
+<p class="mb-3 text-sm text-kumo-strong">
+  Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">autoScrollOnOpen</code> on long collapsible sections to keep newly revealed content in view.
+</p>
+
+<ComponentExample demo="SidebarAutoScrollDemo" code={autoScrollCode} vrSection="auto-scroll" vrTitle="Auto Scroll" />
+
 ### Sliding Views
 
 <p class="mb-3 text-sm text-kumo-strong">
@@ -259,6 +284,14 @@ import { Sidebar } from 'kumo-svelte/components/sidebar';
 
 <ComponentExample demo="SidebarFullDemo" code={fullCode} vrSection="full-example" vrTitle="Full Example" />
 
+### Mobile
+
+<p class="mb-3 text-sm text-kumo-strong">
+  On narrow viewports the sidebar renders as a navigation drawer. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-xs">mobileBreakpoint</code> to control the threshold.
+</p>
+
+<ComponentExample demo="SidebarMobileDemo" code={mobileCode} vrSection="mobile" vrTitle="Mobile" />
+
 </ComponentSection>
 
 <!-- API Reference -->
@@ -269,7 +302,7 @@ import { Sidebar } from 'kumo-svelte/components/sidebar';
 
 ### Sidebar
 
-The main sidebar container. Renders as `<aside>` on desktop and as a dialog sheet on mobile.
+The main sidebar container. Renders as `<aside>` on desktop and a navigation drawer on mobile.
 
 <PropsTable component="Sidebar" />
 

--- a/packages/kumo-svelte/src/routes/llms.txt/+server.ts
+++ b/packages/kumo-svelte/src/routes/llms.txt/+server.ts
@@ -1,0 +1,265 @@
+import registry from "../../../ai/component-registry.json";
+import type { RequestHandler } from "./$types";
+
+export const prerender = true;
+
+const SITE_URL = "https://kumo-svelte.com";
+
+const componentDocPages = import.meta.glob("../components/*/+page.md");
+const blockDocPages = import.meta.glob("../blocks/*/+page.md");
+const chartDocPages = import.meta.glob("../charts/**/+page.md");
+
+const registryRouteOverrides: Record<string, string> = {
+  Code: "code-highlighted",
+  DropdownMenu: "dropdown",
+  ResourceListPage: "resource-list",
+  Toasty: "toast",
+};
+
+const titleOverrides: Record<string, string> = {
+  "code-highlighted": "CodeHighlighted",
+  "input-area": "InputArea",
+  "input-group": "InputGroup",
+  "menu-bar": "MenuBar",
+  "resource-list": "Resource List",
+  "table-of-contents": "Table of Contents",
+};
+
+const chartTitleOverrides: Record<string, string> = {
+  colors: "Chart Colors",
+  custom: "Custom Chart",
+  index: "Charts",
+};
+
+const chartDescriptions: Record<string, string> = {
+  colors: "Chart color tokens and palette guidance.",
+  custom: "Guidance for custom chart implementations.",
+  index: "Overview of Kumo charting patterns.",
+  sankey: "Sankey chart usage and examples.",
+  timeseries: "Timeseries chart usage and examples.",
+};
+
+interface LlmLink {
+  title: string;
+  path: string;
+  description: string;
+}
+
+interface RegistryItem {
+  name: string;
+  description: string;
+}
+
+const coreDocs: LlmLink[] = [
+  {
+    title: "Installation",
+    path: "/installation.md",
+    description:
+      "Install kumo-svelte and configure styles in a Svelte application.",
+  },
+  {
+    title: "Components vs Blocks",
+    path: "/components-vs-blocks.md",
+    description:
+      "Understand reusable package components versus CLI-installed blocks.",
+  },
+  {
+    title: "CLI",
+    path: "/cli.md",
+    description:
+      "Use the kumo-svelte command-line tools for project setup and blocks.",
+  },
+  {
+    title: "Contributing",
+    path: "/contributing.md",
+    description: "Contribution workflow and development guidelines.",
+  },
+  {
+    title: "Accessibility",
+    path: "/accessibility.md",
+    description: "Accessibility guidance for building with Kumo components.",
+  },
+  {
+    title: "Colors",
+    path: "/colors.md",
+    description: "Semantic color tokens and theme behavior.",
+  },
+  {
+    title: "Figma Resources",
+    path: "/figma.md",
+    description: "Design resources and Figma integration notes.",
+  },
+  {
+    title: "Streaming",
+    path: "/streaming.md",
+    description: "Streaming interface patterns and examples.",
+  },
+  {
+    title: "Registry",
+    path: "/registry.md",
+    description: "Component registry reference and metadata.",
+  },
+  {
+    title: "Changelog",
+    path: "/changelog.md",
+    description: "Release notes for kumo-svelte.",
+  },
+];
+
+function slugFromPagePath(pagePath: string) {
+  const slug = pagePath
+    .replace(/^\.\.\/(components|blocks|charts)\//, "")
+    .replace(/\/\+page\.md$/, "")
+    .replace(/^\+page\.md$/, "index");
+
+  return slug || "index";
+}
+
+function slugFromRegistryName(name: string) {
+  return (
+    registryRouteOverrides[name] ??
+    name
+      .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+      .toLowerCase()
+  );
+}
+
+function titleFromSlug(slug: string) {
+  return (
+    titleOverrides[slug] ??
+    slug
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ")
+  );
+}
+
+function plainAscii(value: string) {
+  return value
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/\u2026/g, "...")
+    .replace(/\u00A0/g, " ")
+    .replace(/[^\x20-\x7E\n]/g, "");
+}
+
+function descriptionSummary(description: string) {
+  const normalized = plainAscii(description).replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+
+  const [firstSentence] = normalized.split(/\.\s+(?=[A-Z])/);
+  const summary =
+    firstSentence.length > 180
+      ? `${firstSentence.slice(0, 177)}...`
+      : firstSentence;
+  return summary.endsWith(".") ? summary : `${summary}.`;
+}
+
+function registryDocs(
+  pagePaths: Record<string, unknown>,
+  registryItems: RegistryItem[],
+  routePrefix: "blocks" | "components",
+) {
+  const documentedSlugs = new Set(Object.keys(pagePaths).map(slugFromPagePath));
+  const registryLinks = registryItems
+    .map((item) => ({ item, slug: slugFromRegistryName(item.name) }))
+    .filter(({ slug }) => documentedSlugs.has(slug));
+  const registrySlugs = new Set(registryLinks.map(({ slug }) => slug));
+  const fallbackLinks = [...documentedSlugs]
+    .filter((slug) => !registrySlugs.has(slug))
+    .map((slug) => ({
+      title: titleFromSlug(slug),
+      path: `/${routePrefix}/${slug}.md`,
+      description: `${titleFromSlug(slug)} docs, usage, and examples.`,
+    }));
+  const links = registryLinks.map(({ item, slug }) => ({
+    title: titleFromSlug(slug),
+    path: `/${routePrefix}/${slug}.md`,
+    description: descriptionSummary(item.description),
+  }));
+
+  return [...links, ...fallbackLinks].toSorted((a, b) =>
+    a.title.localeCompare(b.title),
+  );
+}
+
+function pageDocs(
+  pagePaths: Record<string, unknown>,
+  routePrefix: "charts",
+  descriptions: Record<string, string>,
+  titles: Record<string, string>,
+) {
+  return Object.keys(pagePaths)
+    .map(slugFromPagePath)
+    .map((slug) => ({
+      title: titles[slug] ?? titleFromSlug(slug),
+      path:
+        slug === "index" ? `/${routePrefix}.md` : `/${routePrefix}/${slug}.md`,
+      description:
+        descriptions[slug] ??
+        `${titles[slug] ?? titleFromSlug(slug)} docs, usage, and examples.`,
+    }))
+    .toSorted((a, b) => {
+      if (a.path === `/${routePrefix}.md`) return -1;
+      if (b.path === `/${routePrefix}.md`) return 1;
+      return a.title.localeCompare(b.title);
+    });
+}
+
+const components = registryDocs(
+  componentDocPages,
+  Object.values(registry.components),
+  "components",
+);
+
+const charts = pageDocs(
+  chartDocPages,
+  "charts",
+  chartDescriptions,
+  chartTitleOverrides,
+);
+
+const blocks = registryDocs(
+  blockDocPages,
+  Object.values(registry.blocks),
+  "blocks",
+);
+
+function formatSection(title: string, links: LlmLink[]) {
+  return [
+    `## ${title}`,
+    "",
+    ...links.map(
+      (link) =>
+        `- [${link.title}](${SITE_URL}${link.path}): ${link.description}`,
+    ),
+  ].join("\n");
+}
+
+const content = [
+  "# Kumo Svelte",
+  "",
+  "> Svelte port of Cloudflare's Kumo component library for building product interfaces.",
+  "",
+  "This file is a curated index for LLMs. It links to markdown versions of kumo-svelte docs pages instead of embedding the full documentation inline.",
+  "",
+  formatSection("Core Docs", coreDocs),
+  "",
+  formatSection("Components", components),
+  "",
+  formatSection("Charts", charts),
+  "",
+  formatSection("Blocks", blocks),
+  "",
+].join("\n");
+
+export const GET: RequestHandler = () => {
+  return new Response(content, {
+    status: 200,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- Port upstream Kumo 2.5.0 sidebar mobile drawer and collapsible auto-scroll behavior.
- Align tabs scroll fade/ring classes, chart transparent background defaults, and Flow connector SVG rendering.
- Add /llms.txt docs index and update Sidebar docs/examples plus generated registry metadata.

## Tests
- [x] Tests included/updated
- pnpm --filter kumo-svelte check
- pnpm --filter kumo-svelte test
- pnpm lint
- pnpm test
- CI=true pnpm build
- Browser parity against https://kumo-ui.com for Sidebar, Tabs, Flow, and Timeseries Chart surfaces.

## Changesets
- [x] Added changeset: .changeset/quiet-clouds-travel.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile drawer with improved focus management and custom keyboard handling
  * Auto-scroll for expanded collapsibles
  * Configurable mobile breakpoint for sidebar
  * Tab auto-scroll to clicked triggers
  * Transparent chart backgrounds with improved dark mode support
  * Documentation LLM index endpoint

* **Documentation**
  * New auto-scroll and mobile sidebar demos

<!-- end of auto-generated comment: release notes by coderabbit.ai -->