### PR TITLE
[codex] fix chart color table spacing

### DIFF
--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
@@ -31,8 +31,8 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each categoricalColorIndices as colorIndex}
-            <Table.Cell class="w-1/6 whitespace-nowrap">{colorIndex}</Table.Cell>
+          {#each categoricalColorIndices as colorIndex, index}
+            <Table.Cell class={index === 0 ? 'w-1/6 whitespace-nowrap !pl-6' : 'w-1/6 whitespace-nowrap'}>{colorIndex}</Table.Cell>
           {/each}
         </Table.Row>
       </Table.Body>
@@ -42,9 +42,9 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each categoricalColorIndices as colorIndex}
+          {#each categoricalColorIndices as colorIndex, index}
             {@const color = ChartPalette.categorical(colorIndex, isDarkMode)}
-            <Table.Cell class="w-1/6">
+            <Table.Cell class={index === 0 ? 'w-1/6 !pl-6' : 'w-1/6'}>
               <div class="flex items-center gap-2">
                 <div style:background-color={color} class="size-5 rounded"></div>
                 <span class="font-mono text-xs">{color}</span>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
@@ -39,14 +39,14 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
             {@const color = ChartPalette.categorical(colorIndex, isDarkMode)}
             <Table.Cell class="w-1/6">
               <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
                 <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
@@ -28,7 +28,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
@@ -39,7 +39,7 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
@@ -45,9 +45,9 @@
           {#each categoricalColorIndices as colorIndex}
             {@const color = ChartPalette.categorical(colorIndex, isDarkMode)}
             <Table.Cell class="w-1/6">
-              <div class="flex items-center gap-2">
-                <div style:background-color={color} class="size-5 rounded"></div>
-                <span class="font-mono text-xs">{color}</span>
+              <div class="flex items-center gap-4">
+                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalColorsDemo.svelte
@@ -28,7 +28,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
@@ -39,15 +39,15 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
             {@const color = ChartPalette.categorical(colorIndex, isDarkMode)}
             <Table.Cell class="w-1/6">
-              <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
-                <span class="font-mono text-xl">{color}</span>
+              <div class="flex items-center gap-2">
+                <div style:background-color={color} class="size-5 rounded"></div>
+                <span class="font-mono text-xs">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
@@ -34,8 +34,8 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each categoricalColorIndices as colorIndex}
-            <Table.Cell class="w-1/6 whitespace-nowrap">{colorIndex}</Table.Cell>
+          {#each categoricalColorIndices as colorIndex, index}
+            <Table.Cell class={index === 0 ? 'w-1/6 whitespace-nowrap !pl-6' : 'w-1/6 whitespace-nowrap'}>{colorIndex}</Table.Cell>
           {/each}
         </Table.Row>
       </Table.Body>
@@ -45,8 +45,8 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each simulatedColors as color}
-            <Table.Cell class="w-1/6 text-center">
+          {#each simulatedColors as color, index}
+            <Table.Cell class={index === 0 ? 'w-1/6 text-center !pl-6' : 'w-1/6 text-center'}>
               <div class="flex items-center gap-2">
                 <div style:background-color={color} class="size-5 rounded"></div>
                 <span class="font-mono text-xs">{color}</span>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
@@ -46,10 +46,10 @@
       <Table.Body>
         <Table.Row>
           {#each simulatedColors as color}
-            <Table.Cell class="w-1/6 text-center">
-              <div class="flex items-center gap-2">
-                <div style:background-color={color} class="size-5 rounded"></div>
-                <span class="font-mono text-xs">{color}</span>
+            <Table.Cell class="w-1/6">
+              <div class="flex items-center gap-4">
+                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
@@ -31,7 +31,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
@@ -42,14 +42,14 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each simulatedColors as color}
-            <Table.Cell class="w-1/6">
-              <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
-                <span class="font-mono text-xl">{color}</span>
+            <Table.Cell class="w-1/6 text-center">
+              <div class="flex items-center gap-2">
+                <div style:background-color={color} class="size-5 rounded"></div>
+                <span class="font-mono text-xs">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
@@ -42,13 +42,13 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each simulatedColors as color}
             <Table.Cell class="w-1/6">
               <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
                 <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/CategoricalCvdDemo.svelte
@@ -31,7 +31,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each categoricalColorIndices as colorIndex}
@@ -42,7 +42,7 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
       <Table.Body>
         <Table.Row>
           {#each simulatedColors as color}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
@@ -14,7 +14,7 @@
     </colgroup>
     <Table.Body>
       <Table.Row>
-        <Table.Cell>System</Table.Cell>
+        <Table.Cell class="!pl-6">System</Table.Cell>
         <Table.Cell>When to use</Table.Cell>
         <Table.Cell>User task</Table.Cell>
         <Table.Cell>Examples</Table.Cell>
@@ -32,7 +32,7 @@
       <Table.Body>
         {#each colorSystemRows as { system, when, task, examples }}
           <Table.Row>
-            <Table.Cell>{system}</Table.Cell>
+            <Table.Cell class="!pl-6">{system}</Table.Cell>
             <Table.Cell>{when}</Table.Cell>
             <Table.Cell>{task}</Table.Cell>
             <Table.Cell>{examples}</Table.Cell>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
@@ -5,7 +5,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0" />
-  <Table class="!m-0 !p-0 [&_tbody]:text-sm [&_tbody]:font-medium [&_tbody]:text-kumo-default">
+  <Table class="!m-0 !p-0 [&_tbody]:text-sm [&_tbody]:font-medium [&_tbody]:text-kumo-default [&_td]:!px-6 [&_td]:!py-6">
     <colgroup>
       <col class="w-[14%]" />
       <col class="w-[38%]" />
@@ -22,7 +22,7 @@
     </Table.Body>
   </Table>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 w-full [&_td]:align-top [&_td]:text-kumo-default">
+    <Table layout="fixed" class="!m-0 !p-0 w-full [&_td]:!px-6 [&_td]:!py-8 [&_td]:align-top [&_td]:text-kumo-default">
       <colgroup>
         <col class="w-[14%]" />
         <col class="w-[38%]" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ChartColorSystemsDemo.svelte
@@ -5,7 +5,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0" />
-  <Table class="!m-0 !p-0 [&_tbody]:text-sm [&_tbody]:font-medium [&_tbody]:text-kumo-default [&_td]:!px-6 [&_td]:!py-6">
+  <Table class="!m-0 !p-0 [&_tbody]:text-sm [&_tbody]:font-medium [&_tbody]:text-kumo-default">
     <colgroup>
       <col class="w-[14%]" />
       <col class="w-[38%]" />
@@ -22,7 +22,7 @@
     </Table.Body>
   </Table>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 w-full [&_td]:!px-6 [&_td]:!py-8 [&_td]:align-top [&_td]:text-kumo-default">
+    <Table layout="fixed" class="!m-0 !p-0 w-full [&_td]:align-top [&_td]:text-kumo-default">
       <colgroup>
         <col class="w-[14%]" />
         <col class="w-[38%]" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
@@ -31,8 +31,8 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each semanticColorNames as name}
-            <Table.Cell class="w-1/6 whitespace-nowrap">{name}</Table.Cell>
+          {#each semanticColorNames as name, index}
+            <Table.Cell class={index === 0 ? 'w-1/6 whitespace-nowrap !pl-6' : 'w-1/6 whitespace-nowrap'}>{name}</Table.Cell>
           {/each}
         </Table.Row>
       </Table.Body>
@@ -42,9 +42,9 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each semanticColorNames as name}
+          {#each semanticColorNames as name, index}
             {@const color = semantic(name, isDarkMode)}
-            <Table.Cell class="w-1/6">
+            <Table.Cell class={index === 0 ? 'w-1/6 !pl-6' : 'w-1/6'}>
               <div class="flex items-center gap-2">
                 <div style:background-color={color} class="size-5 rounded"></div>
                 <span class="font-mono text-xs">{color}</span>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
@@ -39,14 +39,14 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each semanticColorNames as name}
             {@const color = semantic(name, isDarkMode)}
             <Table.Cell class="w-1/6">
               <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
                 <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
@@ -45,9 +45,9 @@
           {#each semanticColorNames as name}
             {@const color = semantic(name, isDarkMode)}
             <Table.Cell class="w-1/6">
-              <div class="flex items-center gap-2">
-                <div style:background-color={color} class="size-5 rounded"></div>
-                <span class="font-mono text-xs">{color}</span>
+              <div class="flex items-center gap-4">
+                <div style:background-color={color} class="size-10 rounded-lg"></div>
+                <span class="font-mono text-xl">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
@@ -28,7 +28,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each semanticColorNames as name}
@@ -39,7 +39,7 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
       <Table.Body>
         <Table.Row>
           {#each semanticColorNames as name}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SemanticColorsDemo.svelte
@@ -28,7 +28,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each semanticColorNames as name}
@@ -39,15 +39,15 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each semanticColorNames as name}
             {@const color = semantic(name, isDarkMode)}
             <Table.Cell class="w-1/6">
