### PR TITLE
Align Kumo 2.6 docs metadata

### DIFF
--- a/.changeset/kumo-2-6-doc-metadata.md
+++ b/.changeset/kumo-2-6-doc-metadata.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Align Kumo 2.6 prop documentation metadata for chart, radio, and toolbar APIs.

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -3636,7 +3636,7 @@
             "value": {
               "type": "Value",
               "optional": true,
-              "description": "Controlled value."
+              "description": "Controlled value. Parameterized by the radio value type Value, which defaults to string."
             },
             "disabled": {
               "type": "boolean",
@@ -3666,7 +3666,7 @@
             "defaultValue": {
               "type": "Value",
               "optional": true,
-              "description": "Initial uncontrolled value."
+              "description": "Initial uncontrolled value. Parameterized by the radio value type Value, which defaults to string."
             },
             "required": {
               "type": "boolean",
@@ -3676,7 +3676,7 @@
             "onValueChange": {
               "type": "(value: Value, eventDetails?: unknown) => void",
               "optional": true,
-              "description": "Called when the value changes."
+              "description": "Called when the value changes. The second argument carries native event details about the interaction."
             }
           }
         },
@@ -3733,7 +3733,7 @@
               "type": "Value",
               "optional": false,
               "required": true,
-              "description": "Controlled value."
+              "description": "Item value. Parameterized by the radio value type Value to match the enclosing Radio.Group value type."
             }
           }
         },
@@ -5212,7 +5212,7 @@
             "lg"
           ],
           "default": "base",
-          "description": "Locks every supported toolbar item to this size."
+          "description": "Locks every toolbar item to this size."
         },
         "class": {
           "type": "string",

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio__Group.ts
@@ -43,7 +43,7 @@ const rows: PropRow[] = [
     "prop": "value",
     "type": "Value",
     "required": false,
-    "description": "Controlled value."
+    "description": "Controlled value. Parameterized by the radio value type Value, which defaults to string."
   },
   {
     "prop": "disabled",
@@ -74,7 +74,7 @@ const rows: PropRow[] = [
     "prop": "defaultValue",
     "type": "Value",
     "required": false,
-    "description": "Initial uncontrolled value."
+    "description": "Initial uncontrolled value. Parameterized by the radio value type Value, which defaults to string."
   },
   {
     "prop": "required",
@@ -86,7 +86,7 @@ const rows: PropRow[] = [
     "prop": "onValueChange",
     "type": "(value: Value, eventDetails?: unknown) => void",
     "required": false,
-    "description": "Called when the value changes."
+    "description": "Called when the value changes. The second argument carries native event details about the interaction."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Radio__Item.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Radio__Item.ts
@@ -49,7 +49,7 @@ const rows: PropRow[] = [
     "prop": "value",
     "type": "Value",
     "required": true,
-    "description": "Controlled value."
+    "description": "Item value. Parameterized by the radio value type Value to match the enclosing Radio.Group value type."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/TimeseriesChart.ts
@@ -91,7 +91,7 @@ const rows: PropRow[] = [
     type: "'clipping-ancestors' | Element | Element[]",
     required: false,
     description:
-      'Constrains tooltip placement to the chart container when provided.'
+      'Constrains the tooltip to stay within clipping ancestors by default, or within a specific Element or Element[] when provided.'
   },
   {
     prop: 'tooltipFollowCursor',
@@ -99,7 +99,7 @@ const rows: PropRow[] = [
     required: false,
     default: '"both"',
     description:
-      'Controls whether the tooltip follows both cursor axes or locks to the chart top while following x.'
+      'Controls which axis the tooltip follows: both axes near the pointer, or the x-axis only with a fixed vertical position to avoid jitter.'
   },
   {
     prop: 'incomplete',
@@ -114,7 +114,7 @@ const rows: PropRow[] = [
     required: false,
     default: 'false',
     description:
-      'Adds a hidden ECharts legend so custom controls can drive series visibility through legendSelect, legendUnSelect, and legendToggleSelect actions.'
+      'Adds a hidden ECharts legend so custom controls can drive series visibility through legendSelect, legendUnSelect, and legendToggleSelect actions. Toggled-off series are excluded from the tooltip and consumers must register ECharts LegendComponent.'
   },
   {
     prop: 'height',
@@ -156,14 +156,14 @@ const rows: PropRow[] = [
     type: 'string',
     required: false,
     description:
-      'Accessible description passed to ECharts aria.label.description.'
+      'Accessible description passed to ECharts aria.label.description and announced when the chart receives focus.'
   },
   {
     prop: 'optionUpdateBehavior',
     type: 'SetOptionOpts',
     required: false,
     description:
-      'Additional options passed as the second argument to chart.setOption().'
+      'Additional options passed as the second argument to chart.setOption(). Defaults to { notMerge: false, lazyUpdate: true }.'
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar.ts
@@ -9,7 +9,7 @@ export default [
     prop: 'size',
     type: '"xs" | "sm" | "base" | "lg"',
     default: '"base"',
-    description: 'Locks every supported toolbar item to this size.'
+    description: 'Locks every toolbar item to this size.'
   },
   {
     prop: 'class',


### PR DESCRIPTION
## Summary

Follow-up to the Kumo 2.6 parity port: align the prop documentation metadata and generated registry descriptions for the changed chart, radio, and toolbar APIs.

- expands TimeseriesChart docs metadata for tooltip boundary/follow behavior, legend selection, aria description, and option update behavior
- expands Radio.Group and Radio.Item typed value descriptions
- matches the upstream Toolbar size wording
- adds a patch changeset for the docs metadata update

## Validation

- [x] Additional testing not necessary because: this only changes docs metadata and generated registry descriptions; svelte-check validates the typed metadata files.
- [x] pnpm -F kumo-svelte codegen:registry
- [x] pnpm -F kumo-svelte check