### PR TITLE
Port latest Kumo UI updates

### DIFF
--- a/.changeset/blue-red-button-rings.md
+++ b/.changeset/blue-red-button-rings.md
@@ -1,0 +1,5 @@
+---
+'kumo-svelte': patch
+---
+
+Keep primary and destructive button active/focus rings matched to their variant color.

--- a/.changeset/fix-dialog-size-width.md
+++ b/.changeset/fix-dialog-size-width.md
@@ -1,0 +1,5 @@
+---
+'kumo-svelte': patch
+---
+
+Fix Dialog `size` prop to set a fixed width instead of only a minimum width. Previously, dialog content could stretch the dialog beyond its intended size.

--- a/.changeset/spicy-maps-glow.md
+++ b/.changeset/spicy-maps-glow.md
@@ -1,0 +1,11 @@
+---
+'kumo-svelte': minor
+---
+
+feat(chart): add `BubbleMap` chart component
+
+New `BubbleMap` component renders proportional bubbles over a registered
+geographic map using ECharts' scatter series. Includes value-based radius
+scaling, a `mapColors` palette addition to `ChartPalette`, and supporting
+types. Also extracts `escapeHtml` / `defaultValueFormat` tooltip helpers into a
+shared `tooltip-utils` module reused by `SankeyChart`.

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -2054,7 +2054,7 @@
             "xl"
           ],
           "default": "base",
