### PR TITLE
Fix release baseline version

### DIFF
--- a/packages/kumo-svelte/CHANGELOG.md
+++ b/packages/kumo-svelte/CHANGELOG.md
@@ -1,11 +1,5 @@
 # kumo-svelte
 
-## 0.7.0
-
-### Minor Changes
-
-- Port upstream Kumo updates after June 25, 2026, including ChoroplethMap, map projection sizing, vertical Flow parity, dropdown viewport height limits, faster class merging, and the Firefox button rendering fix.
-
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/kumo-svelte/package.json
+++ b/packages/kumo-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kumo-svelte",
-  "version": "0.7.0",
+  "version": "0.6.0",
   "description": "Svelte port of Cloudflare's Kumo UI library using bits-ui primitives.",
   "type": "module",
   "packageManager": "pnpm@11.10.0",


### PR DESCRIPTION
## Summary
- resets the `kumo-svelte` package baseline on `main` from `0.7.0` to `0.6.0`
- removes the premature `0.7.0` changelog section so Changesets can generate it in the release PR

## Verification
- [x] Confirmed `pnpm changeset version` calculates the next release as `0.7.0` from this baseline, then restored the generated release output before committing
- [x] Verified `packages/kumo-svelte/package.json` reads `0.6.0`

## Notes
- This is release metadata only, so no changeset is included. The local pre-push changeset hook was skipped with the documented `LEFTHOOK_EXCLUDE=validate-changeset` bypass.