### PR TITLE
Fix toolbar active highlight

### DIFF
--- a/.changeset/blue-toolbar-focus.md
+++ b/.changeset/blue-toolbar-focus.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Fix toolbar input-group active highlights and align the homepage toolbar demo actions.

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "components": {
     "Autocomplete": {
       "name": "Autocomplete",
@@ -5224,7 +5224,6 @@
         "bg-kumo-control",
         "border-kumo-line",
         "ring-kumo-brand",
-        "ring-kumo-focus",
         "ring-kumo-line"
       ],
       "subComponents": {

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -1,6 +1,6 @@
 # Kumo Svelte Component Registry
 
-Version: 0.2.0
+Version: 0.3.0
 
 ## Autocomplete
 

--- a/packages/kumo-svelte/src/lib/components/input-group/InputGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/input-group/InputGroup.svelte
@@ -28,6 +28,7 @@
     error?: FieldError;
     required?: boolean;
     id?: string;
+    wrapLabel?: boolean;
     [key: string]: unknown;
   }
 
@@ -43,6 +44,7 @@
     error,
     required,
     id,
+    wrapLabel = true,
     ...rest
   }: Props = $props();
 
@@ -50,6 +52,7 @@
   const inputId = $derived(id ?? generatedId);
   const descriptionId = $derived(description ? `${inputId}-description` : undefined);
   const errorId = $derived(error ? `${inputId}-error` : undefined);
+  const ariaLabel = $derived(typeof rest['aria-label'] === 'string' ? rest['aria-label'] : undefined);
   const showError = $derived(typeof error === 'string' ? error : error?.message);
   const hasField = $derived(Boolean(label || description || showError));
 
@@ -68,6 +71,9 @@
     },
     get inputId() {
       return inputId;
+    },
+    get ariaLabel() {
+      return ariaLabel;
     },
     get describedBy() {
       return [descriptionId, errorId].filter(Boolean).join(' ') || undefined;
@@ -134,7 +140,7 @@
     {/if}
   </div>
 {:else}
-  {#if focusMode === 'container'}
+  {#if focusMode === 'container' && wrapLabel}
     <label class="!mb-0 block w-full">
       {@render control()}
     </label>

--- a/packages/kumo-svelte/src/lib/components/input-group/InputGroupInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/input-group/InputGroupInput.svelte
@@ -8,6 +8,7 @@
     onValueChange?: (value: string) => void;
     oninput?: (event: Event) => void;
     id?: string;
+    'aria-label'?: string;
     disabled?: boolean;
     [key: string]: unknown;
   }
@@ -18,6 +19,7 @@
     onValueChange,
     oninput,
     id,
+    'aria-label': ariaLabel,
     disabled,
     ...rest
   }: Props = $props();
@@ -27,6 +29,7 @@
   const tokens = $derived(INPUT_GROUP_SIZE[size]);
   const isIndividual = $derived(context?.focusMode === 'individual');
   const inputId = $derived(id ?? context?.inputId);
+  const effectiveAriaLabel = $derived(ariaLabel ?? context?.ariaLabel);
   const isDisabled = $derived(disabled ?? context?.disabled);
   const hasError = $derived(Boolean(context?.error));
   const describedBy = $derived(context?.describedBy);
@@ -41,6 +44,7 @@
 <input
   bind:value
   id={inputId}
+  aria-label={effectiveAriaLabel}
   disabled={isDisabled}
   aria-invalid={hasError || undefined}
   aria-describedby={describedBy}

--- a/packages/kumo-svelte/src/lib/components/input-group/context.ts
+++ b/packages/kumo-svelte/src/lib/components/input-group/context.ts
@@ -94,6 +94,7 @@ export interface InputGroupContextValue {
   disabled: boolean;
   error?: FieldError;
   inputId: string;
+  ariaLabel?: string;
   describedBy?: string;
 }
 

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInputGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarInputGroup.svelte
@@ -15,6 +15,6 @@
   const size = $derived(toolbar?.size ?? 'base');
 </script>
 
-<InputGroup class={toolbarControlClassName(className)} {size} {...rest}>
+<InputGroup {...rest} class={toolbarControlClassName(className)} {size} wrapLabel={false}>
   {@render children?.()}
 </InputGroup>

--- a/packages/kumo-svelte/src/lib/components/toolbar/context.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/context.ts
@@ -47,8 +47,8 @@ export function toolbarControlClassName(className?: string) {
     'relative min-w-0 border-0 bg-transparent shadow-none ring-0 focus:z-2 focus-within:z-2 focus-visible:z-2',
     'rounded-none first:rounded-l-lg last:rounded-r-lg only:rounded-lg',
     'not-first:border-l not-first:border-kumo-line',
-    'focus:ring-kumo-focus/50 focus:ring-[1.5px] focus-visible:ring-2 focus-visible:ring-kumo-brand',
-    'focus-within:ring-kumo-focus/50 focus-within:ring-[1.5px]',
+    'focus:ring-2 focus:ring-kumo-brand focus-visible:ring-2 focus-visible:ring-kumo-brand',
+    'focus-within:ring-2 focus-within:ring-kumo-brand',
     className
   );
 }

--- a/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
@@ -44,7 +44,8 @@ describe('Toolbar', () => {
     expect(toolbarGroup.className).toContain('rounded-none');
     expect(toolbarGroup.className).toContain('first:rounded-l-lg');
     expect(toolbarGroup.className).toContain('last:rounded-r-lg');
-    expect(toolbarGroup.className).toContain('focus-within:ring-kumo-focus/50');
+    expect(toolbarGroup.className).toContain('focus-within:ring-kumo-brand');
+    expect(toolbarGroup.parentElement?.getAttribute('role')).toBe('toolbar');
     expect(plainGroup.className).not.toContain('rounded-none');
   });
 

--- a/packages/kumo-svelte/src/lib/docs/HomeGrid.svelte
+++ b/packages/kumo-svelte/src/lib/docs/HomeGrid.svelte
@@ -141,16 +141,15 @@
                     <div
                         class="flex w-full items-center justify-center p-8 tracking-normal leading-normal"
                     >
-                        <Toolbar class="w-full max-w-md">
-                            <Toolbar.InputGroup
+                        <Toolbar class="w-[260px]">
+                            <Toolbar.Input
                                 aria-label="Search DNS records"
-                                class="flex-1"
-                            >
-                                <InputGroupAddon>
-                                    <MagnifyingGlass class="size-4" />
-                                </InputGroupAddon>
-                                <InputGroupInput placeholder="Search" />
-                            </Toolbar.InputGroup>
+                                placeholder="Search..."
+                            />
+                            <Toolbar.Button
+                                icon={MagnifyingGlass}
+                                aria-label="Search"
+                            />
                             <Toolbar.Button icon={Plus} aria-label="Add" />
                         </Toolbar>
                     </div>


### PR DESCRIPTION
## Summary
- make toolbar input groups render as direct toolbar controls so grouped rounding applies correctly
- switch toolbar active/focus highlights to the blue brand ring
- align the homepage toolbar demo with the upstream two-action toolbar and add the missing search button
- add a patch changeset and refresh generated component registry metadata

---

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

## Validation
- pnpm -F kumo-svelte test
- CI=true pnpm -F kumo-svelte check
- CI=true pnpm -F kumo-svelte build
- rendered-page DOM check for homepage toolbar actions and toolbar blue grouped focus classes