### PR TITLE
Port Kumo 2.6 updates

### DIFF
--- a/.changeset/port-kumo-2-6.md
+++ b/.changeset/port-kumo-2-6.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": minor
+---
+
+Port Kumo 2.6 updates, including Toolbar, chart legend interactions, button token styling, sidebar overflow fixes, and typed radio values.

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -608,15 +608,14 @@
       },
       "colors": [
         "bg-kumo-base",
-        "bg-kumo-brand",
-        "bg-kumo-brand-hover",
-        "bg-kumo-danger",
         "bg-kumo-tint",
         "ring-kumo-brand",
+        "ring-kumo-danger",
         "ring-kumo-focus",
-        "ring-kumo-hairline",
+        "ring-kumo-line",
         "text-kumo-danger",
         "text-kumo-default",
+        "text-kumo-strong",
         "text-kumo-subtle"
       ],
       "subComponents": {
@@ -5189,6 +5188,119 @@
       "props": {},
       "colors": []
     },
+    "Toolbar": {
+      "name": "Toolbar",
+      "type": "component",
+      "category": "Action",
+      "description": "Compose explicit toolbar controls into one clean grouped card.",
+      "importPath": "kumo-svelte/components/toolbar",
+      "sourceFile": "components/toolbar",
+      "props": {
+        "children": {
+          "type": "Snippet",
+          "optional": false,
+          "required": true,
+          "description": "Toolbar controls rendered as one grouped card."
+        },
+        "size": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "xs",
+            "sm",
+            "base",
+            "lg"
+          ],
+          "default": "base",
+          "description": "Locks every supported toolbar item to this size."
+        },
+        "class": {
+          "type": "string",
+          "optional": true,
+          "description": "Additional classes merged onto the toolbar root."
+        }
+      },
+      "colors": [
+        "bg-kumo-control",
+        "border-kumo-line",
+        "ring-kumo-brand",
+        "ring-kumo-focus",
+        "ring-kumo-line"
+      ],
+      "subComponents": {
+        "Button": {
+          "description": "Toolbar.Button",
+          "props": {
+            "children": {
+              "type": "Snippet",
+              "optional": true,
+              "description": "Optional visible button label."
+            },
+            "icon": {
+              "type": "Component",
+              "optional": true,
+              "description": "Optional icon component rendered before the label."
+            },
+            "shape": {
+              "type": "enum",
+              "optional": true,
+              "values": [
+                "base",
+                "square",
+                "circle"
+              ],
+              "description": "Button shape. Icon-only toolbar buttons default to square."
+            },
+            "disabled": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Disables the toolbar button."
+            },
+            "loading": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Shows a loading indicator and disables the toolbar button."
+            }
+          }
+        },
+        "Input": {
+          "description": "Toolbar.Input",
+          "props": {
+            "value": {
+              "type": "string | number",
+              "optional": true,
+              "description": "Input value, bindable with `bind:value`."
+            },
+            "onValueChange": {
+              "type": "(value: string) => void",
+              "optional": true,
+              "description": "Called when the input value changes."
+            },
+            "class": {
+              "type": "string",
+              "optional": true,
+              "description": "Additional classes merged onto the toolbar input."
+            }
+          }
+        },
+        "InputGroup": {
+          "description": "Toolbar.InputGroup",
+          "props": {
+            "children": {
+              "type": "Snippet",
+              "optional": false,
+              "required": true,
+              "description": "InputGroup children rendered as one toolbar item."
+            },
+            "class": {
+              "type": "string",
+              "optional": true,
+              "description": "Additional classes merged onto the toolbar input group."
+            }
+          }
+        }
+      }
+    },
     "Tooltip": {
       "name": "Tooltip",
       "type": "component",
@@ -5362,12 +5474,14 @@
       "Tabs",
       "Text",
       "Toast",
+      "Toolbar",
       "Tooltip"
     ],
     "byCategory": {
       "Action": [
         "Button",
-        "Link"
+        "Link",
+        "Toolbar"
       ],
       "Display": [
         "Badge",
@@ -5465,6 +5579,7 @@
         "Tabs",
         "Text",
         "Toast",
+        "Toolbar",
         "Tooltip"
       ],
       "block": [

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -3568,7 +3568,7 @@
           "description": "Additional classes merged onto the root element."
         },
         "onValueChange": {
-          "type": "(value: string) => void",
+          "type": "(value: string, eventDetails?: unknown) => void",
           "optional": true,
           "description": "Called when the value changes."
         }
@@ -3634,7 +3634,7 @@
               "description": "Supporting description text."
             },
             "value": {
-              "type": "string",
+              "type": "Value",
               "optional": true,
               "description": "Controlled value."
             },
@@ -3664,7 +3664,7 @@
               "description": "Additional classes merged onto the root element."
             },
             "defaultValue": {
-              "type": "string",
+              "type": "Value",
               "optional": true,
               "description": "Initial uncontrolled value."
             },
@@ -3674,7 +3674,7 @@
               "description": "Marks the field as required."
             },
             "onValueChange": {
-              "type": "(value: string) => void",
+              "type": "(value: Value, eventDetails?: unknown) => void",
               "optional": true,
               "description": "Called when the value changes."
             }
