### PR TITLE
Fix docs GitHub source links

### DIFF
--- a/.changeset/fix-docs-github-links.md
+++ b/.changeset/fix-docs-github-links.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Fix documentation GitHub source links so they point to files under the package directory.

--- a/packages/kumo-svelte/src/lib/docs/MdxPage.svelte
+++ b/packages/kumo-svelte/src/lib/docs/MdxPage.svelte
@@ -62,9 +62,13 @@
             'primitives/skeleton-line': 'components/loader'
           };
           const sourcePath = sourceMap[sourceFile] ?? sourceFile;
-          if (sourcePath.startsWith('blocks/')) return `${repo}/tree/main/src/${sourcePath}`;
-          if (/\.\w+$/.test(sourceFile)) return `${repo}/blob/main/src/lib/${sourcePath}`;
-          return `${repo}/tree/main/src/lib/${sourcePath}`;
+          if (sourcePath.startsWith('blocks/')) {
+            return `${repo}/tree/main/packages/kumo-svelte/src/${sourcePath}`;
+          }
+          if (/\.\w+$/.test(sourcePath)) {
+            return `${repo}/blob/main/packages/kumo-svelte/src/lib/${sourcePath}`;
+          }
+          return `${repo}/tree/main/packages/kumo-svelte/src/lib/${sourcePath}`;
         })()
       : null
   );


### PR DESCRIPTION
## Summary
- update docs source URL generation to include the package path under packages/kumo-svelte
- keep block links pointing at src/blocks and component links pointing at src/lib
- add a patch changeset for the docs link fix

## Testing
- pnpm run check
- pnpm run lint
- verified representative GitHub URLs with curl