### PR TITLE
Fix toolbar input group double focus

### DIFF
--- a/.changeset/quiet-toolbar-input-group-outline.md
+++ b/.changeset/quiet-toolbar-input-group-outline.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Remove the duplicate InputGroup outline from toolbar input group focus states.

--- a/packages/kumo-svelte/src/lib/styles.css
+++ b/packages/kumo-svelte/src/lib/styles.css
@@ -1095,6 +1095,10 @@ pre.shiki {
   outline: solid 1px var(--color-kumo-focus);
 }
 
+[role="toolbar"] > [data-slot="input-group"][data-focus-mode="container"]:has(:focus-visible) {
+  outline: none;
+}
+
 /* InputGroup hybrid mode uses the same 1px active outline as individual controls. */
 [data-slot="input-group-container-zone"]:has(:focus-visible) {
   outline: solid 1px var(--color-kumo-focus);


### PR DESCRIPTION
## Summary
- suppress the legacy InputGroup focus outline only when an input group is rendered directly inside a toolbar
- keep the toolbar blue active ring as the single focus highlight for the docs toolbar examples
- add a patch changeset

---

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->

## Validation
- pnpm -F kumo-svelte test
- CI=true pnpm -F kumo-svelte check
- CI=true pnpm -F kumo-svelte build
- rendered docs route check for both toolbar input-group examples, blue ring classes, and compiled toolbar outline override