@@ -3730,7 +3730,7 @@
               "description": "Supporting description text."
             },
             "value": {
-              "type": "string",
+              "type": "Value",
               "optional": false,
               "required": true,
               "description": "Controlled value."

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -322,6 +322,14 @@ A notification system for displaying brief, non-intrusive messages to users.
 - Import: `import { Toast } from "kumo-svelte/components/toast";`
 - Source: `components/toast`
 
+## Toolbar
+
+Compose explicit toolbar controls into one clean grouped card.
+
+- Category: Action
+- Import: `import { Toolbar } from "kumo-svelte/components/toolbar";`
+- Source: `components/toolbar`
+
 ## Tooltip
 
 A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.

--- a/packages/kumo-svelte/scripts/component-registry.ts
+++ b/packages/kumo-svelte/scripts/component-registry.ts
@@ -28,7 +28,10 @@ type RegistryComponent = {
   sourceFile: string;
   props: Record<string, RegistryProp>;
   colors: string[];
-  subComponents?: Record<string, { description: string; props: Record<string, RegistryProp> }>;
+  subComponents?: Record<
+    string,
+    { description: string; props: Record<string, RegistryProp> }
+  >;
 };
 
 type Registry = {
@@ -54,6 +57,7 @@ const outputDir = join(packageRoot, 'ai');
 
 const categoryByName: Record<string, string> = {
   Button: 'Action',
+  Toolbar: 'Action',
   Link: 'Action',
   Badge: 'Display',
   ClipboardText: 'Display',
@@ -139,7 +143,9 @@ function normalizeDefault(value: string | undefined) {
 }
 
 function enumValues(type: string) {
-  const values = [...type.matchAll(/'([^']+)'|"([^"]+)"/g)].map((match) => match[1] ?? match[2]);
+  const values = [...type.matchAll(/'([^']+)'|"([^"]+)"/g)].map(
+    (match) => match[1] ?? match[2]
+  );
   return values.length > 0 ? values : undefined;
 }
 
@@ -188,7 +194,10 @@ async function loadSubComponents(componentName: string) {
 }
 
 function componentColors(sourceFile: string) {
-  const componentPath = join(componentsDir, sourceFile.replace(/^components\//, ''));
+  const componentPath = join(
+    componentsDir,
+    sourceFile.replace(/^components\//, '')
+  );
   const files = existsSync(componentPath)
     ? readdirSync(componentPath)
         .filter((file) => file.endsWith('.svelte') || file.endsWith('.ts'))
@@ -198,7 +207,9 @@ function componentColors(sourceFile: string) {
 
   for (const file of files) {
     const source = readFileSync(file, 'utf8');
-    for (const match of source.matchAll(/\b(?:bg|text|border|ring|fill|stroke)-kumo-[a-z-]+/g)) {
+    for (const match of source.matchAll(
+      /\b(?:bg|text|border|ring|fill|stroke)-kumo-[a-z-]+/g
+    )) {
       colors.add(match[0]);
     }
   }
@@ -215,7 +226,8 @@ async function buildRegistry() {
 
     const source = readFileSync(page, 'utf8');
     const frontmatter = parseFrontmatter(source);
-    const name = displayNameByRoute[route] ?? frontmatter.title ?? titleCaseRoute(route);
+    const name =
+      displayNameByRoute[route] ?? frontmatter.title ?? titleCaseRoute(route);
     const sourceFile = frontmatter.sourceFile ?? `components/${route}`;
     const props = propRowsToRegistry(await loadPropRows(name));
 
@@ -241,20 +253,28 @@ async function buildRegistry() {
   for (const names of Object.values(byCategory)) names.sort();
 
   const byName = Object.keys(components).sort();
-  const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { version?: string };
+  const packageJson = JSON.parse(
+    readFileSync(join(packageRoot, 'package.json'), 'utf8')
+  ) as { version?: string };
 
   const previousRegistryPath = join(outputDir, 'component-registry.json');
   const previous = existsSync(previousRegistryPath)
-    ? (JSON.parse(readFileSync(previousRegistryPath, 'utf8')) as Partial<Registry>)
+    ? (JSON.parse(
+        readFileSync(previousRegistryPath, 'utf8')
+      ) as Partial<Registry>)
     : {};
 
   const registry: Registry = {
     version: packageJson.version ?? previous.version ?? '0.0.0',
-    components: Object.fromEntries(Object.entries(components).sort(([a], [b]) => a.localeCompare(b))),
+    components: Object.fromEntries(
+      Object.entries(components).sort(([a], [b]) => a.localeCompare(b))
+    ),
     blocks: previous.blocks ?? {},
     search: {
       byName,
-      byCategory: Object.fromEntries(Object.entries(byCategory).sort(([a], [b]) => a.localeCompare(b))),
+      byCategory: Object.fromEntries(
+        Object.entries(byCategory).sort(([a], [b]) => a.localeCompare(b))
+      ),
       byType: {
         component: byName,
         block: Object.keys(previous.blocks ?? {}).sort()
@@ -272,13 +292,18 @@ async function buildRegistry() {
       '',
       ...byName.map((name) => {
         const component = registry.components[name]!;
-        const relativeSource = relative(packageRoot, join(packageRoot, component.sourceFile));
+        const relativeSource = relative(
+          packageRoot,
+          join(packageRoot, component.sourceFile)
+        );
         return `## ${name}\n\n${component.description}\n\n- Category: ${component.category}\n- Import: \`import { ${name} } from "${component.importPath}";\`\n- Source: \`${relativeSource}\`\n`;
       })
     ].join('\n')
   );
 
-  console.log(`Generated ${byName.length} components in ai/component-registry.json`);
+  console.log(
+    `Generated ${byName.length} components in ai/component-registry.json`
+  );
 }
 
 await buildRegistry();

--- a/packages/kumo-svelte/src/lib/components/button/Button.svelte
+++ b/packages/kumo-svelte/src/lib/components/button/Button.svelte
@@ -45,12 +45,13 @@
     },
     variant: {
       primary: {
-        classes: 'bg-kumo-brand !text-white hover:bg-kumo-brand-hover disabled:bg-kumo-brand/50',
+        classes:
+          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
         description: 'High-emphasis button for primary actions'
       },
       secondary: {
         classes:
-          'bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-hairline data-[state=open]:bg-kumo-base',
+          'bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-base',
         description: 'Default button style for most actions'
       },
       ghost: {
@@ -58,16 +59,18 @@
         description: 'Minimal button with no background'
       },
       destructive: {
-        classes: 'bg-kumo-danger !text-white hover:bg-kumo-danger/70',
+        classes:
+          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
         description: 'Danger button for destructive actions like delete'
       },
       'secondary-destructive': {
         classes:
-          'bg-kumo-base !text-kumo-danger ring not-disabled:hover:bg-kumo-base disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-hairline data-[state=open]:bg-kumo-base',
+          'bg-kumo-base !text-kumo-danger ring not-disabled:hover:!text-kumo-danger not-disabled:hover:ring-kumo-danger/30 disabled:bg-kumo-base/50 disabled:!text-kumo-danger/70 ring-kumo-line data-[state=open]:bg-kumo-base',
         description: 'Secondary button with destructive text for less prominent dangerous actions'
       },
       outline: {
-        classes: 'bg-transparent text-kumo-default ring ring-kumo-hairline',
+        classes:
+          'bg-transparent text-kumo-default ring ring-kumo-line transition-colors not-disabled:hover:text-kumo-strong not-disabled:hover:ring-kumo-focus/25',
         description: 'Bordered button with transparent background'
       }
     }
@@ -100,10 +103,10 @@
       'focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand',
       'cursor-pointer',
       'disabled:cursor-not-allowed disabled:text-kumo-subtle',
-      KUMO_BUTTON_VARIANTS.variant[variant].classes,
       KUMO_BUTTON_VARIANTS.size[size].classes,
       KUMO_BUTTON_VARIANTS.shape[shape].classes,
-      isCompactShape && KUMO_BUTTON_VARIANTS.compactSize[size].classes
+      isCompactShape && KUMO_BUTTON_VARIANTS.compactSize[size].classes,
+      KUMO_BUTTON_VARIANTS.variant[variant].classes
     );
   }
 
@@ -120,7 +123,7 @@
     variant?: Variant;
     loading?: boolean;
     title?: string;
-    componentName?: 'Button' | 'LinkButton';
+    componentName?: 'Button' | 'LinkButton' | 'Toolbar.Button';
     [key: string]: unknown;
   }
 
@@ -152,6 +155,19 @@
 
   const loaderSize = $derived(size === 'lg' ? 16 : 14);
   const externalProps = $derived(external ? { target: '_blank', rel: 'noopener noreferrer' } : {});
+  const emphasisToken = $derived(
+    variant === 'primary'
+      ? 'var(--color-kumo-brand)'
+      : variant === 'destructive'
+        ? 'var(--color-kumo-danger)'
+        : undefined
+  );
+  const emphasisRing = $derived(emphasisToken ? `color-mix(in oklch, ${emphasisToken}, black 10%)` : undefined);
+  const emphasisBg = $derived(emphasisToken ? `color-mix(in oklch, ${emphasisToken}, white 30%)` : undefined);
+  const emphasisGradientStart = $derived(
+    emphasisToken ? `color-mix(in oklch, ${emphasisToken}, white 15%)` : undefined
+  );
+  const emphasisGradientEnd = $derived(emphasisToken);
 </script>
 
 {#snippet buttonElement()}
@@ -164,16 +180,37 @@
     aria-busy={loading || undefined}
     data-kumo-component={componentName}
     data-kumo-part={href ? 'link-button' : 'button'}
+    style:--kumo-button-emphasis-ring={emphasisRing}
+    style:--kumo-button-emphasis-bg={emphasisBg}
+    style:--kumo-button-emphasis-gradient-start={emphasisGradientStart}
+    style:--kumo-button-emphasis-gradient-end={emphasisGradientEnd}
     {...externalProps}
     {...rest}
   >
-    {#if loading}
-      <Loader size={loaderSize} />
-    {:else if IconComponent}
-      <IconComponent />
-    {/if}
-    {#if children}
-      <span class="contents">{@render children()}</span>
+    {#if emphasisToken}
+      <span
+        aria-hidden="true"
+        class="absolute inset-0 translate-y-px rounded-[inherit] bg-linear-to-b from-(--kumo-button-emphasis-gradient-start) to-(--kumo-button-emphasis-gradient-end) group-hover:from-(--kumo-button-emphasis-bg)"
+      ></span>
+      <span class="relative flex items-center gap-1.5">
+        {#if loading}
+          <Loader size={loaderSize} />
+        {:else if IconComponent}
+          <IconComponent />
+        {/if}
+        {#if children}
+          <span class="contents">{@render children()}</span>
+        {/if}
+      </span>
+    {:else}
+      {#if loading}
+        <Loader size={loaderSize} />
+      {:else if IconComponent}
+        <IconComponent />
+      {/if}
+      {#if children}
+        <span class="contents">{@render children()}</span>
+      {/if}
     {/if}
   </svelte:element>
 {/snippet}

--- a/packages/kumo-svelte/src/lib/components/chart/ChartLegend.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/ChartLegend.svelte
@@ -8,13 +8,47 @@
     value: string;
     unit?: string;
     inactive?: boolean;
+    onpointerenter?: (event: PointerEvent) => void;
+    onpointerleave?: (event: PointerEvent) => void;
+    onclick?: (event: MouseEvent) => void;
+    class?: string;
+    [key: string]: unknown;
   }
 
-  let { variant = 'small', name, color, value, unit, inactive = false }: Props = $props();
+  let {
+    variant = 'small',
+    name,
+    color,
+    value,
+    unit,
+    inactive = false,
+    onpointerenter,
+    onpointerleave,
+    onclick,
+    class: className,
+    ...rest
+  }: Props = $props();
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!onclick || (event.key !== 'Enter' && event.key !== ' ')) return;
+    event.preventDefault();
+    (event.currentTarget as HTMLElement).dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+  }
 </script>
 
 {#if variant === 'large'}
-  <div class="inline-flex min-w-42 flex-col gap-2 py-2">
+  <div
+    role="button"
+    tabindex={onclick ? 0 : -1}
+    class={cn('inline-flex min-w-42 flex-col gap-2 py-2', onclick && 'cursor-pointer', className)}
+    {onpointerenter}
+    {onpointerleave}
+    {onclick}
+    onkeydown={handleKeydown}
+    {...rest}
+  >
     <div class="flex items-center gap-2">
       <span class={cn('inline-block size-2 rounded-full', inactive && 'opacity-50')} style:background-color={color}></span>
       <span class={cn('text-xs', inactive && 'opacity-50')}>{name}</span>
@@ -25,7 +59,16 @@
     </div>
   </div>
 {:else}
-  <div class="inline-flex items-center gap-2">
+  <div
+    role="button"
+    tabindex={onclick ? 0 : -1}
+    class={cn('inline-flex items-center gap-2', onclick && 'cursor-pointer', className)}
+    {onpointerenter}
+    {onpointerleave}
+    {onclick}
+    onkeydown={handleKeydown}
+    {...rest}
+  >
     <span class={cn('inline-block size-2 rounded-full', inactive && 'opacity-50')} style:background-color={color}></span>
     <span class={cn('text-xs', inactive && 'opacity-50')}>{name}</span>
     <span class={cn('text-xs font-medium', inactive && 'opacity-50')}>{value}</span>

--- a/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/TimeseriesChart.svelte
@@ -28,12 +28,14 @@
     tooltipBoundary?: 'clipping-ancestors' | Element | Element[];
     tooltipFollowCursor?: 'both' | 'x';
     incomplete?: { before?: number; after?: number };
+    enableLegendSelection?: boolean;
     height?: number;
     onTimeRangeChange?: (from: number, to: number) => void;
     isDarkMode?: boolean;
     gradient?: boolean;
     loading?: boolean;
     ariaDescription?: string;
+    chartRef?: EChartsType | null;
     animation?: boolean;
     animationDuration?: number;
     optionUpdateBehavior?: Record<string, unknown>;
@@ -56,22 +58,24 @@
     tooltipBoundary,
     tooltipFollowCursor = 'both',
     incomplete,
+    enableLegendSelection = false,
     height = 350,
     onTimeRangeChange,
     isDarkMode,
     gradient = false,
     loading = false,
     ariaDescription,
+    chartRef = $bindable(null),
     animation = true,
     animationDuration = 600,
     optionUpdateBehavior
   }: Props = $props();
 
-  let chartRef: EChartsType | null = $state(null);
   let detectedDarkMode = $state(false);
   let containerRef: HTMLDivElement;
   let tooltipAnchor: HTMLSpanElement | null = $state(null);
   let tooltipState: { ts: number; rows: { name: string; value: number; color: string }[]; hiddenCount: number } | null = $state(null);
+  let legendSelected: Record<string, boolean> | null = $state(null);
   let mousePos = $state({ x: 0, y: 0 });
   const effectiveDarkMode = $derived(isDarkMode ?? detectedDarkMode);
 
@@ -207,6 +211,7 @@
       animationEasing: 'cubicOut',
       animationEasingUpdate: 'cubicOut',
       toolbox: { show: false },
+      ...(enableLegendSelection ? { legend: { show: false } } : {}),
       xAxis: {
         name: xAxisName,
         nameLocation: 'middle',
@@ -242,6 +247,7 @@
 
         for (const series of data) {
           if (seenNames.has(series.name)) continue;
+          if (legendSelected && legendSelected[series.name] === false) continue;
           seenNames.add(series.name);
           const value = findNearest(series.data, ts);
           if (value != null) allRows.push({ name: series.name, value, color: series.color });
@@ -270,6 +276,15 @@
       globalout: () => {
         tooltipState = null;
       },
+      legendselectchanged: (params: { selected?: Record<string, boolean> }) => {
+        legendSelected = params.selected ?? null;
+      },
+      legendselected: (params: { selected?: Record<string, boolean> }) => {
+        legendSelected = params.selected ?? null;
+      },
+      legendunselected: (params: { selected?: Record<string, boolean> }) => {
+        legendSelected = params.selected ?? null;
+      },
       ...(onTimeRangeChange
         ? {
             brushend: (params: any) => {
@@ -282,6 +297,12 @@
         : {})
     }
   );
+
+  $effect(() => {
+    enableLegendSelection;
+    effectiveDarkMode;
+    legendSelected = null;
+  });
 
   $effect(() => {
     if (chartRef && onTimeRangeChange && !loading) {

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
@@ -136,7 +136,7 @@
 
   let contentClasses = $derived(
     cn(
-      'shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-3rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0',
+      'shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0',
       KUMO_DIALOG_VARIANTS.size[size].classes,
       className
     )

--- a/packages/kumo-svelte/src/lib/components/radio/Radio.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/Radio.svelte
@@ -76,7 +76,7 @@
     description?: string | Snippet;
     error?: string;
     class?: string;
-    onValueChange?: (value: string) => void;
+    onValueChange?: (value: string, eventDetails?: unknown) => void;
   }
 
   let {

--- a/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
@@ -1,25 +1,25 @@
-<script lang="ts">
+<script lang="ts" generics="Value = string">
   import { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
   import { setContext } from 'svelte';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
   import type { RadioAppearance, RadioControlPosition } from './Radio.svelte';
 
-  interface Props {
+  export interface Props<Value = string> {
     children?: Snippet;
     legend?: string;
     orientation?: 'vertical' | 'horizontal';
     appearance?: RadioAppearance;
     error?: string;
     description?: string | Snippet;
-    value?: string;
-    defaultValue?: string;
+    value?: Value;
+    defaultValue?: Value;
     disabled?: boolean;
     required?: boolean;
     controlPosition?: RadioControlPosition;
     name?: string;
     class?: string;
-    onValueChange?: (value: string) => void;
+    onValueChange?: (value: Value, eventDetails?: unknown) => void;
   }
 
   let {
@@ -30,7 +30,7 @@
     error,
     description,
     defaultValue,
-    value = $bindable(defaultValue ?? ''),
+    value = $bindable(defaultValue),
     disabled = false,
     required,
     controlPosition,

--- a/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioGroup.svelte
@@ -37,7 +37,9 @@
     name,
     class: className,
     onValueChange
-  }: Props = $props();
+  }: Props<Value> = $props();
+
+  const serializedValues = new Map<string, unknown>();
 
   $effect(() => {
     if (value === undefined && defaultValue !== undefined) {
@@ -45,17 +47,44 @@
     }
   });
 
+  function serializeValue(itemValue: unknown) {
+    if (typeof itemValue === 'string') return itemValue;
+
+    const serialized = `kumo-radio:${typeof itemValue}:${String(itemValue)}`;
+    serializedValues.set(serialized, itemValue);
+    return serialized;
+  }
+
+  function deserializeValue(serializedValue: string) {
+    return serializedValues.has(serializedValue) ? serializedValues.get(serializedValue) : serializedValue;
+  }
+
+  const primitiveValue = $derived(value === undefined ? undefined : serializeValue(value));
+  function handleValueChange(nextValue: string, eventDetails?: unknown) {
+    const deserializedValue = deserializeValue(nextValue) as Value;
+    value = deserializedValue;
+    onValueChange?.(deserializedValue, eventDetails);
+  }
+
   setContext('kumo-radio-group', {
     get controlPosition() {
       return controlPosition;
     },
     get appearance() {
       return appearance;
-    }
+    },
+    serializeValue
   });
 </script>
 
-<RadioGroupPrimitive.Root bind:value {orientation} {disabled} {required} {name} {onValueChange}>
+<RadioGroupPrimitive.Root
+  value={primitiveValue}
+  {orientation}
+  {disabled}
+  {required}
+  {name}
+  onValueChange={handleValueChange}
+>
   <fieldset class={cn('flex flex-col gap-4', className)} {disabled}>
     {#if legend}
       <legend class="text-base font-medium text-kumo-default">

--- a/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="Value = string">
   import { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
   import { getContext } from 'svelte';
   import type { Snippet } from 'svelte';
@@ -10,7 +10,7 @@
     readonly appearance: RadioAppearance;
   }
 
-  interface Props {
+  export interface Props<Value = string> {
     children?: Snippet;
     class?: string;
     disabled?: boolean;
@@ -18,7 +18,7 @@
     appearance?: RadioAppearance;
     label: string | Snippet;
     description?: string | Snippet;
-    value: string;
+    value: Value;
   }
 
   let {

--- a/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioItem.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="Value = string">
+<script lang="ts" generics="Value = unknown">
   import { RadioGroup as RadioGroupPrimitive } from 'bits-ui';
   import { getContext } from 'svelte';
   import type { Snippet } from 'svelte';
@@ -8,9 +8,10 @@
   interface RadioGroupContext {
     readonly controlPosition: RadioControlPosition | undefined;
     readonly appearance: RadioAppearance;
+    serializeValue: (value: unknown) => string;
   }
 
-  export interface Props<Value = string> {
+  export interface Props<Value = unknown> {
     children?: Snippet;
     class?: string;
     disabled?: boolean;
@@ -30,18 +31,19 @@
     label,
     description,
     value
-  }: Props = $props();
+  }: Props<Value> = $props();
 
   const group = getContext<RadioGroupContext | undefined>('kumo-radio-group');
   const appearance = $derived(appearanceProp ?? group?.appearance ?? 'default');
   const isCard = $derived(appearance === 'card');
   const effectiveControlPosition = $derived(group?.controlPosition ?? (isCard ? 'end' : 'start'));
   const controlAtStart = $derived(effectiveControlPosition === 'start');
+  const primitiveValue = $derived(group?.serializeValue(value) ?? (typeof value === 'string' ? value : String(value)));
 </script>
 
 {#snippet control()}
   <RadioGroupPrimitive.Item
-    {value}
+    value={primitiveValue}
     {disabled}
     data-kumo-component="Radio"
     data-kumo-part="item"

--- a/packages/kumo-svelte/src/lib/components/radio/RadioTypedValueTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/radio/RadioTypedValueTestHost.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import RadioGroup from './RadioGroup.svelte';
+  import RadioItem from './RadioItem.svelte';
+
+  let pageSize = $state<number>(10);
+</script>
+
+<RadioGroup legend="Items per page" bind:value={pageSize}>
+  <RadioItem label="10" value={10} />
+  <RadioItem label="25" value={25} />
+  <RadioItem label="50" value={50} />
+</RadioGroup>
+
+<output aria-label="Selected page size">{pageSize}</output>

--- a/packages/kumo-svelte/src/lib/components/radio/index.ts
+++ b/packages/kumo-svelte/src/lib/components/radio/index.ts
@@ -14,4 +14,10 @@ export const Radio = Object.assign(RadioRoot, {
 };
 
 export { RadioGroup, RadioItem, RadioLegend };
-export type { RadioAppearance, RadioControlPosition, RadioVariant } from './Radio.svelte';
+export type {
+  RadioAppearance,
+  RadioControlPosition,
+  RadioVariant
+} from './Radio.svelte';
+export type { Props as RadioGroupProps } from './RadioGroup.svelte';
+export type { Props as RadioItemProps } from './RadioItem.svelte';

--- a/packages/kumo-svelte/src/lib/components/radio/radio.test.ts
+++ b/packages/kumo-svelte/src/lib/components/radio/radio.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import RadioTypedValueTestHost from './RadioTypedValueTestHost.svelte';
+
+describe('Radio', () => {
+  it('round-trips non-string values through the radio group', async () => {
+    render(RadioTypedValueTestHost);
+
+    await fireEvent.click(screen.getByLabelText('25'));
+
+    expect(screen.getByLabelText('Selected page size').textContent).toBe('25');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarContent.svelte
@@ -8,7 +8,7 @@
 <div
   data-sidebar="content"
   class={cn(
-    'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-[11px] py-3 transition-[padding] duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:px-3.5 group-data-[state=collapsed]/sidebar:overflow-x-hidden!',
+    'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden! px-[11px] py-3 transition-[padding] duration-(--sidebar-animation-duration) group-not-data-[state=collapsed]/sidebar:px-3.5',
     'group-data-[mobile=true]/sidebar:px-3.5',
     className
   )}

--- a/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
+++ b/packages/kumo-svelte/src/lib/components/sidebar/SidebarGroupLabel.svelte
@@ -15,7 +15,7 @@
   {...rest}
 >
   <div class="min-h-0 min-w-0">
-    <div class="truncate px-3 mt-6 mb-2 text-sm font-medium text-kumo-subtle [[data-sidebar=group]:first-child_&]:mt-2">
+    <div class="truncate px-3 mt-4 mb-2 text-sm font-medium text-kumo-subtle [[data-sidebar=group]:first-child_&]:mt-2">
       {@render children?.()}
     </div>
   </div>

--- a/packages/kumo-svelte/src/lib/components/toolbar/Toolbar.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/Toolbar.svelte
@@ -1,0 +1,68 @@
+<script module lang="ts">
+  export {
+    KUMO_TOOLBAR_DEFAULT_VARIANTS,
+    KUMO_TOOLBAR_VARIANTS,
+    type ToolbarSize
+  } from './context';
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils/cn';
+  import {
+    KUMO_TOOLBAR_DEFAULT_VARIANTS,
+    KUMO_TOOLBAR_VARIANTS,
+    setToolbarContext,
+    type ToolbarSize
+  } from './context';
+
+  export interface Props {
+    children?: Snippet;
+    class?: string;
+    size?: ToolbarSize;
+    [key: string]: unknown;
+  }
+
+  let {
+    children,
+    class: className,
+    size = KUMO_TOOLBAR_DEFAULT_VARIANTS.size,
+    ...rest
+  }: Props = $props();
+
+  setToolbarContext({
+    get size() {
+      return size;
+    }
+  });
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    const root = event.currentTarget as HTMLElement;
+    const controls = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((element) => !element.hasAttribute('aria-hidden'));
+    const index = controls.indexOf(event.target as HTMLElement);
+    if (index === -1) return;
+
+    event.preventDefault();
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    controls[(index + direction + controls.length) % controls.length]?.focus();
+  }
+</script>
+
+<div
+  data-kumo-component="Toolbar"
+  role="toolbar"
+  class={cn(
+    'inline-flex w-fit items-stretch rounded-lg bg-kumo-control shadow-xs ring ring-kumo-line',
+    KUMO_TOOLBAR_VARIANTS.size[size].classes,
+    className
+  )}
+  onkeydown={handleKeydown}
+  {...rest}
+>
+  {@render children?.()}
+</div>

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarButton.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarButton.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { Component, Snippet } from 'svelte';
+  import Button from '$lib/components/button/Button.svelte';
+  import { getToolbarContext, toolbarControlClassName } from './context';
+
+  export interface Props {
+    children?: Snippet;
+    class?: string;
+    disabled?: boolean;
+    loading?: boolean;
+    icon?: Component;
+    shape?: 'base' | 'square' | 'circle';
+    type?: 'button' | 'submit' | 'reset';
+    [key: string]: unknown;
+  }
+
+  let {
+    children,
+    class: className,
+    disabled = false,
+    loading = false,
+    icon,
+    shape,
+    type = 'button',
+    ...rest
+  }: Props = $props();
+
+  const toolbar = getToolbarContext();
+  const size = $derived(toolbar?.size ?? 'base');
+  const resolvedShape = $derived(shape ?? (!children && icon ? 'square' : 'base'));
+</script>
+
+<Button
+  class={toolbarControlClassName(className)}
+  {disabled}
+  {icon}
+  {loading}
+  shape={resolvedShape}
+  {size}
+  {type}
+  variant="ghost"
+  componentName="Toolbar.Button"
+  {...rest}
+>
+  {@render children?.()}
+</Button>

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInput.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Input from '$lib/components/input/Input.svelte';
+  import { getToolbarContext, toolbarControlClassName } from './context';
+
+  export interface Props {
+    class?: string;
+    value?: string | number;
+    onValueChange?: (value: string) => void;
+    [key: string]: unknown;
+  }
+
+  let { class: className, value = $bindable(''), onValueChange, ...rest }: Props = $props();
+
+  const toolbar = getToolbarContext();
+  const size = $derived(toolbar?.size ?? 'base');
+</script>
+
+<Input bind:value {onValueChange} class={toolbarControlClassName(className)} {size} {...rest} />

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInputGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInputGroup.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { InputGroup } from '$lib/components/input-group';
+  import { getToolbarContext, toolbarControlClassName } from './context';
+
+  export interface Props {
+    children?: Snippet;
+    class?: string;
+    [key: string]: unknown;
+  }
+
+  let { children, class: className, ...rest }: Props = $props();
+
+  const toolbar = getToolbarContext();
+  const size = $derived(toolbar?.size ?? 'base');
+</script>
+
+<InputGroup class={toolbarControlClassName(className)} {size} {...rest}>
+  {@render children?.()}
+</InputGroup>

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { Input } from '$lib/components/input';
+  import { InputGroup } from '$lib/components/input-group';
+  import { Toolbar } from './index';
+</script>
+
+<Toolbar size="sm">
+  <Toolbar.Input aria-label="Toolbar input" />
+  <Input aria-label="Direct input" size="lg" />
+</Toolbar>
+
+<Toolbar size="sm">
+  <Toolbar.InputGroup aria-label="Hostname">
+    <InputGroup.Input placeholder="example" aria-label="Hostname" />
+    <InputGroup.Suffix>.workers.dev</InputGroup.Suffix>
+  </Toolbar.InputGroup>
+  <InputGroup>
+    <InputGroup.Input placeholder="plain" aria-label="Plain" />
+  </InputGroup>
+</Toolbar>
+
+<Toolbar>
+  <Toolbar.InputGroup aria-label="Search DNS records">
+    <InputGroup.Input placeholder="Search DNS records" />
+  </Toolbar.InputGroup>
+  <Toolbar.Button aria-label="Filter">Filter</Toolbar.Button>
+  <Toolbar.Button aria-label="Settings">Settings</Toolbar.Button>
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
@@ -26,3 +26,11 @@
   <Toolbar.Button aria-label="Filter">Filter</Toolbar.Button>
   <Toolbar.Button aria-label="Settings">Settings</Toolbar.Button>
 </Toolbar>
+
+<Toolbar>
+  <Toolbar.InputGroup aria-label="Worker subdomain">
+    <InputGroup.Input placeholder="my-worker" />
+    <InputGroup.Suffix>.workers.dev</InputGroup.Suffix>
+  </Toolbar.InputGroup>
+  <Toolbar.Button>Visit</Toolbar.Button>
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/components/toolbar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/context.ts
@@ -1,0 +1,53 @@
+import { getContext, setContext } from 'svelte';
+import { cn } from '$lib/utils/cn';
+
+export const KUMO_TOOLBAR_VARIANTS = {
+  size: {
+    xs: {
+      classes: 'text-xs',
+      description: 'Extra small toolbar for compact UIs'
+    },
+    sm: {
+      classes: 'text-xs',
+      description: 'Small toolbar for secondary controls'
+    },
+    base: {
+      classes: 'text-base',
+      description: 'Default toolbar size'
+    },
+    lg: {
+      classes: 'text-base',
+      description: 'Large toolbar for prominent controls'
+    }
+  }
+} as const;
+
+export const KUMO_TOOLBAR_DEFAULT_VARIANTS = {
+  size: 'base'
+} as const;
+
+export type ToolbarSize = keyof typeof KUMO_TOOLBAR_VARIANTS.size;
+
+export interface ToolbarContextValue {
+  size: ToolbarSize;
+}
+
+const TOOLBAR_CONTEXT = 'kumo-toolbar';
+
+export function setToolbarContext(context: ToolbarContextValue) {
+  setContext(TOOLBAR_CONTEXT, context);
+}
+
+export function getToolbarContext() {
+  return getContext<ToolbarContextValue | undefined>(TOOLBAR_CONTEXT);
+}
+
+export function toolbarControlClassName(className?: string) {
+  return cn(
+    'relative min-w-0 border-0 bg-transparent shadow-none ring-0 focus:z-2 focus-within:z-2 focus-visible:z-2',
+    'rounded-none first:rounded-l-lg last:rounded-r-lg only:rounded-lg',
+    'not-first:border-l not-first:border-kumo-line',
+    'focus:ring-kumo-focus/50 focus:ring-[1.5px] focus-visible:ring-2 focus-visible:ring-kumo-brand',
+    className
+  );
+}

--- a/packages/kumo-svelte/src/lib/components/toolbar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/context.ts
@@ -48,6 +48,7 @@ export function toolbarControlClassName(className?: string) {
     'rounded-none first:rounded-l-lg last:rounded-r-lg only:rounded-lg',
     'not-first:border-l not-first:border-kumo-line',
     'focus:ring-kumo-focus/50 focus:ring-[1.5px] focus-visible:ring-2 focus-visible:ring-kumo-brand',
+    'focus-within:ring-kumo-focus/50 focus-within:ring-[1.5px]',
     className
   );
 }

--- a/packages/kumo-svelte/src/lib/components/toolbar/index.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/index.ts
@@ -1,0 +1,34 @@
+import Root from './Toolbar.svelte';
+import Button from './ToolbarButton.svelte';
+import Input from './ToolbarInput.svelte';
+import InputGroup from './ToolbarInputGroup.svelte';
+
+const Toolbar = Object.assign(Root, {
+  Root,
+  Button,
+  Input,
+  InputGroup
+}) as typeof Root & {
+  Root: typeof Root;
+  Button: typeof Button;
+  Input: typeof Input;
+  InputGroup: typeof InputGroup;
+};
+
+export {
+  Toolbar,
+  Root as ToolbarRoot,
+  Button as ToolbarButton,
+  Input as ToolbarInput,
+  InputGroup as ToolbarInputGroup
+};
+
+export {
+  KUMO_TOOLBAR_DEFAULT_VARIANTS,
+  KUMO_TOOLBAR_VARIANTS,
+  type ToolbarSize
+} from './context';
+export type { Props as ToolbarProps } from './Toolbar.svelte';
+export type { Props as ToolbarButtonProps } from './ToolbarButton.svelte';
+export type { Props as ToolbarInputProps } from './ToolbarInput.svelte';
+export type { Props as ToolbarInputGroupProps } from './ToolbarInputGroup.svelte';

--- a/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
@@ -61,4 +61,17 @@ describe('Toolbar', () => {
     await fireEvent.keyDown(filter, { key: 'ArrowRight' });
     expect(document.activeElement).toBe(settings);
   });
+
+  it('moves focus from Toolbar.InputGroup input with suffix to the next toolbar button', async () => {
+    render(ToolbarTestHost);
+
+    const input = screen.getByRole('textbox', { name: 'Worker subdomain' });
+    const visit = screen.getByRole('button', { name: 'Visit' });
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    await fireEvent.keyDown(input, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(visit);
+  });
 });

--- a/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
@@ -42,6 +42,9 @@ describe('Toolbar', () => {
 
     expect(toolbarGroup.className).toContain('h-7');
     expect(toolbarGroup.className).toContain('rounded-none');
+    expect(toolbarGroup.className).toContain('first:rounded-l-lg');
+    expect(toolbarGroup.className).toContain('last:rounded-r-lg');
+    expect(toolbarGroup.className).toContain('focus-within:ring-kumo-focus/50');
     expect(plainGroup.className).not.toContain('rounded-none');
   });
 

--- a/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import {
+  Toolbar,
+  ToolbarButton,
+  ToolbarInput,
+  ToolbarInputGroup,
+  ToolbarRoot
+} from './index';
+import ToolbarTestHost from './ToolbarTestHost.svelte';
+
+describe('Toolbar exports', () => {
+  it('exports the compound component parts', () => {
+    expect(Toolbar).toBeDefined();
+    expect(Toolbar.Root).toBe(ToolbarRoot);
+    expect(Toolbar.Button).toBe(ToolbarButton);
+    expect(Toolbar.Input).toBe(ToolbarInput);
+    expect(Toolbar.InputGroup).toBe(ToolbarInputGroup);
+  });
+});
+
+describe('Toolbar', () => {
+  it('applies toolbar size and item styles through Toolbar.Input', () => {
+    render(ToolbarTestHost);
+
+    const toolbarInput = screen.getByRole('textbox', { name: 'Toolbar input' });
+    const directInput = screen.getByRole('textbox', { name: 'Direct input' });
+
+    expect(toolbarInput.className).toContain('h-6.5');
+    expect(toolbarInput.className).toContain('rounded-none');
+    expect(directInput.className).toContain('h-10');
+    expect(directInput.className).not.toContain('rounded-none');
+  });
+
+  it('passes toolbar size and item styles directly to Toolbar.InputGroup', () => {
+    const { container } = render(ToolbarTestHost);
+
+    const groups = container.querySelectorAll('[data-slot="input-group"]');
+    const toolbarGroup = groups[0] as HTMLElement;
+    const plainGroup = groups[1] as HTMLElement;
+
+    expect(toolbarGroup.className).toContain('h-7');
+    expect(toolbarGroup.className).toContain('rounded-none');
+    expect(plainGroup.className).not.toContain('rounded-none');
+  });
+
+  it('moves focus from Toolbar.InputGroup input to the next toolbar button', async () => {
+    render(ToolbarTestHost);
+
+    const input = screen.getByRole('textbox', { name: 'Search DNS records' });
+    const filter = screen.getByRole('button', { name: 'Filter' });
+    const settings = screen.getByRole('button', { name: 'Settings' });
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    await fireEvent.keyDown(input, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(filter);
+
+    await fireEvent.keyDown(filter, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(settings);
+  });
+});

--- a/packages/kumo-svelte/src/lib/docs/HomeGrid.svelte
+++ b/packages/kumo-svelte/src/lib/docs/HomeGrid.svelte
@@ -61,6 +61,7 @@
         Tabs,
         Text,
         Toasty,
+        Toolbar,
         createKumoToastManager,
         Tooltip,
     } from "$lib";
@@ -125,6 +126,33 @@
                             >
                             <Button loading>Create Worker</Button>
                         </div>
+                    </div>
+                </li>
+
+                <li
+                    class="relative flex aspect-square items-center justify-center bg-kumo-canvas"
+                >
+                    <a
+                        id="toolbar"
+                        href="/components/toolbar"
+                        class="absolute top-4 left-4 text-base font-medium text-kumo-subtle hover:text-kumo-default"
+                        >Toolbar</a
+                    >
+                    <div
+                        class="flex w-full items-center justify-center p-8 tracking-normal leading-normal"
+                    >
+                        <Toolbar class="w-full max-w-md">
+                            <Toolbar.InputGroup
+                                aria-label="Search DNS records"
+                                class="flex-1"
+                            >
+                                <InputGroupAddon>
+                                    <MagnifyingGlass class="size-4" />
+                                </InputGroupAddon>
+                                <InputGroupInput placeholder="Search" />
+                            </Toolbar.InputGroup>
+                            <Toolbar.Button icon={Plus} aria-label="Add" />
+                        </Toolbar>
                     </div>
                 </li>
 

--- a/packages/kumo-svelte/src/lib/docs/PropsTable.svelte
+++ b/packages/kumo-svelte/src/lib/docs/PropsTable.svelte
@@ -4,9 +4,10 @@
   interface Props {
     component?: string;
     sourceFile?: string;
+    hiddenProps?: string[];
   }
 
-  let { component, sourceFile }: Props = $props();
+  let { component, sourceFile, hiddenProps = [] }: Props = $props();
 
   const propModules = import.meta.glob('./props-data/*.ts', {
     eager: true,
@@ -165,6 +166,7 @@
     const omitted = new Set([
       ...(omittedProps[key] ?? omittedProps[resolvedKey] ?? []),
       ...(snippetPropsOmittedByComponent[key] ?? snippetPropsOmittedByComponent[resolvedKey] ?? []),
+      ...hiddenProps,
       ...(isTopLevelComponent ? [] : ['class', 'children'])
     ]);
     const required = new Set(requiredProps[key] ?? requiredProps[resolvedKey] ?? []);

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BadgeColorVariantsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BadgeColorVariantsDemo.svelte
@@ -5,6 +5,7 @@
 <div class="flex flex-wrap items-center gap-2">
   <Badge variant="neutral">Neutral</Badge>
   <Badge variant="red">Red</Badge>
+  <Badge variant="green">Green</Badge>
   <Badge variant="orange">Orange</Badge>
   <Badge variant="teal">Teal</Badge>
   <Badge variant="blue">Blue</Badge>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogMaxWidthDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogMaxWidthDemo.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { Button, Dialog } from '$lib';
+</script>
+
+<div class="flex min-h-24 w-full items-center justify-center">
+  <Dialog title="Max width override" description="This dialog uses class=&quot;max-w-lg&quot; and should stay capped around 512px on desktop." class="max-w-lg p-8">
+    {#snippet trigger(props)}
+      <Button {...props}>Open capped dialog</Button>
+    {/snippet}
+    <div class="mt-4 truncate rounded-md border border-kumo-line bg-kumo-recessed p-3 font-mono text-sm">
+      abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+    </div>
+  </Dialog>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogWithSelectDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogWithSelectDemo.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
-  import { Dialog } from '$lib';
+  import { Button, Dialog, Select } from '$lib';
+
+  const regions = [
+    { value: 'us-east', label: 'US East' },
+    { value: 'us-west', label: 'US West' },
+    { value: 'eu-west', label: 'EU West' },
+    { value: 'ap-south', label: 'AP South' }
+  ];
 </script>
 
 <div class="flex min-h-24 w-full items-center justify-center">
-  <Dialog title="Select Region" description="Make changes and save when you are done.">
-    {#snippet trigger()}<span class="inline-flex h-9 cursor-pointer items-center rounded-lg bg-kumo-base px-3 text-base font-medium text-kumo-default shadow-xs ring ring-kumo-hairline">Click me</span>{/snippet}
-    <div class="grid gap-3">
-      <p class="text-sm text-kumo-subtle">Dialog content goes here.</p>
+  <Dialog title="Create Resource" description="Select a region for your new resource." class="p-8">
+    {#snippet trigger(props)}
+      <Button {...props}>Open Form</Button>
+    {/snippet}
+    <Select
+      class="w-full"
+      placeholder="Select region..."
+      options={regions}
+      renderValue={(value) => regions.find((region) => region.value === value)?.label}
+    />
+    <div class="mt-8 flex justify-end gap-2">
+      <Button variant="secondary">Cancel</Button>
+      <Button variant="primary">Create</Button>
     </div>
   </Dialog>
 </div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LegendHighlightDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LegendHighlightDemo.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import type { EChartsType } from 'echarts/core';
+  import { ChartLegend, ChartPalette, LayerCard, TimeseriesChart } from 'kumo-svelte';
+  import { buildSeriesData, getIsDarkMode } from './chart-color-demo-data';
+
+  let isDarkMode = $state(false);
+  let chartRef: EChartsType | null = $state(null);
+  let hoveredSeries: string | null = $state(null);
+
+  const series = $derived([
+    {
+      name: 'P99',
+      color: ChartPalette.semantic('Attention', isDarkMode),
+      value: '124',
+      unit: 'ms'
+    },
+    {
+      name: 'P95',
+      color: ChartPalette.semantic('Warning', isDarkMode),
+      value: '76',
+      unit: 'ms'
+    },
+    {
+      name: 'P75',
+      color: ChartPalette.semantic('Neutral', isDarkMode),
+      value: '32',
+      unit: 'ms'
+    },
+    {
+      name: 'P50',
+      color: ChartPalette.semantic('Neutral', isDarkMode),
+      value: '10',
+      unit: 'ms'
+    }
+  ]);
+
+  const data = $derived(
+    series.map((item, index) => ({
+      name: item.name,
+      data: buildSeriesData(3 - index, 30, 60_000, 1 - index * 0.2),
+      color: item.color
+    }))
+  );
+
+  function handlePointerEnter(name: string) {
+    hoveredSeries = name;
+    chartRef?.dispatchAction({ type: 'highlight', seriesName: name });
+  }
+
+  function handlePointerLeave(name: string) {
+    hoveredSeries = null;
+    chartRef?.dispatchAction({ type: 'downplay', seriesName: name });
+  }
+
+  onMount(() => {
+    const update = () => {
+      isDarkMode = getIsDarkMode();
+    };
+    const observer = new MutationObserver(update);
+
+    update();
+    [document.documentElement, document.body].forEach((node) => {
+      observer.observe(node, { attributes: true, attributeFilter: ['data-mode', 'class'] });
+    });
+
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    mediaQuery?.addEventListener('change', update);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery?.removeEventListener('change', update);
+    };
+  });
+</script>
+
+<LayerCard>
+  <LayerCard.Secondary>Read latency</LayerCard.Secondary>
+  <LayerCard.Primary>
+    <div class="mb-2 flex divide-x divide-kumo-line px-2">
+      {#each series as item (item.name)}
+        <ChartLegend
+          variant="large"
+          name={item.name}
+          color={item.color}
+          value={item.value}
+          unit={item.unit}
+          inactive={hoveredSeries !== null && hoveredSeries !== item.name}
+          onpointerenter={() => handlePointerEnter(item.name)}
+          onpointerleave={() => handlePointerLeave(item.name)}
+          class="not-first:pl-4"
+        />
+      {/each}
+    </div>
+    <TimeseriesChart
+      bind:chartRef
+      {echarts}
+      xAxisName="Time (UTC)"
+      {isDarkMode}
+      {data}
+      height={300}
+    />
+  </LayerCard.Primary>
+</LayerCard>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/LegendOnClickDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/LegendOnClickDemo.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import type { EChartsType } from 'echarts/core';
+  import { ChartLegend, ChartPalette, LayerCard, TimeseriesChart } from 'kumo-svelte';
+  import { buildSeriesData, getIsDarkMode } from './chart-color-demo-data';
+
+  let isDarkMode = $state(false);
+  let chartRef: EChartsType | null = $state(null);
+  let hiddenSeries: Record<string, boolean> = $state({});
+
+  const series = $derived([
+    {
+      name: 'P99',
+      color: ChartPalette.semantic('Attention', isDarkMode),
+      value: '124',
+      unit: 'ms'
+    },
+    {
+      name: 'P95',
+      color: ChartPalette.semantic('Warning', isDarkMode),
+      value: '76',
+      unit: 'ms'
+    },
+    {
+      name: 'P75',
+      color: ChartPalette.semantic('Neutral', isDarkMode),
+      value: '32',
+      unit: 'ms'
+    },
+    {
+      name: 'P50',
+      color: ChartPalette.semantic('Neutral', isDarkMode),
+      value: '10',
+      unit: 'ms'
+    }
+  ]);
+
+  const data = $derived(
+    series.map((item, index) => ({
+      name: item.name,
+      data: buildSeriesData(3 - index, 30, 60_000, 1 - index * 0.2),
+      color: item.color
+    }))
+  );
+
+  $effect(() => {
+    isDarkMode;
+    hiddenSeries = {};
+  });
+
+  function handleClick(name: string) {
+    if (!chartRef) return;
+
+    const isIsolated = series.every((item) => (item.name === name ? !hiddenSeries[item.name] : hiddenSeries[item.name]));
+    const nextHidden: Record<string, boolean> = {};
+
+    for (const item of series) {
+      const shouldHide = isIsolated ? false : item.name !== name;
+      nextHidden[item.name] = shouldHide;
+      chartRef.dispatchAction({
+        type: shouldHide ? 'legendUnSelect' : 'legendSelect',
+        name: item.name
+      });
+    }
+
+    hiddenSeries = nextHidden;
+  }
+
+  onMount(() => {
+    const update = () => {
+      isDarkMode = getIsDarkMode();
+    };
+    const observer = new MutationObserver(update);
+
+    update();
+    [document.documentElement, document.body].forEach((node) => {
+      observer.observe(node, { attributes: true, attributeFilter: ['data-mode', 'class'] });
+    });
+
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    mediaQuery?.addEventListener('change', update);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery?.removeEventListener('change', update);
+    };
+  });
+</script>
+
+<LayerCard>
+  <LayerCard.Secondary>Read latency</LayerCard.Secondary>
+  <LayerCard.Primary>
+    <div class="mb-2 flex divide-x divide-kumo-line px-2">
+      {#each series as item (item.name)}
+        <ChartLegend
+          variant="large"
+          name={item.name}
+          color={item.color}
+          value={item.value}
+          unit={item.unit}
+          inactive={hiddenSeries[item.name] ?? false}
+          onclick={() => handleClick(item.name)}
+          class="not-first:pl-4"
+        />
+      {/each}
+    </div>
+    <TimeseriesChart
+      bind:chartRef
+      {echarts}
+      xAxisName="Time (UTC)"
+      {isDarkMode}
+      {data}
+      height={300}
+      enableLegendSelection
+    />
+  </LayerCard.Primary>
+</LayerCard>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioTypedValueDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/RadioTypedValueDemo.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { RadioGroup, RadioItem } from '$lib';
+
+  const ThemeType = {
+    dark: 'dark',
+    light: 'light',
+    system: 'system'
+  } as const;
+  type ThemeType = (typeof ThemeType)[keyof typeof ThemeType];
+
+  let pageSize = $state<number>(10);
+  let theme = $state<ThemeType>(ThemeType.system);
+</script>
+
+<div class="grid grid-cols-2 gap-6">
+  <RadioGroup legend="Items per page" bind:value={pageSize}>
+    <RadioItem label="10" value={10} />
+    <RadioItem label="25" value={25} />
+    <RadioItem label="50" value={50} />
+  </RadioGroup>
+  <RadioGroup legend="Theme" bind:value={theme}>
+    <RadioItem label="Light" value={ThemeType.light} />
+    <RadioItem label="Dark" value={ThemeType.dark} />
+    <RadioItem label="System" value={ThemeType.system} />
+  </RadioGroup>
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarActionsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarActionsDemo.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { DownloadSimple, UploadSimple } from 'phosphor-svelte';
+  import { Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar>
+  <Toolbar.Button icon={UploadSimple}>Upload</Toolbar.Button>
+  <Toolbar.Button icon={DownloadSimple}>Download</Toolbar.Button>
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarDemo.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { FunnelSimple, Gear, MagnifyingGlass } from 'phosphor-svelte';
+  import { InputGroup, Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar class="w-full max-w-md">
+  <Toolbar.InputGroup aria-label="Search DNS records" class="flex-1">
+    <InputGroup.Addon>
+      <MagnifyingGlass />
+    </InputGroup.Addon>
+    <InputGroup.Input placeholder="Search DNS records" />
+  </Toolbar.InputGroup>
+  <Toolbar.Button icon={FunnelSimple} aria-label="Filter" />
+  <Toolbar.Button icon={Gear} aria-label="Settings" />
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarInputGroupDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarInputGroupDemo.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { InputGroup, Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar class="w-full max-w-lg">
+  <Toolbar.InputGroup aria-label="Worker subdomain" class="flex-1">
+    <InputGroup.Input placeholder="my-worker" />
+    <InputGroup.Suffix>.workers.dev</InputGroup.Suffix>
+  </Toolbar.InputGroup>
+  <Toolbar.Button>Visit</Toolbar.Button>
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarLabelsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarLabelsDemo.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { MagnifyingGlass } from 'phosphor-svelte';
+  import { Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar class="w-full max-w-lg">
+  <Toolbar.Input aria-label="Search records" class="flex-1" placeholder="Search" />
+  <Toolbar.Button icon={MagnifyingGlass} aria-label="Search" />
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarMixedControlsDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarMixedControlsDemo.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { FunnelSimple, Gear } from 'phosphor-svelte';
+  import { Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar class="w-full max-w-md">
+  <Toolbar.Input aria-label="Search DNS records" placeholder="Search DNS records" class="flex-1" />
+  <Toolbar.Button icon={FunnelSimple} aria-label="Filter" />
+  <Toolbar.Button icon={Gear} aria-label="Settings" />
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarSizesDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarSizesDemo.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Toolbar } from 'kumo-svelte';
+
+  const sizes = ['xs', 'sm', 'base', 'lg'] as const;
+</script>
+
+<div class="grid gap-3">
+  {#each sizes as size}
+    <div class="flex items-center gap-3">
+      <span class="w-10 text-sm text-kumo-subtle">{size}</span>
+      <Toolbar {size} class="w-fit">
+        <Toolbar.Input aria-label={`${size} search`} placeholder="Search..." />
+        <Toolbar.Button>Apply</Toolbar.Button>
+      </Toolbar>
+    </div>
+  {/each}
+</div>

--- a/packages/kumo-svelte/src/lib/docs/nav.ts
+++ b/packages/kumo-svelte/src/lib/docs/nav.ts
@@ -55,6 +55,7 @@ export const componentItems: NavItem[] = [
   { label: 'Table of Contents', href: '/components/table-of-contents' },
   { label: 'Tabs', href: '/components/tabs' },
   { label: 'Text', href: '/components/text' },
+  { label: 'Toolbar', href: '/components/toolbar' },
   { label: 'Toast', href: '/components/toast' },
   { label: 'Tooltip', href: '/components/tooltip' }
 ];

--- a/packages/kumo-svelte/src/lib/docs/props-data/ChartLegend.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/ChartLegend.ts
@@ -2,42 +2,71 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "variant",
-    "type": "'large' | 'small'",
-    "required": false,
-    "default": "\"small\"",
-    "description": "Svelte variant matching the upstream SmallItem or LargeItem legend layouts."
+    prop: 'variant',
+    type: "'large' | 'small'",
+    required: false,
+    default: '"small"',
+    description:
+      'Svelte variant matching the upstream SmallItem or LargeItem legend layouts.'
   },
   {
-    "prop": "name",
-    "type": "string",
-    "required": true,
-    "description": "Series name shown as a label."
+    prop: 'name',
+    type: 'string',
+    required: true,
+    description: 'Series name shown as a label.'
   },
   {
-    "prop": "color",
-    "type": "string",
-    "required": true,
-    "description": "Hex color string for the series indicator dot."
+    prop: 'color',
+    type: 'string',
+    required: true,
+    description: 'Hex color string for the series indicator dot.'
   },
   {
-    "prop": "value",
-    "type": "string",
-    "required": true,
-    "description": "Formatted value string to display."
+    prop: 'value',
+    type: 'string',
+    required: true,
+    description: 'Formatted value string to display.'
   },
   {
-    "prop": "unit",
-    "type": "string",
-    "required": false,
-    "description": "Optional unit label shown after the value."
+    prop: 'unit',
+    type: 'string',
+    required: false,
+    description: 'Optional unit label shown after the value.'
   },
   {
-    "prop": "inactive",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Renders the item at reduced opacity to indicate a deselected state."
+    prop: 'inactive',
+    type: 'boolean',
+    required: false,
+    default: 'false',
+    description:
+      'Renders the item at reduced opacity to indicate a deselected state.'
+  },
+  {
+    prop: 'onpointerenter',
+    type: '(event: PointerEvent) => void',
+    required: false,
+    description:
+      'Fired when a pointer enters the legend item, useful for highlighting the corresponding chart series.'
+  },
+  {
+    prop: 'onpointerleave',
+    type: '(event: PointerEvent) => void',
+    required: false,
+    description:
+      'Fired when a pointer leaves the legend item, useful for resetting chart series emphasis.'
+  },
+  {
+    prop: 'onclick',
+    type: '(event: MouseEvent) => void',
+    required: false,
+    description:
+      'Fired when the legend item is clicked, useful for toggling series visibility.'
+  },
+  {
+    prop: 'class',
+    type: 'string',
+    required: false,
+    description: 'Optional class for customizing legend item presentation.'
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio.ts
@@ -98,7 +98,7 @@ const rows: PropRow[] = [
   },
   {
     "prop": "onValueChange",
-    "type": "(value: string) => void",
+    "type": "(value: string, eventDetails?: unknown) => void",
     "required": false,
     "description": "Called when the value changes."
   }

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
@@ -41,7 +41,7 @@ const rows: PropRow[] = [
   },
   {
     "prop": "value",
-    "type": "string",
+    "type": "Value",
     "required": false,
     "description": "Controlled value."
   },
@@ -72,7 +72,7 @@ const rows: PropRow[] = [
   },
   {
     "prop": "defaultValue",
-    "type": "string",
+    "type": "Value",
     "required": false,
     "description": "Initial uncontrolled value."
   },
@@ -84,7 +84,7 @@ const rows: PropRow[] = [
   },
   {
     "prop": "onValueChange",
-    "type": "(value: string) => void",
+    "type": "(value: Value, eventDetails?: unknown) => void",
     "required": false,
     "description": "Called when the value changes."
   }

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio__Item.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio__Item.ts
@@ -47,7 +47,7 @@ const rows: PropRow[] = [
   },
   {
     "prop": "value",
-    "type": "string",
+    "type": "Value",
     "required": true,
     "description": "Controlled value."
   }

--- a/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
@@ -2,149 +2,168 @@ import type { PropRow } from '../prop-types';
 
 const rows: PropRow[] = [
   {
-    "prop": "echarts",
-    "type": "any",
-    "required": true,
-    "description": "The ECharts core instance imported by the consumer."
+    prop: 'echarts',
+    type: 'any',
+    required: true,
+    description: 'The ECharts core instance imported by the consumer.'
   },
   {
-    "prop": "type",
-    "type": "'line' | 'bar'",
-    "required": false,
-    "default": "\"line\"",
-    "description": "Visual style of each series."
+    prop: 'type',
+    type: "'line' | 'bar'",
+    required: false,
+    default: '"line"',
+    description: 'Visual style of each series.'
   },
   {
-    "prop": "data",
-    "type": "TimeseriesData[]",
-    "required": true,
-    "description": "Array of time series data to display on the chart."
+    prop: 'data',
+    type: 'TimeseriesData[]',
+    required: true,
+    description: 'Array of time series data to display on the chart.'
   },
   {
-    "prop": "xAxisName",
-    "type": "string",
-    "required": false,
-    "description": "Label for the x-axis."
+    prop: 'xAxisName',
+    type: 'string',
+    required: false,
+    description: 'Label for the x-axis.'
   },
   {
-    "prop": "xAxisTickCount",
-    "type": "number",
-    "required": false,
-    "description": "Number of ticks to display on the x-axis."
+    prop: 'xAxisTickCount',
+    type: 'number',
+    required: false,
+    description: 'Number of ticks to display on the x-axis.'
   },
   {
-    "prop": "xAxisTickFormat",
-    "type": "(value: number) => string",
-    "required": false,
-    "description": "Custom formatter for x-axis tick labels."
+    prop: 'xAxisTickFormat',
+    type: '(value: number) => string',
+    required: false,
+    description: 'Custom formatter for x-axis tick labels.'
   },
   {
-    "prop": "yAxisTickFormat",
-    "type": "(value: number) => string",
-    "required": false,
-    "description": "Custom formatter for y-axis tick labels."
+    prop: 'yAxisTickFormat',
+    type: '(value: number) => string',
+    required: false,
+    description: 'Custom formatter for y-axis tick labels.'
   },
   {
-    "prop": "yAxisTickLabelFormat",
-    "type": "(value: number) => string",
-    "required": false,
-    "description": "Deprecated: use tooltipValueFormat instead. Formats tooltip values, not y-axis tick labels."
+    prop: 'yAxisTickLabelFormat',
+    type: '(value: number) => string',
+    required: false,
+    description:
+      'Deprecated: use tooltipValueFormat instead. Formats tooltip values, not y-axis tick labels.'
   },
   {
-    "prop": "yAxisName",
-    "type": "string",
-    "required": false,
-    "description": "Label for the y-axis."
+    prop: 'yAxisName',
+    type: 'string',
+    required: false,
+    description: 'Label for the y-axis.'
   },
   {
-    "prop": "yAxisTickCount",
-    "type": "number",
-    "required": false,
-    "description": "Number of ticks to display on the y-axis."
+    prop: 'yAxisTickCount',
+    type: 'number',
+    required: false,
+    description: 'Number of ticks to display on the y-axis.'
   },
   {
-    "prop": "tooltipValueFormat",
-    "type": "(value: number) => string",
-    "required": false,
-    "description": "Custom formatter for tooltip values. Takes precedence over yAxisTickLabelFormat."
+    prop: 'tooltipValueFormat',
+    type: '(value: number) => string',
+    required: false,
+    description:
+      'Custom formatter for tooltip values. Takes precedence over yAxisTickLabelFormat.'
   },
   {
-    "prop": "tooltipMode",
-    "type": "'all' | 'single'",
-    "required": false,
-    "default": "\"all\"",
-    "description": "Controls whether the native tooltip lists all series at the active timestamp or only the nearest series."
+    prop: 'tooltipMode',
+    type: "'all' | 'single'",
+    required: false,
+    default: '"all"',
+    description:
+      'Controls whether the native tooltip lists all series at the active timestamp or only the nearest series.'
   },
   {
-    "prop": "tooltipMaxItems",
-    "type": "number",
-    "required": false,
-    "default": "10",
-    "description": "Maximum number of series rows shown when tooltipMode is 'all'."
+    prop: 'tooltipMaxItems',
+    type: 'number',
+    required: false,
+    default: '10',
+    description:
+      "Maximum number of series rows shown when tooltipMode is 'all'."
   },
   {
-    "prop": "tooltipBoundary",
-    "type": "'clipping-ancestors' | Element | Element[]",
-    "required": false,
-    "description": "Constrains tooltip placement to the chart container when provided."
+    prop: 'tooltipBoundary',
+    type: "'clipping-ancestors' | Element | Element[]",
+    required: false,
+    description:
+      'Constrains tooltip placement to the chart container when provided.'
   },
   {
-    "prop": "tooltipFollowCursor",
-    "type": "'both' | 'x'",
-    "required": false,
-    "default": "\"both\"",
-    "description": "Controls whether the tooltip follows both cursor axes or locks to the chart top while following x."
+    prop: 'tooltipFollowCursor',
+    type: "'both' | 'x'",
+    required: false,
+    default: '"both"',
+    description:
+      'Controls whether the tooltip follows both cursor axes or locks to the chart top while following x.'
   },
   {
-    "prop": "incomplete",
-    "type": "{ before?: number; after?: number }",
-    "required": false,
-    "description": "Indicates incomplete data periods with optional before/after timestamps in milliseconds."
+    prop: 'incomplete',
+    type: '{ before?: number; after?: number }',
+    required: false,
+    description:
+      'Indicates incomplete data periods with optional before/after timestamps in milliseconds.'
   },
   {
-    "prop": "height",
-    "type": "number",
-    "required": false,
-    "default": "350",
-    "description": "Chart height in pixels."
+    prop: 'enableLegendSelection',
+    type: 'boolean',
+    required: false,
+    default: 'false',
+    description:
+      'Adds a hidden ECharts legend so custom controls can drive series visibility through legendSelect, legendUnSelect, and legendToggleSelect actions.'
   },
   {
-    "prop": "onTimeRangeChange",
-    "type": "(from: number, to: number) => void",
-    "required": false,
-    "description": "Callback fired when the user selects a time range via brush selection."
+    prop: 'height',
+    type: 'number',
+    required: false,
+    default: '350',
+    description: 'Chart height in pixels.'
   },
   {
-    "prop": "isDarkMode",
-    "type": "boolean",
-    "required": false,
-    "description": "When true, switches the chart to ECharts' dark theme."
+    prop: 'onTimeRangeChange',
+    type: '(from: number, to: number) => void',
+    required: false,
+    description:
+      'Callback fired when the user selects a time range via brush selection.'
   },
   {
-    "prop": "gradient",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Renders a vertical gradient fill beneath line series. Has no effect for bars."
+    prop: 'isDarkMode',
+    type: 'boolean',
+    required: false,
+    description: "When true, switches the chart to ECharts' dark theme."
   },
   {
-    "prop": "loading",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Hides the chart and displays an animated sine-wave skeleton."
+    prop: 'gradient',
+    type: 'boolean',
+    required: false,
+    default: 'false',
+    description:
+      'Renders a vertical gradient fill beneath line series. Has no effect for bars.'
   },
   {
-    "prop": "ariaDescription",
-    "type": "string",
-    "required": false,
-    "description": "Accessible description passed to ECharts aria.label.description."
+    prop: 'loading',
+    type: 'boolean',
+    required: false,
+    default: 'false',
+    description: 'Hides the chart and displays an animated sine-wave skeleton.'
   },
   {
-    "prop": "optionUpdateBehavior",
-    "type": "SetOptionOpts",
-    "required": false,
-    "description": "Additional options passed as the second argument to chart.setOption()."
+    prop: 'ariaDescription',
+    type: 'string',
+    required: false,
+    description:
+      'Accessible description passed to ECharts aria.label.description.'
+  },
+  {
+    prop: 'optionUpdateBehavior',
+    type: 'SetOptionOpts',
+    required: false,
+    description:
+      'Additional options passed as the second argument to chart.setOption().'
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar.ts
@@ -1,0 +1,19 @@
+export default [
+  {
+    prop: 'children',
+    type: 'Snippet',
+    required: true,
+    description: 'Toolbar controls rendered as one grouped card.'
+  },
+  {
+    prop: 'size',
+    type: '"xs" | "sm" | "base" | "lg"',
+    default: '"base"',
+    description: 'Locks every supported toolbar item to this size.'
+  },
+  {
+    prop: 'class',
+    type: 'string',
+    description: 'Additional classes merged onto the toolbar root.'
+  }
+];

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Button.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Button.ts
@@ -1,0 +1,27 @@
+export default [
+  {
+    prop: 'children',
+    type: 'Snippet',
+    description: 'Optional visible button label.'
+  },
+  {
+    prop: 'icon',
+    type: 'Component',
+    description: 'Optional icon component rendered before the label.'
+  },
+  {
+    prop: 'shape',
+    type: '"base" | "square" | "circle"',
+    description: 'Button shape. Icon-only toolbar buttons default to square.'
+  },
+  {
+    prop: 'disabled',
+    type: 'boolean',
+    description: 'Disables the toolbar button.'
+  },
+  {
+    prop: 'loading',
+    type: 'boolean',
+    description: 'Shows a loading indicator and disables the toolbar button.'
+  }
+];

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Input.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Input.ts
@@ -1,0 +1,17 @@
+export default [
+  {
+    prop: 'value',
+    type: 'string | number',
+    description: 'Input value, bindable with `bind:value`.'
+  },
+  {
+    prop: 'onValueChange',
+    type: '(value: string) => void',
+    description: 'Called when the input value changes.'
+  },
+  {
+    prop: 'class',
+    type: 'string',
+    description: 'Additional classes merged onto the toolbar input.'
+  }
+];

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__InputGroup.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__InputGroup.ts
@@ -1,0 +1,13 @@
+export default [
+  {
+    prop: 'children',
+    type: 'Snippet',
+    required: true,
+    description: 'InputGroup children rendered as one toolbar item.'
+  },
+  {
+    prop: 'class',
+    type: 'string',
+    description: 'Additional classes merged onto the toolbar input group.'
+  }
+];

--- a/packages/kumo-svelte/src/lib/index.ts
+++ b/packages/kumo-svelte/src/lib/index.ts
@@ -5,9 +5,25 @@ export { Banner } from './components/banner';
 export { Breadcrumbs } from './components/breadcrumbs';
 export type { BreadcrumbsItem } from './components/breadcrumbs';
 export { Button, LinkButton, RefreshButton } from './components/button';
-export { Chart, ChartLegend, ChartPalette, SankeyChart, TimeseriesChart } from './components/chart';
-export type { ChartEvents, ChartSemanticColorName, KumoChartOption, SafeTooltipOption } from './components/chart';
-export { Checkbox, CheckboxGroup, CheckboxItem, CheckboxLegend } from './components/checkbox';
+export {
+  Chart,
+  ChartLegend,
+  ChartPalette,
+  SankeyChart,
+  TimeseriesChart
+} from './components/chart';
+export type {
+  ChartEvents,
+  ChartSemanticColorName,
+  KumoChartOption,
+  SafeTooltipOption
+} from './components/chart';
+export {
+  Checkbox,
+  CheckboxGroup,
+  CheckboxItem,
+  CheckboxLegend
+} from './components/checkbox';
 export type { CheckboxVariant } from './components/checkbox';
 export { ClipboardText } from './components/clipboard-text';
 export {
@@ -36,15 +52,35 @@ export {
 export { Combobox } from './components/combobox';
 export { CommandPalette } from './components/command-palette';
 export { DatePicker } from './components/date-picker';
-export type { DatePickerMode, DatePickerSelection, DateRange } from './components/date-picker';
+export type {
+  DatePickerMode,
+  DatePickerSelection,
+  DateRange
+} from './components/date-picker';
 export { DateRangePicker } from './components/date-range-picker';
 export { Dialog } from './components/dialog';
-export { DropdownMenu, KUMO_DROPDOWN_DEFAULT_VARIANTS, KUMO_DROPDOWN_VARIANTS } from './components/dropdown-menu';
+export {
+  DropdownMenu,
+  KUMO_DROPDOWN_DEFAULT_VARIANTS,
+  KUMO_DROPDOWN_VARIANTS
+} from './components/dropdown-menu';
 export type { KumoDropdownVariant } from './components/dropdown-menu';
-export { Empty, KUMO_EMPTY_DEFAULT_VARIANTS, KUMO_EMPTY_VARIANTS, emptyVariants } from './components/empty';
+export {
+  Empty,
+  KUMO_EMPTY_DEFAULT_VARIANTS,
+  KUMO_EMPTY_VARIANTS,
+  emptyVariants
+} from './components/empty';
 export type { KumoEmptySize, KumoEmptyVariantsProps } from './components/empty';
 export { Field } from './components/field';
-export { Flow, FlowAnchor, FlowList, FlowNode, FlowParallel, FlowRoot } from './components/flow';
+export {
+  Flow,
+  FlowAnchor,
+  FlowList,
+  FlowNode,
+  FlowParallel,
+  FlowRoot
+} from './components/flow';
 export type { FlowAlign, FlowOrientation } from './components/flow';
 export { Grid, GridItem } from './components/grid';
 export { Input, Textarea } from './components/input';
@@ -56,7 +92,11 @@ export {
   InputGroupInput,
   InputGroupSuffix
 } from './components/input-group';
-export type { FieldError, InputGroupFocusMode, InputGroupSize } from './components/input-group';
+export type {
+  FieldError,
+  InputGroupFocusMode,
+  InputGroupSize
+} from './components/input-group';
 export { Label } from './components/label';
 export { LayerCard } from './components/layer-card';
 export {
@@ -70,7 +110,12 @@ export type { KumoLinkVariant } from './components/link';
 export { Loader, SkeletonLine } from './components/loader';
 export { KumoLogo, SvelteLogo } from './components/logo';
 export { MenuBar } from './components/menu-bar';
-export { Meter, KUMO_METER_DEFAULT_VARIANTS, KUMO_METER_VARIANTS, meterVariants } from './components/meter';
+export {
+  Meter,
+  KUMO_METER_DEFAULT_VARIANTS,
+  KUMO_METER_VARIANTS,
+  meterVariants
+} from './components/meter';
 export type { KumoMeterVariantsProps } from './components/meter';
 export {
   Pagination,
@@ -89,17 +134,31 @@ export {
   PopoverTrigger
 } from './components/popover';
 export { Radio, RadioGroup, RadioItem, RadioLegend } from './components/radio';
-export type { RadioAppearance, RadioControlPosition, RadioVariant } from './components/radio';
+export type {
+  RadioAppearance,
+  RadioControlPosition,
+  RadioGroupProps,
+  RadioItemProps,
+  RadioVariant
+} from './components/radio';
 export { Select } from './components/select';
 export {
   KUMO_SENSITIVE_INPUT_DEFAULT_VARIANTS,
   KUMO_SENSITIVE_INPUT_VARIANTS,
   SensitiveInput
 } from './components/sensitive-input';
-export type { SensitiveInputSize, SensitiveInputVariant } from './components/sensitive-input';
+export type {
+  SensitiveInputSize,
+  SensitiveInputVariant
+} from './components/sensitive-input';
 export { Sidebar } from './components/sidebar';
 export { Surface } from './components/surface';
-export { Switch, SwitchGroup, SwitchItem, SwitchLegend } from './components/switch';
+export {
+  Switch,
+  SwitchGroup,
+  SwitchItem,
+  SwitchLegend
+} from './components/switch';
 export type { SwitchSize, SwitchVariant } from './components/switch';
 export {
   KUMO_TABLE_DEFAULT_VARIANTS,
@@ -116,12 +175,36 @@ export {
   TableRow,
   tableStickyColumnClasses
 } from './components/table';
-export type { KumoTableLayout, KumoTableRowVariant, KumoTableStickyColumn } from './components/table';
+export type {
+  KumoTableLayout,
+  KumoTableRowVariant,
+  KumoTableStickyColumn
+} from './components/table';
 export { TableOfContents } from './components/table-of-contents';
 export { Tabs } from './components/tabs';
 export type { TabsItem } from './components/tabs';
 export { Text } from './components/text';
-export { Toasty, createKumoToastManager, useKumoToastManager } from './components/toasty';
+export {
+  KUMO_TOOLBAR_DEFAULT_VARIANTS,
+  KUMO_TOOLBAR_VARIANTS,
+  Toolbar,
+  ToolbarButton,
+  ToolbarInput,
+  ToolbarInputGroup,
+  ToolbarRoot
+} from './components/toolbar';
+export type {
+  ToolbarButtonProps,
+  ToolbarInputGroupProps,
+  ToolbarInputProps,
+  ToolbarProps,
+  ToolbarSize
+} from './components/toolbar';
+export {
+  Toasty,
+  createKumoToastManager,
+  useKumoToastManager
+} from './components/toasty';
 export type { KumoToastOptions, KumoToastVariant } from './components/toasty';
 export { Tooltip, TooltipProvider } from './components/tooltip';
 export { cn } from './utils/cn';

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -252,7 +252,7 @@
 
   --color-kumo-brand: light-dark(
     oklch(0.5772 0.2324 260),
-    oklch(0.5772 0.2324 260)
+    color-mix(in oklch, oklch(0.5772 0.2324 260), black 10%)
   );
 
   --color-kumo-brand-hover: light-dark(
@@ -322,7 +322,7 @@
 
   --color-kumo-danger: light-dark(
     var(--color-red-500, oklch(63.7% 0.237 25.331)),
-    var(--color-red-400, oklch(70.4% 0.191 22.216))
+    var(--color-red-600, oklch(57.7% 0.245 27.325))
   );
 
   --color-kumo-success-tint: light-dark(
@@ -366,7 +366,7 @@
   );
 
   --color-kumo-badge-green: light-dark(
-    var(--color-emerald-700, oklch(50.8% 0.118 165.612)),
+    var(--color-emerald-600, oklch(59.6% 0.145 163.225)),
     var(--color-emerald-700, oklch(50.8% 0.118 165.612))
   );
 
@@ -456,7 +456,11 @@
     --color-kumo-interact: var(--color-neutral-300, oklch(87% 0 0));
     --color-kumo-fill: var(--color-neutral-200, oklch(92.2% 0 0));
     --color-kumo-fill-hover: var(--color-kumo-neutral-125, oklch(96.5% 0 0));
-    --color-kumo-brand: oklch(0.5772 0.2324 260);
+    --color-kumo-brand: color-mix(
+      in oklch,
+      oklch(0.5772 0.2324 260),
+      black 10%
+    );
     --color-kumo-brand-hover: var(--color-blue-700, oklch(48.8% 0.243 264.376));
     --color-kumo-line: oklch(14.5% 0 0 / 0.1);
     --color-kumo-hairline: var(--color-kumo-neutral-150, oklch(93.5% 0 0));
@@ -572,7 +576,7 @@
     );
     --color-kumo-warning: var(--color-yellow-400, oklch(85.2% 0.199 91.936));
     --color-kumo-danger-tint: var(--color-red-900, oklch(39.6% 0.141 25.723));
-    --color-kumo-danger: var(--color-red-400, oklch(70.4% 0.191 22.216));
+    --color-kumo-danger: var(--color-red-600, oklch(57.7% 0.245 27.325));
     --color-kumo-success-tint: var(
       --color-emerald-900,
       oklch(37.8% 0.077 168.94)

--- a/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/timeseries/+page.md
@@ -12,9 +12,8 @@ sourceFile: "components/chart"
   import PropsTable from '$lib/docs/PropsTable.svelte';
 </script>
 
-
 The timeseries chart is a specialized chart for displaying time-based data.
-  Each data point is a tuple of <code>[timestamp_in_ms, value]</code>.
+Each data point is a tuple of <code>[timestamp_in_ms, value]</code>.
 
 <ComponentSection>
 
@@ -30,9 +29,9 @@ A simple line chart displaying multiple data series over time.
 
 ## Custom X-Axis Label Format
 
-  Use the <code>xAxisTickLabelFormat</code> prop to control how x-axis tick
-  labels are rendered. The formatter receives the raw timestamp in milliseconds
-  and returns a display string, overriding ECharts' built-in time formatting.
+Use the <code>xAxisTickLabelFormat</code> prop to control how x-axis tick
+labels are rendered. The formatter receives the raw timestamp in milliseconds
+and returns a display string, overriding ECharts' built-in time formatting.
 
 <ComponentExample demo="CustomAxisLabelFormatDemo" />
 
@@ -42,10 +41,10 @@ A simple line chart displaying multiple data series over time.
 
 ## Gradient Fill
 
-  Set <code>gradient</code> to <code>true</code> to render a vertical gradient
-  fill beneath each line series. The fill fades from the series color at the top
-  to transparent at the bottom, giving the chart a polished area-chart look
-  without losing the clarity of individual lines.
+Set <code>gradient</code> to <code>true</code> to render a vertical gradient
+fill beneath each line series. The fill fades from the series color at the top
+to transparent at the bottom, giving the chart a polished area-chart look
+without losing the clarity of individual lines.
 
 <ComponentExample demo="GradientLineChartDemo" />
 
@@ -55,8 +54,8 @@ A simple line chart displaying multiple data series over time.
 
 ## Incomplete Data
 
-  Use the <code>incomplete</code> prop to indicate regions where data may be
-  incomplete or still being collected.
+Use the <code>incomplete</code> prop to indicate regions where data may be
+incomplete or still being collected.
 
 <ComponentExample demo="IncompleteDataChartDemo" />
 
@@ -66,8 +65,8 @@ A simple line chart displaying multiple data series over time.
 
 ## Time Range Selection
 
-  Enable time range selection by providing the <code>onTimeRangeChange</code>
-  callback. Users can click and drag on the chart to select a time range.
+Enable time range selection by providing the <code>onTimeRangeChange</code>
+callback. Users can click and drag on the chart to select a time range.
 
 <ComponentExample demo="TimeRangeSelectionChartDemo" />
 
@@ -75,10 +74,33 @@ A simple line chart displaying multiple data series over time.
 
 <ComponentSection>
 
+## Legend Highlight
+
+Hovering a legend item highlights the corresponding series on the chart and
+fades the others. Use `onpointerenter` and `onpointerleave` on `ChartLegend`
+items together with `dispatchAction` on the chart ref.
+
+<ComponentExample demo="LegendHighlightDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Legend Click
+
+Clicking a `ChartLegend` item isolates that series, showing only it and hiding
+the rest. Clicking the already-isolated series restores them all.
+
+<ComponentExample demo="LegendOnClickDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
 ## Tooltip Cursor Tracking
 
-  Use <code>tooltipFollowCursor</code> to choose whether the tooltip follows both cursor axes or only tracks the x position.
-  Set <code>tooltipMode="single"</code> when dense charts should show only the series nearest to the pointer.
+Use <code>tooltipFollowCursor</code> to choose whether the tooltip follows both cursor axes or only tracks the x position.
+Set <code>tooltipMode="single"</code> when dense charts should show only the series nearest to the pointer.
 
 <ComponentExample demo="TooltipFollowCursorDemo" />
 
@@ -88,7 +110,7 @@ A simple line chart displaying multiple data series over time.
 
 ## Tooltip Boundary
 
-  Set <code>tooltipBoundary</code> to keep the native tooltip within the chart container instead of letting it overflow the visual frame.
+Set <code>tooltipBoundary</code> to keep the native tooltip within the chart container instead of letting it overflow the visual frame.
 
 <ComponentExample demo="TooltipBoundaryDemo" />
 
@@ -98,8 +120,8 @@ A simple line chart displaying multiple data series over time.
 
 ## Bar Chart
 
-  Set <code>type="bar"</code> to render series as stacked bars instead of lines.
-  All other props — axes, tooltips, colors — work identically.
+Set <code>type="bar"</code> to render series as stacked bars instead of lines.
+All other props — axes, tooltips, colors — work identically.
 
 <ComponentExample demo="BarChartDemo" />
 
@@ -109,9 +131,9 @@ A simple line chart displaying multiple data series over time.
 
 ## Loading State
 
-  Set <code>loading</code> to <code>true</code> to display an animated sine-wave
-  skeleton while data is being fetched. The chart canvas is hidden until loading
-  completes; swap back to <code>loading=false</code> to reveal the chart.
+Set <code>loading</code> to <code>true</code> to display an animated sine-wave
+skeleton while data is being fetched. The chart canvas is hidden until loading
+completes; swap back to <code>loading=false</code> to reveal the chart.
 
 <ComponentExample demo="LoadingChartDemo" />
 

--- a/packages/kumo-svelte/src/routes/components/dialog/+page.md
+++ b/packages/kumo-svelte/src/routes/components/dialog/+page.md
@@ -150,6 +150,12 @@ For confirmation dialogs that should not be dismissed by clicking outside, use
 
 <ComponentExample demo="DialogWithActionsDemo" />
 
+### Custom Max Width
+
+Dialog max width can be customized with utility classes like `max-w-lg`.
+
+<ComponentExample demo="DialogMaxWidthDemo" />
+
 ### With Select
 
 

--- a/packages/kumo-svelte/src/routes/components/radio/+page.md
+++ b/packages/kumo-svelte/src/routes/components/radio/+page.md
@@ -157,6 +157,13 @@ Use `Radio.Legend` with `class="sr-only"` to keep the legend accessible to
 
 <ComponentExample demo="RadioLegendCustomDemo" />
 
+### Typed Values
+
+Use generic values when radio options are numbers, enums, or other non-string
+  values.
+
+<ComponentExample demo="RadioTypedValueDemo" />
+
 </ComponentSection>
 
 <!-- API Reference -->

--- a/packages/kumo-svelte/src/routes/components/toolbar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/toolbar/+page.md
@@ -1,0 +1,133 @@
+---
+title: "Toolbar"
+description: "Compose explicit toolbar controls into one clean grouped card."
+sourceFile: "components/toolbar"
+---
+
+<script>
+  import ComponentExample from '$lib/docs/ComponentExample.svelte';
+  import ComponentSection from '$lib/docs/ComponentSection.svelte';
+  import PropsTable from '$lib/docs/PropsTable.svelte';
+</script>
+
+<ComponentSection>
+  <ComponentExample demo="ToolbarDemo" />
+</ComponentSection>
+
+<ComponentSection>
+
+## Installation
+
+### Barrel
+
+```typescript
+import { Toolbar } from "kumo-svelte";
+```
+
+### Granular
+
+```typescript
+import { Toolbar } from "kumo-svelte/components/toolbar";
+```
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Usage
+
+Use `Toolbar` when multiple controls should read as one compact toolbar or
+filter card. Use `Toolbar.Button`, `Toolbar.Input`, and `Toolbar.InputGroup` to
+opt supported controls into toolbar sizing, button styling, borders, and radii.
+
+```svelte
+<script lang="ts">
+  import { FunnelSimple, MagnifyingGlass } from 'phosphor-svelte';
+  import { InputGroup, Toolbar } from 'kumo-svelte';
+</script>
+
+<Toolbar>
+  <Toolbar.InputGroup aria-label="Search DNS records">
+    <InputGroup.Addon>
+      <MagnifyingGlass />
+    </InputGroup.Addon>
+    <InputGroup.Input placeholder="Search DNS records" />
+  </Toolbar.InputGroup>
+  <Toolbar.Button icon={FunnelSimple} aria-label="Filter" />
+</Toolbar>
+```
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Behavior
+
+- `Toolbar.Button`, `Toolbar.Input`, and `Toolbar.InputGroup` inherit the toolbar `size`.
+- `Toolbar.Button` always renders with quiet toolbar button styling.
+- `Toolbar.InputGroup` passes props directly to `InputGroup` with the toolbar `size`.
+- Adjacent toolbar items share borders and only the outer corners are rounded.
+- Direct `Toolbar` children that are not one of the supported toolbar item components do not receive toolbar overrides.
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Examples
+
+### Input Shorthand
+
+Use `Toolbar.Input` for simple text inputs that do not need addons.
+
+<ComponentExample demo="ToolbarMixedControlsDemo" />
+
+### Input Group
+
+Use `Toolbar.InputGroup` when one toolbar item needs its own inline addon or
+suffix.
+
+<ComponentExample demo="ToolbarInputGroupDemo" />
+
+### Sizes
+
+The `size` prop supports `xs`, `sm`, `base`, and `lg`. Every supported toolbar
+item is locked to the same size.
+
+<ComponentExample demo="ToolbarSizesDemo" />
+
+### Button Actions
+
+Toolbar buttons use quiet styling so grouped actions remain visually quiet and
+consistent.
+
+<ComponentExample demo="ToolbarActionsDemo" />
+
+### Accessible Labels
+
+Use `aria-label` for compact toolbar controls that do not have visible labels.
+
+<ComponentExample demo="ToolbarLabelsDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## API Reference
+
+### Toolbar
+
+<PropsTable component="Toolbar" />
+
+### Toolbar.Button
+
+<PropsTable component="Toolbar.Button" />
+
+### Toolbar.Input
+
+<PropsTable component="Toolbar.Input" />
+
+### Toolbar.InputGroup
+
+<PropsTable component="Toolbar.InputGroup" />
+
+</ComponentSection>


### PR DESCRIPTION
## Summary

Ports the component and docs changes from upstream @cloudflare/kumo@2.6.0 into kumo-svelte.

- adds the new Toolbar compound component, docs page, examples, props metadata, tests, exports, and generated registry entries
- ports chart legend pointer/click interactions plus TimeseriesChart enableLegendSelection and docs demos
- updates Button emphasis styling, Kumo theme tokens, Sidebar overflow/spacing fixes, and Radio generic value typing
- adds a minor changeset for the public API additions

## Validation

- [x] Tests included/updated
- [x] pnpm -F kumo-svelte check
- [x] pnpm -F kumo-svelte test
- [x] pnpm -F kumo-svelte build

Upstream release: https://github.com/cloudflare/kumo/releases/tag/%40cloudflare%2Fkumo%402.6.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Toolbar component with keyboard navigation and subcomponents (Button, Input, InputGroup).
  * Radio component now supports typed values beyond strings.
  * Chart legend interactions: pointer events and selection filtering support.
  * Timeseries chart legend selection enables filtering series in tooltips.

* **Bug Fixes**
  * Improved dialog responsive max-width behavior.
  * Enhanced sidebar horizontal overflow handling.
  * Button emphasis styling refinements.

* **Documentation**
  * Added guides for custom dialog widths and typed radio values.
  * Complete Toolbar component documentation with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->