-              <div class="flex items-center gap-4">
-                <div style:background-color={color} class="size-10 shrink-0 rounded-lg"></div>
-                <span class="font-mono text-xl">{color}</span>
+              <div class="flex items-center gap-2">
+                <div style:background-color={color} class="size-5 rounded"></div>
+                <span class="font-mono text-xs">{color}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
@@ -33,7 +33,7 @@
       <Table.Body>
         <Table.Row>
           {#each scale as _, index}
-            <Table.Cell class="w-1/5 whitespace-nowrap">Step {index + 1}</Table.Cell>
+            <Table.Cell class={index === 0 ? 'w-1/5 whitespace-nowrap !pl-6' : 'w-1/5 whitespace-nowrap'}>Step {index + 1}</Table.Cell>
           {/each}
         </Table.Row>
       </Table.Body>
@@ -43,8 +43,8 @@
     <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
-          {#each scale as hex}
-            <Table.Cell class="w-1/5">
+          {#each scale as hex, index}
+            <Table.Cell class={index === 0 ? 'w-1/5 !pl-6' : 'w-1/5'}>
               <div class="flex items-center gap-2">
                 <div style:background-color={hex} class="size-5 rounded"></div>
                 <span class="font-mono text-xs">{hex}</span>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
@@ -40,13 +40,13 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each scale as hex}
             <Table.Cell class="w-1/5">
               <div class="flex items-center gap-4">
-                <div style:background-color={hex} class="size-10 rounded-lg"></div>
+                <div style:background-color={hex} class="size-10 shrink-0 rounded-lg"></div>
                 <span class="font-mono text-xl">{hex}</span>
               </div>
             </Table.Cell>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
@@ -45,9 +45,9 @@
         <Table.Row>
           {#each scale as hex}
             <Table.Cell class="w-1/5">
-              <div class="flex items-center gap-2">
-                <div style:background-color={hex} class="size-5 rounded"></div>
-                <span class="font-mono text-xs">{hex}</span>
+              <div class="flex items-center gap-4">
+                <div style:background-color={hex} class="size-10 rounded-lg"></div>
+                <span class="font-mono text-xl">{hex}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
@@ -29,7 +29,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each scale as _, index}
@@ -40,14 +40,14 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
+    <Table layout="fixed" class="!m-0 !p-0">
       <Table.Body>
         <Table.Row>
           {#each scale as hex}
             <Table.Cell class="w-1/5">
-              <div class="flex items-center gap-4">
-                <div style:background-color={hex} class="size-10 shrink-0 rounded-lg"></div>
-                <span class="font-mono text-xl">{hex}</span>
+              <div class="flex items-center gap-2">
+                <div style:background-color={hex} class="size-5 rounded"></div>
+                <span class="font-mono text-xs">{hex}</span>
               </div>
             </Table.Cell>
           {/each}

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SequentialColorsDemo.svelte
@@ -29,7 +29,7 @@
 
 <LayerCard>
   <LayerCard.Secondary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-6">
       <Table.Body>
         <Table.Row>
           {#each scale as _, index}
@@ -40,7 +40,7 @@
     </Table>
   </LayerCard.Secondary>
   <LayerCard.Primary class="!m-0 !p-0">
-    <Table layout="fixed" class="!m-0 !p-0">
+    <Table layout="fixed" class="!m-0 !p-0 [&_td]:!px-6 [&_td]:!py-8">
       <Table.Body>
         <Table.Row>
           {#each scale as hex}

--- a/packages/kumo-svelte/src/routes/charts/colors/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/colors/+page.md
@@ -2,6 +2,7 @@
 title: "Chart Colors"
 description: "Semantic and categorical color tokens for Cloudflare dashboard charts."
 sourceFile: "components/chart/Color.ts"
+contentLayout: "wide"
 ---
 
 <script>


### PR DESCRIPTION
## Summary

Fixes the chart colors system table spacing so the header and body rows match the intended roomier Kumo table layout.

## Details

- Adds explicit cell padding overrides to the chart color systems header table.
- Adds explicit horizontal and vertical cell padding to the body table while preserving the fixed column layout.
- Leaves changesets untouched per request.

## Validation

- `pnpm --filter kumo-svelte check`
- Opened `/charts/colors` locally and verified the rendered table spacing in browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Chart Colors documentation page layout to display in a wider format for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->