-          "description": "Dialog width preset."
+          "description": "Fixed dialog width preset: sm (288px), base (384px), lg (512px), or xl (768px)."
         },
         "style": {
           "type": "string",

--- a/packages/kumo-svelte/src/lib/components/button/Button.svelte
+++ b/packages/kumo-svelte/src/lib/components/button/Button.svelte
@@ -46,7 +46,7 @@
     variant: {
       primary: {
         classes:
-          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
+          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
         description: 'High-emphasis button for primary actions'
       },
       secondary: {
@@ -60,7 +60,7 @@
       },
       destructive: {
         classes:
-          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
+          'relative overflow-hidden bg-(--kumo-button-emphasis-bg) !text-white ring ring-(--kumo-button-emphasis-ring) focus:ring-(--kumo-button-emphasis-ring) focus-visible:ring-(--kumo-button-emphasis-ring) active:ring-(--kumo-button-emphasis-ring) disabled:opacity-50',
         description: 'Danger button for destructive actions like delete'
       },
       'secondary-destructive': {

--- a/packages/kumo-svelte/src/lib/components/button/button.test.ts
+++ b/packages/kumo-svelte/src/lib/components/button/button.test.ts
@@ -36,4 +36,22 @@ describe('Button', () => {
     expect((button as HTMLButtonElement).disabled).toBe(true);
     expect(button.getAttribute('aria-busy')).toBe('true');
   });
+
+  it('keeps emphasized variant rings color-matched when pressed or focused', () => {
+    for (const variant of ['primary', 'destructive'] as const) {
+      render(Button, {
+        variant,
+        'aria-label': variant
+      });
+
+      const className = screen.getByRole('button', { name: variant }).className;
+
+      expect(className).toContain('ring-(--kumo-button-emphasis-ring)');
+      expect(className).toContain('focus:ring-(--kumo-button-emphasis-ring)');
+      expect(className).toContain(
+        'focus-visible:ring-(--kumo-button-emphasis-ring)'
+      );
+      expect(className).toContain('active:ring-(--kumo-button-emphasis-ring)');
+    }
+  });
 });

--- a/packages/kumo-svelte/src/lib/components/chart/BubbleMap.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/BubbleMap.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  import type { EChartsType } from 'echarts/core';
+  import Chart, { type ChartEvents, type KumoChartOption } from './Chart.svelte';
+  import { ChartPalette } from './Color';
+  import { defaultValueFormat, escapeHtml } from './tooltip-utils';
+
+  export interface MapGeoJson {
+    type: 'FeatureCollection';
+    features: Array<{
+      type: 'Feature';
+      id?: string | number;
+      properties?: Record<string, unknown> | null;
+      geometry: unknown;
+    }>;
+  }
+
+  /** Accessor for a value on a data row: a key of `T`, or a function of the row. */
+  export type MapAccessor<T, V> = keyof T | ((row: T) => V);
+
+  function resolve<T, V>(row: T, accessor: MapAccessor<T, V>): V {
+    return typeof accessor === 'function' ? accessor(row) : (row[accessor] as V);
+  }
+
+  /** Per-datum style value: a constant, or a function of the row. */
+  export type MapStyle<T, V> = V | ((row: T) => V);
+
+  function resolveStyle<T, V>(row: T, style: MapStyle<T, V>): V {
+    return typeof style === 'function' ? (style as (row: T) => V)(row) : (style as V);
+  }
+
+  const MAX_ZOOM_FACTOR = 8;
+  const geoJsonMapNames = new WeakMap<MapGeoJson, string>();
+
+  function sanitizeMapName(name: string) {
+    return name.replace(/[^a-zA-Z0-9_-]/g, '-');
+  }
+
+  function hashString(value: string) {
+    let hash = 0;
+    for (let i = 0; i < value.length; i++) {
+      hash = Math.imul(31, hash) + value.charCodeAt(i);
+    }
+    return (hash >>> 0).toString(36);
+  }
+
+  function getMapName(geoJson: MapGeoJson, mapName?: string) {
+    if (mapName) return sanitizeMapName(mapName);
+
+    const existing = geoJsonMapNames.get(geoJson);
+    if (existing) return existing;
+
+    const generated = `kumo-map-${hashString(JSON.stringify(geoJson))}`;
+    geoJsonMapNames.set(geoJson, generated);
+    return generated;
+  }
+
+  function buildGeo({
+    mapName,
+    areaColor,
+    center,
+    zoom,
+    roam
+  }: {
+    mapName: string;
+    areaColor: string;
+    center?: [number, number];
+    zoom: number;
+    roam: boolean;
+  }) {
+    return {
+      map: mapName,
+      nameProperty: 'name',
+      roam,
+      ...(roam
+        ? {
+            scaleLimit: {
+              min: Math.min(1, zoom),
+              max: zoom * MAX_ZOOM_FACTOR
+            }
+          }
+        : {}),
+      center,
+      zoom,
+      aspectScale: 1,
+      silent: true,
+      layoutCenter: ['50%', '50%'],
+      layoutSize: '180%',
+      itemStyle: {
+        areaColor,
+        borderColor: areaColor,
+        borderWidth: 0.5
+      },
+      emphasis: { disabled: true }
+    };
+  }
+
+  export interface BubbleMapProps<T = Record<string, unknown>> {
+    echarts: any;
+    geoJson: MapGeoJson;
+    mapName?: string;
+    data: T[];
+    lng: MapAccessor<T, number>;
+    lat: MapAccessor<T, number>;
+    value: MapAccessor<T, number>;
+    name?: MapAccessor<T, string>;
+    minRadius?: number;
+    maxRadius?: number;
+    bubbleSize?: (value: number) => number;
+    bubbleColor?: MapStyle<T, string>;
+    bubbleBorderColor?: MapStyle<T, string>;
+    bubbleBorderWidth?: MapStyle<T, number>;
+    center?: [number, number];
+    zoom?: number;
+    roam?: boolean;
+    showTooltip?: boolean;
+    valueFormat?: (value: number) => string;
+    tooltipFormatter?: (row: T) => string;
+    onBubbleHover?: (row: T | undefined) => void;
+    onBubbleClick?: (row: T) => void;
+    height?: number;
+    class?: string;
+    isDarkMode?: boolean;
+    chartRef?: EChartsType | null;
+  }
+
+  interface BubblePoint<T> {
+    name?: string;
+    value: [number, number, number];
+    symbolSize: number;
+    itemStyle: { color: string; borderColor: string; borderWidth: number };
+    datum: T;
+  }
+
+  let {
+    echarts,
+    geoJson,
+    mapName: mapNameProp,
+    data,
+    lng,
+    lat,
+    value,
+    name,
+    minRadius = 6,
+    maxRadius = 26,
+    bubbleSize,
+    bubbleColor,
+    bubbleBorderColor = 'transparent',
+    bubbleBorderWidth = 0,
+    center,
+    zoom = 1.25,
+    roam = true,
+    showTooltip = true,
+    valueFormat = defaultValueFormat,
+    tooltipFormatter,
+    onBubbleHover,
+    onBubbleClick,
+    height = 400,
+    class: className,
+    isDarkMode,
+    chartRef = $bindable(null)
+  }: BubbleMapProps = $props();
+
+  const mapName = $derived(getMapName(geoJson, mapNameProp));
+
+  $effect.pre(() => {
+    // ECharts requires GeoJSON maps to be registered before setOption uses them.
+    echarts.registerMap(mapName, geoJson);
+  });
+
+  const options = $derived.by(() => {
+    const palette = ChartPalette.mapColors(isDarkMode);
+    const values = data.map((row) => resolve(row, value));
+    const vmin = values.length ? Math.min(...values) : 0;
+    const vmax = values.length ? Math.max(...values) : 1;
+
+    const radiusFor = (datumValue: number) => {
+      if (bubbleSize) return bubbleSize(datumValue);
+      if (vmax <= vmin) return maxRadius;
+      const ratio = Math.sqrt((datumValue - vmin) / (vmax - vmin));
+      return minRadius + ratio * (maxRadius - minRadius);
+    };
+
+    const points: BubblePoint<Record<string, unknown>>[] = data.map((row) => {
+      const datumValue = resolve(row, value);
+      return {
+        name: name ? resolve(row, name) : undefined,
+        value: [resolve(row, lng), resolve(row, lat), datumValue],
+        symbolSize: radiusFor(datumValue),
+        itemStyle: {
+          color: bubbleColor ? resolveStyle(row, bubbleColor) : palette.bubble,
+          borderColor: resolveStyle(row, bubbleBorderColor),
+          borderWidth: resolveStyle(row, bubbleBorderWidth)
+        },
+        datum: row
+      };
+    });
+
+    return {
+      backgroundColor: 'transparent',
+      animation: true,
+      animationDuration: 500,
+      geo: buildGeo({ mapName, areaColor: palette.area, center, zoom, roam }),
+      tooltip: showTooltip
+        ? {
+            trigger: 'item',
+            triggerOn: 'mousemove',
+            backgroundColor: 'var(--color-kumo-base)',
+            borderColor: 'var(--color-kumo-line)',
+            borderWidth: 1,
+            padding: 8,
+            textStyle: {
+              color: 'var(--text-color-kumo-default)',
+              fontSize: 13
+            },
+            extraCssText: 'border-radius: 0.5rem;',
+            dangerousHtmlFormatter: (params: unknown) => {
+              const param = params as { name?: string; value?: number[]; data?: { datum?: Record<string, unknown> } };
+              const row = param.data?.datum;
+              if (tooltipFormatter && row !== undefined) return tooltipFormatter(row);
+
+              const tooltipValue = param.value?.[2];
+              const nameStr = param.name ? `<strong>${escapeHtml(param.name)}</strong>` : '';
+              const valueStr =
+                tooltipValue !== undefined
+                  ? `<span style="color:var(--text-color-kumo-subtle)">${escapeHtml(valueFormat(tooltipValue))}</span>`
+                  : '';
+              return `<div style="display:flex;flex-direction:column;gap:2px;">${nameStr}${valueStr}</div>`;
+            }
+          }
+        : undefined,
+      series: [
+        {
+          type: 'scatter',
+          coordinateSystem: 'geo',
+          data: points,
+          itemStyle: { opacity: 0.8 },
+          emphasis: { scale: 1.2, itemStyle: { opacity: 1 } },
+          z: 3
+        }
+      ]
+    } satisfies KumoChartOption;
+  });
+
+  const events = $derived<Partial<ChartEvents>>({
+    ...(onBubbleHover
+      ? {
+          mouseover: (params: any) => {
+            const datum = params.data?.datum;
+            if (datum !== undefined) onBubbleHover?.(datum);
+          },
+          mouseout: () => onBubbleHover?.(undefined),
+          globalout: () => onBubbleHover?.(undefined)
+        }
+      : {}),
+    ...(onBubbleClick
+      ? {
+          click: (params: any) => {
+            const datum = params.data?.datum;
+            if (datum !== undefined) onBubbleClick?.(datum);
+          }
+        }
+      : {})
+  });
+</script>
+
+<Chart {echarts} options={options} bind:chartRef {height} class={className} {isDarkMode} onEvents={events} />

--- a/packages/kumo-svelte/src/lib/components/chart/BubbleMap.test.ts
+++ b/packages/kumo-svelte/src/lib/components/chart/BubbleMap.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { render, waitFor } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BubbleMap, { type MapGeoJson } from './BubbleMap.svelte';
+
+const geoJson: MapGeoJson = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 'US',
+      properties: { name: 'United States' },
+      geometry: { type: 'Polygon', coordinates: [] }
+    }
+  ]
+};
+
+const data = [
+  { city: 'San Francisco', lat: 37.77, lon: -122.42, requests: 10 },
+  { city: 'London', lat: 51.5, lon: -0.12, requests: 20 }
+];
+
+function createMockChart() {
+  return {
+    setOption: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn()
+  };
+}
+
+function createMockEcharts(mockChart = createMockChart()) {
+  return {
+    init: vi.fn(() => mockChart),
+    registerMap: vi.fn()
+  };
+}
+
+beforeEach(() => {
+  class ResizeObserver {
+    observe = vi.fn();
+    disconnect = vi.fn();
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserver);
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      matches: false
+    }))
+  );
+});
+
+describe('BubbleMap', () => {
+  it('reuses the generated map name across remounts for the same GeoJSON', () => {
+    const mockEcharts = createMockEcharts();
+
+    const first = render(BubbleMap, {
+      echarts: mockEcharts,
+      geoJson,
+      data,
+      lng: 'lon',
+      lat: 'lat',
+      name: 'city',
+      value: 'requests'
+    });
+    first.unmount();
+
+    render(BubbleMap, {
+      echarts: mockEcharts,
+      geoJson,
+      data,
+      lng: 'lon',
+      lat: 'lat',
+      name: 'city',
+      value: 'requests'
+    });
+
+    expect(mockEcharts.registerMap).toHaveBeenCalledTimes(2);
+    expect(mockEcharts.registerMap.mock.calls[0][0]).toBe(
+      mockEcharts.registerMap.mock.calls[1][0]
+    );
+  });
+
+  it('sanitizes custom map names before registering them', () => {
+    const mockEcharts = createMockEcharts();
+
+    render(BubbleMap, {
+      echarts: mockEcharts,
+      geoJson,
+      mapName: 'world:traffic/map',
+      data,
+      lng: 'lon',
+      lat: 'lat',
+      name: 'city',
+      value: 'requests'
+    });
+
+    expect(mockEcharts.registerMap).toHaveBeenCalledWith(
+      'world-traffic-map',
+      geoJson
+    );
+  });
+
+  it('uses bubbleSize when provided', async () => {
+    const mockChart = createMockChart();
+    const mockEcharts = createMockEcharts(mockChart);
+
+    render(BubbleMap, {
+      echarts: mockEcharts,
+      geoJson,
+      data,
+      lng: 'lon',
+      lat: 'lat',
+      name: 'city',
+      value: 'requests',
+      bubbleSize: (value: number) => value / 2
+    });
+
+    await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+    const options = mockChart.setOption.mock.calls[0][0];
+
+    expect(options.series[0].data[0].symbolSize).toBe(5);
+    expect(options.series[0].data[1].symbolSize).toBe(10);
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/chart/Color.ts
+++ b/packages/kumo-svelte/src/lib/components/chart/Color.ts
@@ -34,7 +34,13 @@ enum ChartSemanticDarkColors {
   Skeleton = '#5C5C5C'
 }
 
-export type ChartSemanticColorName = 'Attention' | 'Warning' | 'Success' | 'Neutral' | 'Disabled' | 'Skeleton';
+export type ChartSemanticColorName =
+  | 'Attention'
+  | 'Warning'
+  | 'Success'
+  | 'Neutral'
+  | 'Disabled'
+  | 'Skeleton';
 
 const sequentialLight = {
   blues: ['#E1EAF4', '#8EBCF6', '#4290F0', '#0E58B4', '#03254F']
@@ -43,6 +49,20 @@ const sequentialLight = {
 const sequentialDark = {
   blues: ['#03254F', '#0E58B4', '#4290F0', '#A6BFDD', '#E1EAF4']
 };
+
+/** Colours for GeoJSON-based map charts. */
+export interface MapColors {
+  /** Fill for land regions. */
+  area: string;
+  /** Default bubble fill (the chart palette blue). */
+  bubble: string;
+}
+
+/** Neutral land fill per mode; bubbles use the shared categorical palette. */
+const mapAreaByMode = {
+  light: '#E5E7EB',
+  dark: '#2B2C31'
+} as const;
 
 export const CHART_LIGHT_COLORS = [
   ChartCategoricalLightColors.Blue,
@@ -63,16 +83,28 @@ export const CHART_DARK_COLORS = [
 ];
 
 export namespace ChartPalette {
-  export function semantic(name: ChartSemanticColorName, isDarkMode = false): string {
-    return isDarkMode ? ChartSemanticDarkColors[name] : ChartSemanticLightColors[name];
+  export function semantic(
+    name: ChartSemanticColorName,
+    isDarkMode = false
+  ): string {
+    return isDarkMode
+      ? ChartSemanticDarkColors[name]
+      : ChartSemanticLightColors[name];
   }
 
   export function categorical(index: number, isDarkMode = false): string {
-    return isDarkMode ? CHART_DARK_COLORS[index % CHART_DARK_COLORS.length] : CHART_LIGHT_COLORS[index % CHART_LIGHT_COLORS.length];
+    return isDarkMode
+      ? CHART_DARK_COLORS[index % CHART_DARK_COLORS.length]
+      : CHART_LIGHT_COLORS[index % CHART_LIGHT_COLORS.length];
   }
 
-  export function sequential(palette: keyof typeof sequentialLight, isDarkMode = false): string[] {
-    return isDarkMode ? [...sequentialDark[palette]] : [...sequentialLight[palette]];
+  export function sequential(
+    palette: keyof typeof sequentialLight,
+    isDarkMode = false
+  ): string[] {
+    return isDarkMode
+      ? [...sequentialDark[palette]]
+      : [...sequentialLight[palette]];
   }
 
   export function text(variant: 'primary' | 'secondary', isDarkMode = false) {
@@ -81,5 +113,15 @@ export namespace ChartPalette {
       dark: { primary: '#9CA3AF', secondary: '#6B7280' }
     };
     return isDarkMode ? colors.dark[variant] : colors.light[variant];
+  }
+
+  /** Returns colors for GeoJSON-based map charts. */
+  export function mapColors(isDarkMode = false): MapColors {
+    const mode = isDarkMode ? 'dark' : 'light';
+
+    return {
+      area: mapAreaByMode[mode],
+      bubble: categorical(0, isDarkMode)
+    };
   }
 }

--- a/packages/kumo-svelte/src/lib/components/chart/SankeyChart.svelte
+++ b/packages/kumo-svelte/src/lib/components/chart/SankeyChart.svelte
@@ -2,6 +2,7 @@
   import type { EChartsOption } from 'echarts';
   import Chart, { type ChartEvents } from './Chart.svelte';
   import { ChartPalette } from './Color';
+  import { defaultValueFormat, escapeHtml } from './tooltip-utils';
 
   export interface SankeyNodeData {
     id?: string;
@@ -57,7 +58,7 @@
     links,
     height = 400,
     showNodeValues,
-    formatValue = (value: number) => value.toLocaleString(),
+    formatValue = defaultValueFormat,
     tooltipFormatter,
     nodeWidth = 8,
     nodePadding = 10,
@@ -73,8 +74,6 @@
     onLinkClick
   }: Props = $props();
 
-  const escapeHtml = (str: string): string =>
-    str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   const escapeRichText = (str: string): string => str.replace(/[{}|]/g, (char) => `\\${char}`);
   const sanitizeColor = (color: string): string => (/^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(color) ? color : '#666');
 

--- a/packages/kumo-svelte/src/lib/components/chart/index.ts
+++ b/packages/kumo-svelte/src/lib/components/chart/index.ts
@@ -2,6 +2,17 @@ export { default as Chart } from './Chart.svelte';
 export { default as ChartLegend } from './ChartLegend.svelte';
 export { default as TimeseriesChart } from './TimeseriesChart.svelte';
 export { default as SankeyChart } from './SankeyChart.svelte';
+export { default as BubbleMap } from './BubbleMap.svelte';
 export { ChartPalette, CHART_DARK_COLORS, CHART_LIGHT_COLORS } from './Color';
-export type { ChartSemanticColorName } from './Color';
-export type { KumoChartOption, SafeTooltipOption, ChartEvents } from './Chart.svelte';
+export type { ChartSemanticColorName, MapColors } from './Color';
+export type {
+  KumoChartOption,
+  SafeTooltipOption,
+  ChartEvents
+} from './Chart.svelte';
+export type {
+  BubbleMapProps,
+  MapAccessor,
+  MapGeoJson,
+  MapStyle
+} from './BubbleMap.svelte';

--- a/packages/kumo-svelte/src/lib/components/chart/tooltip-utils.ts
+++ b/packages/kumo-svelte/src/lib/components/chart/tooltip-utils.ts
@@ -1,0 +1,10 @@
+export const defaultValueFormat = (value: number) => value.toLocaleString();
+
+/** Escape HTML special characters to prevent XSS in default tooltips. */
+export const escapeHtml = (str: string): string =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
@@ -6,20 +6,20 @@
   export const KUMO_DIALOG_VARIANTS = {
     size: {
       base: {
-        classes: 'sm:min-w-96',
-        description: 'Default dialog width'
+        classes: 'sm:w-96',
+        description: 'Default dialog width (384px)'
       },
       sm: {
-        classes: 'min-w-72',
-        description: 'Small dialog for simple confirmations'
+        classes: 'sm:w-72',
+        description: 'Small dialog for simple confirmations (288px)'
       },
       lg: {
-        classes: 'min-w-[32rem]',
-        description: 'Large dialog for complex content'
+        classes: 'sm:w-[32rem]',
+        description: 'Large dialog for complex content (512px)'
       },
       xl: {
-        classes: 'min-w-[48rem]',
-        description: 'Extra large dialog for detailed views'
+        classes: 'sm:w-[48rem]',
+        description: 'Extra large dialog for detailed views (768px)'
       }
     },
     role: {
@@ -136,7 +136,7 @@
 
   let contentClasses = $derived(
     cn(
-      'shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full sm:w-auto max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0',
+      'shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0',
       KUMO_DIALOG_VARIANTS.size[size].classes,
       className
     )

--- a/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import Dialog from './Dialog.svelte';
+
+describe('Dialog variants', () => {
+  it('uses fixed width classes for size variants', () => {
+    for (const [size, expectedClass] of [
+      ['sm', 'sm:w-72'],
+      ['base', 'sm:w-96'],
+      ['lg', 'sm:w-[32rem]'],
+      ['xl', 'sm:w-[48rem]']
+    ] as const) {
+      render(Dialog, {
+        open: true,
+        size,
+        title: `${size} dialog`
+      });
+
+      const className = screen.getByRole('dialog', {
+        name: `${size} dialog`
+      }).className;
+      expect(className).toContain(expectedClass);
+      expect(className).not.toContain('min-w');
+    }
+  });
+});

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/BubbleMapDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/BubbleMapDemo.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import * as echarts from 'echarts';
+  import { BubbleMap, ChartPalette, type MapGeoJson } from 'kumo-svelte';
+
+  const world: MapGeoJson = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        id: 'world',
+        properties: { name: 'World' },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-170, -55],
+              [170, -55],
+              [170, 75],
+              [-170, 75],
+              [-170, -55]
+            ]
+          ]
+        }
+      }
+    ]
+  };
+
+  const data = [
+    { city: 'San Francisco', lat: 37.77, lon: -122.42, requests: 128000 },
+    { city: 'London', lat: 51.5, lon: -0.12, requests: 96000 },
+    { city: 'Singapore', lat: 1.35, lon: 103.82, requests: 72000 },
+    { city: 'Sydney', lat: -33.86, lon: 151.21, requests: 48000 }
+  ];
+</script>
+
+<div class="w-full min-w-[280px] max-w-2xl">
+  <BubbleMap
+    {echarts}
+    geoJson={world}
+    mapName="demo-world"
+    {data}
+    lng="lon"
+    lat="lat"
+    name="city"
+    value="requests"
+    bubbleColor={ChartPalette.categorical(0)}
+    valueFormat={(value) => `${value.toLocaleString()} requests`}
+    height={320}
+  />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogSizesDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/DialogSizesDemo.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import { X } from 'phosphor-svelte';
+  import { Button, Dialog } from 'kumo-svelte';
+
+  const sizes = [
+    { size: 'sm', label: 'Small', width: '288px' },
+    { size: 'base', label: 'Base', width: '384px' },
+    { size: 'lg', label: 'Large', width: '512px' },
+    { size: 'xl', label: 'Extra Large', width: '768px' }
+  ] as const;
+
+  let openBySize = $state<Record<string, boolean>>({});
+</script>
+
+<div class="flex flex-wrap gap-2">
+  {#each sizes as { size, label, width } (size)}
+    <Dialog bind:open={openBySize[size]} size={size} class="p-8">
+      {#snippet trigger(props)}
+        <Button variant="secondary" {...props}>{label} ({width})</Button>
+      {/snippet}
+
+      <div class="mb-4 flex items-start justify-between gap-4">
+        <h2 class="text-2xl font-semibold">{label} Dialog</h2>
+        <Button variant="secondary" shape="square" aria-label="Close" onclick={() => (openBySize[size] = false)}>
+          <X />
+        </Button>
+      </div>
+      <p class="text-kumo-subtle">
+        This <code>size="{size}"</code> dialog should stay at {width} wide regardless of the content below.
+      </p>
+      <div class="mt-4 overflow-auto rounded-md border border-kumo-line">
+        <table class="w-max text-sm">
+          <thead class="bg-kumo-elevated text-left">
+            <tr>
+              <th class="px-3 py-2">Resource</th>
+              <th class="px-3 py-2">Region</th>
+              <th class="px-3 py-2">Status</th>
+              <th class="px-3 py-2">Latency</th>
+              <th class="px-3 py-2">Requests</th>
+              <th class="px-3 py-2">Last Deployed</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-kumo-hairline">
+            <tr>
+              <td class="px-3 py-2">api-gateway-prod</td>
+              <td class="px-3 py-2">us-east-1</td>
+              <td class="px-3 py-2 text-kumo-success">Healthy</td>
+              <td class="px-3 py-2">12ms</td>
+              <td class="px-3 py-2">1,234,567</td>
+              <td class="px-3 py-2">2026-06-23</td>
+            </tr>
+            <tr>
+              <td class="px-3 py-2">worker-analytics</td>
+              <td class="px-3 py-2">eu-west-1</td>
+              <td class="px-3 py-2 text-kumo-warning">Degraded</td>
+              <td class="px-3 py-2">89ms</td>
+              <td class="px-3 py-2">456,789</td>
+              <td class="px-3 py-2">2026-06-22</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </Dialog>
+  {/each}
+</div>

--- a/packages/kumo-svelte/src/lib/docs/nav.ts
+++ b/packages/kumo-svelte/src/lib/docs/nav.ts
@@ -65,6 +65,7 @@ export const chartItems: NavItem[] = [
   { label: 'Colors', href: '/charts/colors' },
   { label: 'Timeseries', href: '/charts/timeseries' },
   { label: 'Sankey', href: '/charts/sankey' },
+  { label: 'Maps', href: '/charts/maps' },
   { label: 'Custom Chart', href: '/charts/custom' }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/BubbleMap.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/BubbleMap.ts
@@ -1,0 +1,168 @@
+import type { PropRow } from '../prop-types';
+
+const rows: PropRow[] = [
+  {
+    prop: 'echarts',
+    type: 'any',
+    required: true,
+    description: 'The ECharts core instance imported by the consumer.'
+  },
+  {
+    prop: 'geoJson',
+    type: 'MapGeoJson',
+    required: true,
+    description: 'GeoJSON FeatureCollection for the map base.'
+  },
+  {
+    prop: 'mapName',
+    type: 'string',
+    required: false,
+    description:
+      'Stable ECharts map registry name. Invalid characters are replaced with dashes.'
+  },
+  {
+    prop: 'data',
+    type: 'T[]',
+    required: true,
+    description: 'Rows to plot as bubbles.'
+  },
+  {
+    prop: 'lng',
+    type: 'MapAccessor<T, number>',
+    required: true,
+    description: 'Longitude accessor: a row key or function.'
+  },
+  {
+    prop: 'lat',
+    type: 'MapAccessor<T, number>',
+    required: true,
+    description: 'Latitude accessor: a row key or function.'
+  },
+  {
+    prop: 'value',
+    type: 'MapAccessor<T, number>',
+    required: true,
+    description: 'Numeric value accessor used to size bubbles.'
+  },
+  {
+    prop: 'name',
+    type: 'MapAccessor<T, string>',
+    required: false,
+    description: 'Optional label accessor used by the default tooltip.'
+  },
+  {
+    prop: 'minRadius',
+    type: 'number',
+    required: false,
+    default: '6',
+    description: 'Smallest bubble radius in pixels.'
+  },
+  {
+    prop: 'maxRadius',
+    type: 'number',
+    required: false,
+    default: '26',
+    description: 'Largest bubble radius in pixels.'
+  },
+  {
+    prop: 'bubbleSize',
+    type: '(value: number) => number',
+    required: false,
+    description:
+      'Explicit bubble radius function. Overrides minRadius/maxRadius scaling.'
+  },
+  {
+    prop: 'bubbleColor',
+    type: 'MapStyle<T, string>',
+    required: false,
+    description: 'Bubble fill color as a constant or row function.'
+  },
+  {
+    prop: 'bubbleBorderColor',
+    type: 'MapStyle<T, string>',
+    required: false,
+    default: '"transparent"',
+    description: 'Bubble border color as a constant or row function.'
+  },
+  {
+    prop: 'bubbleBorderWidth',
+    type: 'MapStyle<T, number>',
+    required: false,
+    default: '0',
+    description: 'Bubble border width as a constant or row function.'
+  },
+  {
+    prop: 'center',
+    type: '[number, number]',
+    required: false,
+    description: 'Map center as [longitude, latitude]. Defaults to auto-fit.'
+  },
+  {
+    prop: 'zoom',
+    type: 'number',
+    required: false,
+    default: '1.25',
+    description: 'Zoom level as a multiple of the auto-fit scale.'
+  },
+  {
+    prop: 'roam',
+    type: 'boolean',
+    required: false,
+    default: 'true',
+    description: 'Enables drag-to-pan and scroll-to-zoom.'
+  },
+  {
+    prop: 'showTooltip',
+    type: 'boolean',
+    required: false,
+    default: 'true',
+    description: 'Whether to show the default map tooltip.'
+  },
+  {
+    prop: 'valueFormat',
+    type: '(value: number) => string',
+    required: false,
+    description: 'Formats values in the default tooltip.'
+  },
+  {
+    prop: 'tooltipFormatter',
+    type: '(row: T) => string',
+    required: false,
+    description:
+      'Custom HTML tooltip formatter. Escape user-provided strings before returning.'
+  },
+  {
+    prop: 'onBubbleHover',
+    type: '(row: T | undefined) => void',
+    required: false,
+    description: 'Callback fired as the pointer enters or leaves a bubble.'
+  },
+  {
+    prop: 'onBubbleClick',
+    type: '(row: T) => void',
+    required: false,
+    description: 'Callback fired when a bubble is clicked.'
+  },
+  {
+    prop: 'height',
+    type: 'number',
+    required: false,
+    default: '400',
+    description: 'Chart height in pixels.'
+  },
+  {
+    prop: 'class',
+    type: 'string',
+    required: false,
+    description: 'Additional classes merged onto the chart element.'
+  },
+  {
+    prop: 'isDarkMode',
+    type: 'boolean',
+    required: false,
+    description:
+      'When true, switches map and bubble palette choices for dark mode.'
+  }
+];
+
+export default rows;

--- a/packages/kumo-svelte/src/lib/docs/props-data/Dialog.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Dialog.ts
@@ -25,7 +25,7 @@ const rows: PropRow[] = [
     "type": "'sm' | 'base' | 'lg' | 'xl'",
     "required": false,
     "default": "\"base\"",
-    "description": "Dialog width preset."
+    "description": "Fixed dialog width preset: sm (288px), base (384px), lg (512px), or xl (768px)."
   },
   {
     "prop": "style",

--- a/packages/kumo-svelte/src/lib/index.ts
+++ b/packages/kumo-svelte/src/lib/index.ts
@@ -6,6 +6,7 @@ export { Breadcrumbs } from './components/breadcrumbs';
 export type { BreadcrumbsItem } from './components/breadcrumbs';
 export { Button, LinkButton, RefreshButton } from './components/button';
 export {
+  BubbleMap,
   Chart,
   ChartLegend,
   ChartPalette,
@@ -13,9 +14,14 @@ export {
   TimeseriesChart
 } from './components/chart';
 export type {
+  BubbleMapProps,
   ChartEvents,
   ChartSemanticColorName,
   KumoChartOption,
+  MapAccessor,
+  MapColors,
+  MapGeoJson,
+  MapStyle,
   SafeTooltipOption
 } from './components/chart';
 export {

--- a/packages/kumo-svelte/src/routes/charts/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/+page.md
@@ -26,7 +26,6 @@ headings:
   import ComponentSection from '$lib/docs/ComponentSection.svelte';
 </script>
 
-
 <ComponentSection>
 
 <p class="mb-4">
@@ -43,27 +42,37 @@ examples below show the minimum required imports for our use cases.
 </p>
 
 ```ts
-import * as echarts from "echarts/core";
-import { BarChart, LineChart, PieChart } from "echarts/charts";
+import * as echarts from 'echarts/core';
+import {
+  BarChart,
+  LineChart,
+  MapChart,
+  PieChart,
+  ScatterChart
+} from 'echarts/charts';
 import {
   AriaComponent,
   AxisPointerComponent,
   BrushComponent,
+  GeoComponent,
   GridComponent,
-  TooltipComponent,
-} from "echarts/components";
-import { CanvasRenderer } from "echarts/renderers";
+  TooltipComponent
+} from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
 
 echarts.use([
   BarChart,
   LineChart,
   PieChart,
+  MapChart,
+  ScatterChart,
   AxisPointerComponent,
   BrushComponent,
+  GeoComponent,
   GridComponent,
   TooltipComponent,
   CanvasRenderer,
-  AriaComponent,
+  AriaComponent
 ]);
 ```
 
@@ -82,11 +91,19 @@ echarts.use([
   />
 
   <ChartCard
+    title="Bubble Map"
+    description="Plot proportional bubbles over a GeoJSON map."
+    href="/charts/maps"
+    demo="BubbleMapDemo"
+  />
+
+  <ChartCard
     title="Custom Chart"
     description="Examples like pie charts."
     href="/charts/custom"
     demo="PieChartPreviewDemo"
   />
+
 </div>
 
 </ComponentSection>

--- a/packages/kumo-svelte/src/routes/charts/maps/+page.md
+++ b/packages/kumo-svelte/src/routes/charts/maps/+page.md
@@ -1,0 +1,51 @@
+---
+title: 'Bubble Map'
+description: 'A proportional bubble map component for plotting values over GeoJSON maps using ECharts.'
+sourceFile: 'components/chart'
+---
+
+<script>
+  import ComponentExample from '$lib/docs/ComponentExample.svelte';
+  import ComponentSection from '$lib/docs/ComponentSection.svelte';
+  import PropsTable from '$lib/docs/PropsTable.svelte';
+</script>
+
+<ComponentSection>
+
+<ComponentExample demo="BubbleMapDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Installation
+
+BubbleMap requires <code class="text-kumo-default">echarts</code> as a peer dependency.
+
+```bash
+npm install echarts
+```
+
+```svelte
+import { BubbleMap } from "kumo-svelte";
+```
+
+</ComponentSection>
+
+<ComponentSection>
+
+## Usage
+
+Use <code class="text-kumo-default">geoJson</code> to register the map base and accessors to read longitude, latitude, label, and value from each row.
+
+<ComponentExample demo="BubbleMapDemo" />
+
+</ComponentSection>
+
+<ComponentSection>
+
+## API Reference
+
+<PropsTable component="BubbleMap" />
+
+</ComponentSection>

--- a/packages/kumo-svelte/src/routes/components/dialog/+page.md
+++ b/packages/kumo-svelte/src/routes/components/dialog/+page.md
@@ -69,10 +69,8 @@ import { Dialog } from 'kumo-svelte/components/dialog';
 
 ## Dialog vs Alert Dialog
 
-  
 The Dialog component supports two ARIA roles to properly convey semantic
-    meaning to assistive technologies:
-
+meaning to assistive technologies:
 
   <div class="overflow-hidden rounded-lg border border-kumo-hairline">
     <table class="w-full text-sm">
@@ -116,12 +114,19 @@ The Dialog component supports two ARIA roles to properly convey semantic
 
 <ComponentExample demo="DialogBasicDemo" />
 
+### Sizes
+
+The `size` prop controls the fixed width of the dialog on desktop. Content that
+overflows the dialog width will scroll horizontally within the dialog rather
+than stretching it.
+
+<ComponentExample demo="DialogSizesDemo" />
+
 ### Alert Dialog (`role="alertdialog"`)
 
-
 For destructive or confirmation dialogs, use `role="alertdialog"` on
-  `Dialog`. This provides proper accessibility semantics by rendering the
-  dialog with `role="alertdialog"` instead of `role="dialog"`.
+`Dialog`. This provides proper accessibility semantics by rendering the
+dialog with `role="alertdialog"` instead of `role="dialog"`.
 
 <div class="mb-4 rounded-lg border border-kumo-info/30 bg-kumo-info/10 p-4 text-sm text-kumo-info">
   <p class="font-medium mb-2 text-sm">
@@ -139,10 +144,9 @@ For destructive or confirmation dialogs, use `role="alertdialog"` on
 
 ### Confirmation Dialog (with `disablePointerDismissal`)
 
-
 For confirmation dialogs that should not be dismissed by clicking outside, use
-  `disablePointerDismissal` on `Dialog`. This can be combined with
-  `role="alertdialog"` for proper accessibility.
+`disablePointerDismissal` on `Dialog`. This can be combined with
+`role="alertdialog"` for proper accessibility.
 
 <ComponentExample demo="DialogConfirmationDemo" />
 
@@ -158,13 +162,11 @@ Dialog max width can be customized with utility classes like `max-w-lg`.
 
 ### With Select
 
-
 Dialog containing a Select dropdown.
 
 <ComponentExample demo="DialogWithSelectDemo" />
 
 ### With Combobox
-
 
 Dialog containing a Combobox for searchable selection.
 
@@ -185,13 +187,11 @@ Dialog containing a Dropdown menu.
 
 ### Dialog
 
-
 The main dialog container that renders the modal overlay and popup.
 
 <PropsTable component="Dialog" />
 
 ### Dialog.Root
-
 
 Controls the open state of the dialog. Doesn't render its own HTML element.
 
@@ -231,20 +231,17 @@ Controls the open state of the dialog. Doesn't render its own HTML element.
 
 ### Dialog.Trigger
 
-
 A button that opens the dialog when clicked.
 
 <PropsTable component="Dialog.Trigger" />
 
 ### Dialog.Title
 
-
 A heading that labels the dialog for accessibility.
 
 <PropsTable component="Dialog.Title" />
 
 ### Dialog.Description
-
 
 A paragraph providing additional context about the dialog.
 


### PR DESCRIPTION
## Summary
- Port Cloudflare Kumo UI commits a74bd9c9, ebc5cf83, and dd1a0b5f.
- Add BubbleMap chart support with docs, props metadata, demo, exports, and tests.
- Switch Dialog sizes from min-width to fixed widths and preserve emphasized Button ring color on active/focus states.

## Tests
- [x] Tests included/updated
- `pnpm lint`
- `pnpm test`
- `CI=true pnpm -F kumo-svelte build`

## Changesets
- [x] Changeset included
- `.changeset/fix-dialog-size-width.md`
- `.changeset/spicy-maps-glow.md`
- `.changeset/blue-red-button-rings.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Bubble Map chart with demo, documentation, and navigation support.
  * Bubble Map supports configurable bubble sizing, colors, tooltips, and interaction callbacks.

* **Bug Fixes**
  * Dialog sizes now apply as fixed widths, preventing content from stretching dialogs wider than intended.
  * Primary and destructive buttons now show matching focus and active rings for clearer state feedback.

* **Documentation**
  * Updated chart and dialog docs with clearer usage, sizing, and accessibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->