### PR TITLE
Fix dialog variant CI test cleanup

### DIFF
--- a/.changeset/silver-dialog-tests.md
+++ b/.changeset/silver-dialog-tests.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Stabilize dialog variant exports so fixed-width dialog sizing can be tested without mounting dialog overlays.

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
@@ -1,43 +1,12 @@
+<script module lang="ts">
+  export { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
+</script>
+
 <script lang="ts">
   import { AlertDialog, Dialog as DialogPrimitive } from 'bits-ui';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
-
-  export const KUMO_DIALOG_VARIANTS = {
-    size: {
-      base: {
-        classes: 'sm:w-96',
-        description: 'Default dialog width (384px)'
-      },
-      sm: {
-        classes: 'sm:w-72',
-        description: 'Small dialog for simple confirmations (288px)'
-      },
-      lg: {
-        classes: 'sm:w-[32rem]',
-        description: 'Large dialog for complex content (512px)'
-      },
-      xl: {
-        classes: 'sm:w-[48rem]',
-        description: 'Extra large dialog for detailed views (768px)'
-      }
-    },
-    role: {
-      dialog: {
-        classes: '',
-        description: 'Standard dialog for general-purpose modals'
-      },
-      alertdialog: {
-        classes: '',
-        description: 'Alert dialog for confirmation flows requiring explicit user acknowledgment'
-      }
-    }
-  } as const;
-
-  export const KUMO_DIALOG_DEFAULT_VARIANTS = {
-    size: 'base',
-    role: 'dialog'
-  } as const;
+  import { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
 
   export const KUMO_DIALOG_STYLING = {
     dimensions: {

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.variants.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.variants.ts
@@ -1,0 +1,36 @@
+export const KUMO_DIALOG_VARIANTS = {
+  size: {
+    base: {
+      classes: 'sm:w-96',
+      description: 'Default dialog width (384px)'
+    },
+    sm: {
+      classes: 'sm:w-72',
+      description: 'Small dialog for simple confirmations (288px)'
+    },
+    lg: {
+      classes: 'sm:w-[32rem]',
+      description: 'Large dialog for complex content (512px)'
+    },
+    xl: {
+      classes: 'sm:w-[48rem]',
+      description: 'Extra large dialog for detailed views (768px)'
+    }
+  },
+  role: {
+    dialog: {
+      classes: '',
+      description: 'Standard dialog for general-purpose modals'
+    },
+    alertdialog: {
+      classes: '',
+      description:
+        'Alert dialog for confirmation flows requiring explicit user acknowledgment'
+    }
+  }
+} as const;
+
+export const KUMO_DIALOG_DEFAULT_VARIANTS = {
+  size: 'base',
+  role: 'dialog'
+} as const;

--- a/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
@@ -1,6 +1,5 @@
-import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
-import Dialog from './Dialog.svelte';
+import { KUMO_DIALOG_VARIANTS } from './Dialog.variants';
 
 describe('Dialog variants', () => {
   it('uses fixed width classes for size variants', () => {
@@ -10,15 +9,7 @@ describe('Dialog variants', () => {
       ['lg', 'sm:w-[32rem]'],
       ['xl', 'sm:w-[48rem]']
     ] as const) {
-      render(Dialog, {
-        open: true,
-        size,
-        title: `${size} dialog`
-      });
-
-      const className = screen.getByRole('dialog', {
-        name: `${size} dialog`
-      }).className;
+      const className = KUMO_DIALOG_VARIANTS.size[size].classes;
       expect(className).toContain(expectedClass);
       expect(className).not.toContain('min-w');
     }

--- a/packages/kumo-svelte/src/lib/components/dialog/index.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/index.ts
@@ -1,1 +1,2 @@
 export { default as Dialog } from './Dialog.svelte';
+export { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';


### PR DESCRIPTION
## Summary
- Move dialog variant constants into a plain TS module shared by Dialog and tests.
- Avoid mounting Bits UI dialog overlays in the fixed-width variant test, preventing async body-scroll cleanup after Vitest tears down document.

## Tests
- [x] Tests included/updated
- `pnpm lint`
- `CI=true pnpm -F kumo-svelte check`
- `pnpm test`
- `CI=true pnpm -F kumo-svelte build`

## Changesets
- [x] Changeset included
- `.changeset/silver-dialog-tests.md`