### PR TITLE
Restore Flow layout rewrite

### DIFF
--- a/.changeset/restore-flow-layout-rewrite.md
+++ b/.changeset/restore-flow-layout-rewrite.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": minor
+---
+
+Restore the upstream Flow layout rewrite with dedicated layout utilities and regression coverage.

--- a/packages/kumo-svelte/src/lib/components/flow/connectors.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/connectors.ts
@@ -92,11 +92,15 @@ export function createRoundedPath(
   const bottomCurveCommands = [
     `L ${x1} ${firstVerticalEnd}`,
     `Q ${x1} ${horizontalY} ${horizontalStart} ${horizontalY}`,
-    `L ${x2} ${horizontalY}`,
+    single
+      ? `L ${horizontalEnd} ${horizontalY} Q ${x2} ${horizontalY} ${x2} ${secondVerticalStart}`
+      : `L ${x2} ${horizontalY}`,
   ];
 
   const topCurveCommands = [
-    `L ${x1} ${horizontalY}`,
+    single
+      ? `L ${x1} ${firstVerticalEnd} Q ${x1} ${horizontalY} ${horizontalStart} ${horizontalY}`
+      : `L ${x1} ${horizontalY}`,
     `L ${horizontalEnd} ${horizontalY}`,
     `Q ${x2} ${horizontalY} ${x2} ${secondVerticalStart}`,
   ];

--- a/packages/kumo-svelte/src/lib/components/flow/flow-layout.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/flow-layout.ts
@@ -1,0 +1,248 @@
+export type TreeNode =
+  | { kind: "list"; children: TreeNode[] }
+  | { kind: "parallel"; children: TreeNode[]; align?: "end" }
+  | { kind: "node"; id: string };
+
+export type FlowAlign = "start" | "center";
+export type FlowOrientation = "horizontal" | "vertical";
+
+export type FlowState = {
+  nodes: {
+    [id: string]: {
+      width: number;
+      height: number;
+      disabled?: boolean;
+      startAnchorOffset?: number;
+      endAnchorOffset?: number;
+    };
+  };
+  tree: TreeNode;
+  align: FlowAlign;
+  orientation: FlowOrientation;
+};
+
+export type Edges = [string, string][];
+export type NodePositions = Record<string, { x: number; y: number }>;
+export type DiagramRect = { width: number; height: number };
+
+export function computeEdges(flowState: FlowState): Edges {
+  const edges: Edges = [];
+  collectEdges(flowState.tree, edges);
+  return edges;
+}
+
+function entryIds(node: TreeNode): string[] {
+  if (node.kind === "node") return [node.id];
+  if (node.kind === "parallel")
+    return node.children.flatMap((child) => entryIds(child));
+  if (node.children.length === 0) return [];
+  return entryIds(node.children[0]);
+}
+
+function exitIds(node: TreeNode): string[] {
+  if (node.kind === "node") return [node.id];
+  if (node.kind === "parallel")
+    return node.children.flatMap((child) => exitIds(child));
+  if (node.children.length === 0) return [];
+  return exitIds(node.children[node.children.length - 1]);
+}
+
+function collectEdges(node: TreeNode, edges: Edges) {
+  if (node.kind === "node") return;
+
+  if (node.kind === "parallel") {
+    for (const child of node.children) collectEdges(child, edges);
+    return;
+  }
+
+  for (const child of node.children) collectEdges(child, edges);
+
+  for (let i = 0; i < node.children.length - 1; i++) {
+    const current = node.children[i];
+    const next = node.children[i + 1];
+    if (current.kind === "parallel" && next.kind === "parallel") continue;
+
+    for (const from of exitIds(current)) {
+      for (const to of entryIds(next)) {
+        edges.push([from, to]);
+      }
+    }
+  }
+}
+
+export function computePositions(
+  flowState: FlowState,
+  { columnGap = 64, rowGap = 16 } = {},
+): NodePositions {
+  const positions: NodePositions = {};
+  const { align, orientation } = flowState;
+
+  function layout(
+    node: TreeNode,
+    originX: number,
+    originY: number,
+    out: NodePositions,
+  ): { width: number; height: number } {
+    if (node.kind === "node") {
+      const measured = flowState.nodes[node.id];
+      const width = measured?.width ?? 0;
+      const height = measured?.height ?? 0;
+      out[node.id] = { x: originX, y: originY };
+      return { width, height };
+    }
+
+    if (node.kind === "list") {
+      if (orientation === "vertical") {
+        if (align === "center") {
+          const sizes = node.children.map((child) => layout(child, 0, 0, {}));
+          const columnWidth = sizes.reduce(
+            (max, size) => Math.max(max, size.width),
+            0,
+          );
+          let cursorY = originY;
+
+          for (let i = 0; i < node.children.length; i++) {
+            const childX = originX + (columnWidth - sizes[i].width) / 2;
+            layout(node.children[i], childX, cursorY, out);
+            cursorY += sizes[i].height;
+            if (i < node.children.length - 1) cursorY += columnGap;
+          }
+
+          return { width: columnWidth, height: cursorY - originY };
+        }
+
+        let cursorY = originY;
+        let totalWidth = 0;
+        for (let i = 0; i < node.children.length; i++) {
+          const { width, height } = layout(
+            node.children[i],
+            originX,
+            cursorY,
+            out,
+          );
+          cursorY += height;
+          if (i < node.children.length - 1) cursorY += columnGap;
+          totalWidth = Math.max(totalWidth, width);
+        }
+        return { width: totalWidth, height: cursorY - originY };
+      }
+
+      if (align === "center") {
+        const sizes = node.children.map((child) => layout(child, 0, 0, {}));
+        const rowHeight = sizes.reduce(
+          (max, size) => Math.max(max, size.height),
+          0,
+        );
+        let cursorX = originX;
+
+        for (let i = 0; i < node.children.length; i++) {
+          const childY = originY + (rowHeight - sizes[i].height) / 2;
+          layout(node.children[i], cursorX, childY, out);
+          cursorX += sizes[i].width;
+          if (i < node.children.length - 1) cursorX += columnGap;
+        }
+
+        return { width: cursorX - originX, height: rowHeight };
+      }
+
+      let cursorX = originX;
+      let totalHeight = 0;
+      for (let i = 0; i < node.children.length; i++) {
+        const { width, height } = layout(
+          node.children[i],
+          cursorX,
+          originY,
+          out,
+        );
+        cursorX += width;
+        if (i < node.children.length - 1) cursorX += columnGap;
+        totalHeight = Math.max(totalHeight, height);
+      }
+      return { width: cursorX - originX, height: totalHeight };
+    }
+
+    if (orientation === "vertical") {
+      if (node.align === "end") {
+        const sizes = node.children.map((child) => layout(child, 0, 0, {}));
+        const maxHeight = sizes.reduce(
+          (max, size) => Math.max(max, size.height),
+          0,
+        );
+        let cursorX = originX;
+
+        for (let i = 0; i < node.children.length; i++) {
+          const childY = originY + maxHeight - sizes[i].height;
+          layout(node.children[i], cursorX, childY, out);
+          cursorX += sizes[i].width;
+          if (i < node.children.length - 1) cursorX += rowGap;
+        }
+
+        return { width: cursorX - originX, height: maxHeight };
+      }
+
+      let cursorX = originX;
+      let maxHeight = 0;
+      for (let i = 0; i < node.children.length; i++) {
+        const { width, height } = layout(
+          node.children[i],
+          cursorX,
+          originY,
+          out,
+        );
+        maxHeight = Math.max(maxHeight, height);
+        cursorX += width;
+        if (i < node.children.length - 1) cursorX += rowGap;
+      }
+      return { width: cursorX - originX, height: maxHeight };
+    }
+
+    if (node.align === "end") {
+      const sizes = node.children.map((child) => layout(child, 0, 0, {}));
+      const maxWidth = sizes.reduce(
+        (max, size) => Math.max(max, size.width),
+        0,
+      );
+      let cursorY = originY;
+
+      for (let i = 0; i < node.children.length; i++) {
+        const childX = originX + maxWidth - sizes[i].width;
+        layout(node.children[i], childX, cursorY, out);
+        cursorY += sizes[i].height;
+        if (i < node.children.length - 1) cursorY += rowGap;
+      }
+
+      return { width: maxWidth, height: cursorY - originY };
+    }
+
+    let cursorY = originY;
+    let maxWidth = 0;
+    for (let i = 0; i < node.children.length; i++) {
+      const { width, height } = layout(node.children[i], originX, cursorY, out);
+      maxWidth = Math.max(maxWidth, width);
+      cursorY += height;
+      if (i < node.children.length - 1) cursorY += rowGap;
+    }
+    return { width: maxWidth, height: cursorY - originY };
+  }
+
+  layout(flowState.tree, 0, 0, positions);
+
+  return positions;
+}
+
+export function computeDiagramRect(
+  positions: NodePositions,
+  flowState: FlowState,
+): DiagramRect {
+  let width = 0;
+  let height = 0;
+
+  for (const [id, pos] of Object.entries(positions)) {
+    const node = flowState.nodes[id];
+    if (!node) continue;
+    width = Math.max(width, pos.x + node.width);
+    height = Math.max(height, pos.y + node.height);
+  }
+
+  return { width, height };
+}

--- a/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
+++ b/packages/kumo-svelte/src/lib/components/flow/flow.test.ts
@@ -2,6 +2,13 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRoundedPath } from "./connectors";
+import {
+  computeDiagramRect,
+  computeEdges,
+  computePositions,
+  type FlowState,
+  type TreeNode,
+} from "./flow-layout";
 import FlowPanningTestHost from "./FlowPanningTestHost.svelte";
 
 const resizeObservers: TestResizeObserver[] = [];
@@ -120,5 +127,120 @@ describe("createRoundedPath", () => {
 
     expect(verticalPath).not.toContain(",");
     expect(horizontalPath).not.toContain(",");
+  });
+
+  it("rounds both corners for single vertical connector paths", () => {
+    const path = createRoundedPath(
+      { x1: 0, y1: 0, x2: 56, y2: 71 },
+      { orientation: "vertical", single: true },
+    );
+
+    expect(path).toBe("M 0 0 L 0 31 Q 0 39 8 39 L 48 39 Q 56 39 56 47 L 56 63");
+    expect(path).not.toContain(",");
+  });
+});
+
+function makeState(tree: TreeNode, partial?: Partial<FlowState>): FlowState {
+  return {
+    nodes: {},
+    tree,
+    align: "start",
+    orientation: "horizontal",
+    ...partial,
+  };
+}
+
+function node(id: string): TreeNode {
+  return { kind: "node", id };
+}
+
+function parallel(children: TreeNode[]): TreeNode {
+  return { kind: "parallel", children };
+}
+
+function list(children: TreeNode[]): TreeNode {
+  return { kind: "list", children };
+}
+
+function edgeSet(state: FlowState): Set<string> {
+  return new Set(computeEdges(state).map(([from, to]) => `${from}-${to}`));
+}
+
+describe("flow-layout", () => {
+  it("connects sequential nodes", () => {
+    expect(edgeSet(makeState(list([node("A"), node("B"), node("C")])))).toEqual(
+      new Set(["A-B", "B-C"]),
+    );
+  });
+
+  it("connects nodes adjacent to parallel branches", () => {
+    expect(
+      edgeSet(
+        makeState(
+          list([node("A"), parallel([node("B1"), node("B2")]), node("C")]),
+        ),
+      ),
+    ).toEqual(new Set(["A-B1", "A-B2", "B1-C", "B2-C"]));
+  });
+
+  it("does not connect adjacent parallel groups", () => {
+    expect(
+      edgeSet(
+        makeState(
+          list([
+            node("A"),
+            parallel([node("B1"), node("B2")]),
+            parallel([node("C1"), node("C2")]),
+            node("D"),
+          ]),
+        ),
+      ),
+    ).toEqual(new Set(["A-B1", "A-B2", "C1-D", "C2-D"]));
+  });
+
+  it("connects nested lists externally through first and last nodes", () => {
+    expect(
+      edgeSet(
+        makeState(
+          list([
+            node("A"),
+            parallel([list([node("B1"), node("B2")]), node("C1")]),
+            node("D"),
+          ]),
+        ),
+      ),
+    ).toEqual(new Set(["A-B1", "A-C1", "B1-B2", "B2-D", "C1-D"]));
+  });
+
+  it("computes positions and diagram bounds for horizontal flows", () => {
+    const state = makeState(list([node("A"), node("B")]), {
+      nodes: {
+        A: { width: 40, height: 20 },
+        B: { width: 80, height: 30 },
+      },
+    });
+
+    const positions = computePositions(state);
+    expect(positions).toEqual({ A: { x: 0, y: 0 }, B: { x: 104, y: 0 } });
+    expect(computeDiagramRect(positions, state)).toEqual({
+      width: 184,
+      height: 30,
+    });
+  });
+
+  it("computes positions for vertical centered flows", () => {
+    const state = makeState(list([node("A"), node("B")]), {
+      align: "center",
+      orientation: "vertical",
+      nodes: {
+        A: { width: 40, height: 20 },
+        B: { width: 80, height: 30 },
+      },
+    });
+
+    expect(computePositions(state)).toEqual({
+      A: { x: 20, y: 0 },
+      B: { x: 0, y: 84 },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- restores the upstream Flow layout rewrite that was held back from the 0.7 port
- adds the dedicated Flow layout engine and restores connector calculations around it
- adds regression coverage for layout rows, parallel groups, connector anchors, and skip behavior

## Tests
- [x] Tests included/updated
- [x] pnpm --filter kumo-svelte exec vitest run src/lib/components/flow/flow.test.ts
- [x] pnpm --filter kumo-svelte build