### PR TITLE
Port Teddy's Combobox and Autocomplete parity improvements

### DIFF
--- a/.changeset/uhteddy-combobox-autocomplete.md
+++ b/.changeset/uhteddy-combobox-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Improve Combobox and Autocomplete parity with Bits UI primitives, including keyboard navigation, disabled state, multi-value handling, and updated prop documentation. Contributed by Teddy (@uhteddy).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Port components file-by-file from [cloudflare/kumo](https://github.com/cloudflar
 - **Original Live Docs**: [kumo-ui.com](https://kumo-ui.com)
 - **Original Source**: [cloudflare/kumo](https://github.com/cloudflare/kumo)
 
+## Contributors
+
+- [Teddy (@uhteddy)](https://github.com/uhteddy) contributed the Bits UI primitive integration, keyboard-navigation tests, and prop documentation for the Combobox and Autocomplete components.
+
 ## License
 
 MIT

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.9.0",
   "components": {
     "Autocomplete": {
       "name": "Autocomplete",
@@ -75,6 +75,29 @@
           "type": "(open: boolean) => void",
           "optional": true,
           "description": "Called when open state changes."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Prevents interaction with the field."
+        },
+        "size": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "xs",
+            "sm",
+            "base",
+            "lg"
+          ],
+          "default": "base",
+          "description": "Size preset."
+        },
+        "filter": {
+          "type": "((item: AutocompleteItem, query: string) => boolean) | null",
+          "optional": true,
+          "description": "Custom filter function. Set to null to disable filtering."
         }
       },
       "colors": [
@@ -1938,6 +1961,27 @@
           "type": "(open: boolean) => void",
           "optional": true,
           "description": "Called when open state changes."
+        },
+        "disabled": {
+          "type": "boolean",
+          "optional": true,
+          "default": "false",
+          "description": "Prevents interaction with the field."
+        },
+        "defaultValue": {
+          "type": "unknown",
+          "optional": true,
+          "description": "Initial value."
+        },
+        "filter": {
+          "type": "((item: ComboboxItem, query: string) => boolean) | null",
+          "optional": true,
+          "description": "Custom filter function. Set to null to disable filtering."
+        },
+        "isItemEqualToValue": {
+          "type": "(item: unknown, value: unknown) => boolean",
+          "optional": true,
+          "description": "Custom value equality matcher function."
         }
       },
       "colors": [

--- a/packages/kumo-svelte/ai/component-registry.md
+++ b/packages/kumo-svelte/ai/component-registry.md
@@ -1,6 +1,6 @@
 # Kumo Svelte Component Registry
 
-Version: 0.8.0
+Version: 0.9.0
 
 ## Autocomplete
 

--- a/packages/kumo-svelte/src/lib/components/autocomplete/Autocomplete.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/Autocomplete.svelte
@@ -12,6 +12,7 @@
     type NormalizedAutocompleteItem
   } from './context';
   import { createKumoFilter } from '../filter';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   type FieldError = string | { message?: string; match?: boolean };
 
@@ -22,6 +23,7 @@
     value?: AutocompleteValue;
     defaultValue?: AutocompleteValue;
     open?: boolean;
+    disabled?: boolean;
     size?: AutocompleteSize;
     label?: string | Snippet;
     labelTooltip?: string | Snippet;
@@ -41,6 +43,7 @@
     defaultValue,
     value = $bindable(defaultValue ?? ''),
     open = $bindable(false),
+    disabled = false,
     size = 'base',
     label,
     labelTooltip,
@@ -71,6 +74,62 @@
       if (filter) return filter(item.raw, query);
       return contains(item.label, term) || contains(String(item.value), term);
     });
+  });
+
+  const serializedOptions = $derived(
+    normalizedItems.map((item, index) => ({
+      ...item,
+      serializedValue: `kumo-autocomplete:${index}`
+    }))
+  );
+
+  function serializeSelectedValue(selectionValue: unknown) {
+    const option = serializedOptions.find((entry) => valuesEqual(entry.value, selectionValue as AutocompleteValue));
+    if (option) return option.serializedValue;
+    return typeof selectionValue === 'string' || typeof selectionValue === 'number' ? String(selectionValue) : undefined;
+  }
+
+  function deserializePrimitiveValue(primitiveValue: string) {
+    const option = serializedOptions.find((entry) => entry.serializedValue === primitiveValue);
+    return option ? option.value : primitiveValue;
+  }
+
+  const primitiveValue = $derived.by(() => {
+    if (Array.isArray(value)) {
+      return value.map(serializeSelectedValue).filter((v): v is string => v !== undefined);
+    }
+    const val = serializeSelectedValue(value);
+    return val !== undefined ? val : '';
+  });
+
+  function handleSingleValueChange(nextValue: string | undefined) {
+    if (nextValue === undefined) return;
+    const deserialized = deserializePrimitiveValue(nextValue);
+    value = deserialized;
+    const option = serializedOptions.find((entry) => entry.serializedValue === nextValue);
+    if (option) {
+      query = option.label;
+    }
+    open = false;
+    onValueChange?.(deserialized);
+    onOpenChange?.(false);
+  }
+
+  function handleMultipleValueChange(nextValue: string[]) {
+    const deserialized = nextValue.map(deserializePrimitiveValue).map(String);
+    value = deserialized;
+    onValueChange?.(deserialized);
+  }
+
+  $effect(() => {
+    if (!open) {
+      if (Array.isArray(value)) {
+        query = value.join(', ');
+      } else {
+        const option = serializedOptions.find((entry) => entry.value === value);
+        query = option ? option.label : String(value ?? '');
+      }
+    }
   });
 
   function valuesEqual(itemValue: string | number, selectedValue: AutocompleteValue) {
@@ -151,13 +210,39 @@
       onOpenChange?.(false);
     },
     isSelected,
-    select
+    select,
+    serializeValue(itemValue: unknown): string {
+      const option = serializedOptions.find((entry) => entry.value === itemValue);
+      return option?.serializedValue ?? String(itemValue ?? '');
+    }
   });
 </script>
 
 {#snippet control()}
   <div bind:this={rootElement} class={cn('relative w-full', className)} {...rest}>
-    {@render children?.()}
+    {#if Array.isArray(value)}
+      <ComboboxPrimitive.Root
+        type="multiple"
+        value={Array.isArray(primitiveValue) ? primitiveValue : []}
+        onValueChange={handleMultipleValueChange}
+        bind:open={open}
+        disabled={disabled}
+        inputValue={query}
+      >
+        {@render children?.()}
+      </ComboboxPrimitive.Root>
+    {:else}
+      <ComboboxPrimitive.Root
+        type="single"
+        value={Array.isArray(primitiveValue) ? (primitiveValue[0] ?? '') : primitiveValue}
+        onValueChange={handleSingleValueChange}
+        bind:open={open}
+        disabled={disabled}
+        inputValue={query}
+      >
+        {@render children?.()}
+      </ComboboxPrimitive.Root>
+    {/if}
   </div>
 {/snippet}
 

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteContent.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from 'svelte';
   import { getAutocompleteContext } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   type AutocompleteContentAlign = 'start' | 'center' | 'end';
   type AutocompleteContentSide = 'top' | 'right' | 'bottom' | 'left';
@@ -30,49 +31,28 @@
   }: Props = $props();
   const context = getAutocompleteContext('Autocomplete.Content');
 
-  const horizontalAlignClasses: Record<AutocompleteContentAlign, string> = {
-    start: 'left-[var(--autocomplete-align-offset)]',
-    center: 'left-1/2 -translate-x-1/2',
-    end: 'right-[var(--autocomplete-align-offset)]'
-  };
-
-  const verticalAlignClasses: Record<AutocompleteContentAlign, string> = {
-    start: 'top-[var(--autocomplete-align-offset)]',
-    center: 'top-1/2 -translate-y-1/2',
-    end: 'bottom-[var(--autocomplete-align-offset)]'
-  };
-
-  const sideClasses: Record<AutocompleteContentSide, string> = {
-    top: 'bottom-full mb-[var(--autocomplete-side-offset)]',
-    right: 'left-full ml-[var(--autocomplete-side-offset)]',
-    bottom: 'top-full mt-[var(--autocomplete-side-offset)]',
-    left: 'right-full mr-[var(--autocomplete-side-offset)]'
-  };
-
-  function toCssUnit(value: Offset) {
-    return typeof value === 'number' ? `${value}px` : value;
+  function toNumberOffset(val: Offset): number {
+    if (typeof val === 'number') return val;
+    const parsed = parseFloat(val);
+    return isNaN(parsed) ? 0 : parsed;
   }
-
-  const positionStyle = $derived(
-    `--autocomplete-align-offset: ${toCssUnit(alignOffset)}; --autocomplete-side-offset: ${toCssUnit(sideOffset)};${style ? ` ${style}` : ''}`
-  );
-  const positionClass = $derived.by(() =>
-    side === 'top' || side === 'bottom'
-      ? cn(sideClasses[side], horizontalAlignClasses[align])
-      : cn(sideClasses[side], verticalAlignClasses[align])
-  );
 </script>
 
 {#if context.open && context.hasTypedSinceFocus && context.filteredItems.length}
-  <div
-    class={cn(
-      'absolute z-50 flex max-h-[min(24rem,calc(100vh-8rem))] min-w-full flex-col overflow-hidden rounded-lg bg-kumo-control py-1.5 text-kumo-default shadow-lg ring ring-kumo-line',
-      positionClass,
-      className
-    )}
-    style={positionStyle}
-    {...rest}
-  >
-    {@render children?.()}
-  </div>
+  <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Content
+      class={cn(
+        'z-50 flex max-h-[min(24rem,calc(100vh-8rem))] min-w-[calc(var(--bits-select-anchor-width)+3px)] flex-col overflow-hidden rounded-lg bg-kumo-control py-1.5 text-kumo-default shadow-lg ring ring-kumo-line outline-none',
+        className
+      )}
+      side={side}
+      sideOffset={toNumberOffset(sideOffset)}
+      align={align}
+      alignOffset={toNumberOffset(alignOffset)}
+      style={style}
+      {...rest}
+    >
+      {@render children?.()}
+    </ComboboxPrimitive.Content>
+  </ComboboxPrimitive.Portal>
 {/if}

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteInputGroup.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteInputGroup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getAutocompleteContext, type AutocompleteSize } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     class?: string;
@@ -28,17 +29,16 @@
   }
 </script>
 
-<input
+<ComboboxPrimitive.Input
   class={cn(
     'w-full border-0 bg-kumo-control text-kumo-default shadow-xs ring ring-kumo-line outline-none focus:outline-none',
     'placeholder:text-kumo-placeholder disabled:text-kumo-disabled',
     context.invalid
-      ? '!ring-kumo-danger focus:ring-kumo-danger/50 focus:ring-[1.5px]'
+      ? 'ring-kumo-danger! focus:ring-kumo-danger/50 focus:ring-[1.5px]'
       : 'focus:ring-kumo-focus/50 focus:ring-[1.5px]',
     sizes[size ?? context.size],
     className
   )}
-  value={context.query}
   {placeholder}
   aria-invalid={context.invalid || undefined}
   onbeforeinput={(event) => {

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteItem.svelte
@@ -3,6 +3,7 @@
   import Check from 'phosphor-svelte/lib/Check';
   import { getAutocompleteContext, normalizeAutocompleteItem, type AutocompleteItem } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: Snippet;
@@ -18,25 +19,28 @@
     const normalized = normalizeAutocompleteItem(value);
     return { ...normalized, disabled: disabled ?? normalized.disabled };
   });
+  const serializedValue = $derived(context.serializeValue(item.value));
 </script>
 
-<button
-  type="button"
+<ComboboxPrimitive.Item
+  value={serializedValue}
+  label={item.label}
   disabled={item.disabled}
   data-kumo-component="Autocomplete"
   data-kumo-part="item"
   class={cn(
     'group mx-1.5 grid w-[calc(100%-0.75rem)] cursor-pointer grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base outline-none',
-    'hover:bg-kumo-overlay focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',
+    'data-highlighted:bg-kumo-overlay focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',
     'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
-    context.isSelected(item) && 'font-medium',
+    'data-selected:font-medium',
     className
   )}
-  onclick={() => context.select(item)}
   {...rest}
 >
-  <span class="col-start-1 min-w-0 truncate">{@render children?.()}</span>
-  {#if context.isSelected(item)}
-    <Check class="col-start-2 size-3.5 self-center text-kumo-default" aria-hidden="true" />
-  {/if}
-</button>
+  {#snippet children({ selected })}
+    <span class="col-start-1 min-w-0 truncate">{@render children?.()}</span>
+    {#if selected}
+      <Check class="col-start-2 size-3.5 self-center text-kumo-default" aria-hidden="true" />
+    {/if}
+  {/snippet}
+</ComboboxPrimitive.Item>

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteList.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteList.svelte
@@ -2,6 +2,7 @@
   import type { ItemSnippet } from './context';
   import { getAutocompleteContext } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: ItemSnippet;
@@ -13,11 +14,11 @@
   const context = getAutocompleteContext('Autocomplete.List');
 </script>
 
-<div
+<ComboboxPrimitive.Viewport
   class={cn('min-h-0 flex-1 overflow-y-auto overscroll-contain scroll-pb-2 scroll-pt-2', className)}
   {...rest}
 >
   {#each context.filteredItems as item (item.value)}
     {@render children?.(item.raw)}
   {/each}
-</div>
+</ComboboxPrimitive.Viewport>

--- a/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteTest.svelte
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/AutocompleteTest.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Autocomplete from './Autocomplete.svelte';
+  import AutocompleteInputGroup from './AutocompleteInputGroup.svelte';
+  import AutocompleteContent from './AutocompleteContent.svelte';
+  import AutocompleteList from './AutocompleteList.svelte';
+  import AutocompleteItem from './AutocompleteItem.svelte';
+
+  interface Props {
+    value?: string | number | string[];
+    items?: string[];
+    onValueChange?: (value: any) => void;
+  }
+
+  let { value = $bindable(''), items = ['Apple', 'Banana', 'Cherry'], onValueChange }: Props = $props();
+</script>
+
+<Autocomplete bind:value {items} {onValueChange}>
+  <AutocompleteInputGroup placeholder="Search fruit" />
+  <AutocompleteContent>
+    <AutocompleteList>
+      {#snippet children(item)}
+        <AutocompleteItem value={item}>{item}</AutocompleteItem>
+      {/snippet}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>

--- a/packages/kumo-svelte/src/lib/components/autocomplete/autocomplete.test.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/autocomplete.test.ts
@@ -1,37 +1,37 @@
-import { render, screen } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
-import AutocompleteTest from './AutocompleteTest.svelte';
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import AutocompleteTest from "./AutocompleteTest.svelte";
 
-describe('Autocomplete Keyboard Navigation', () => {
-  it('allows typing to search and using Arrow keys and Enter to select', async () => {
+describe("Autocomplete Keyboard Navigation", () => {
+  it("allows typing to search and using Arrow keys and Enter to select", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
 
     render(AutocompleteTest, {
-      value: '',
-      onValueChange
+      value: "",
+      onValueChange,
     });
 
-    const input = screen.getByPlaceholderText('Search fruit');
-    
+    const input = screen.getByPlaceholderText("Search fruit");
+
     // Focus the input
     await user.click(input);
 
     // Type 'B' to filter and trigger opening
-    await user.type(input, 'B');
+    await user.type(input, "B");
 
     // Verify option 'Banana' is visible in document
-    expect(screen.getByRole('option', { name: 'Banana' })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Banana" })).toBeTruthy();
     // 'Apple' should not be visible as it doesn't match 'B'
-    expect(screen.queryByRole('option', { name: 'Apple' })).toBeNull();
+    expect(screen.queryByRole("option", { name: "Apple" })).toBeNull();
 
     // Use ArrowDown to highlight first matching item ('Banana')
-    await user.keyboard('{ArrowDown}');
+    await user.keyboard("{ArrowDown}");
 
     // Use Enter to select it
-    await user.keyboard('{Enter}');
+    await user.keyboard("{Enter}");
 
-    expect(onValueChange).toHaveBeenCalledWith('Banana');
+    expect(onValueChange).toHaveBeenCalledWith("Banana");
   });
 });

--- a/packages/kumo-svelte/src/lib/components/autocomplete/autocomplete.test.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/autocomplete.test.ts
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import AutocompleteTest from './AutocompleteTest.svelte';
+
+describe('Autocomplete Keyboard Navigation', () => {
+  it('allows typing to search and using Arrow keys and Enter to select', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(AutocompleteTest, {
+      value: '',
+      onValueChange
+    });
+
+    const input = screen.getByPlaceholderText('Search fruit');
+    
+    // Focus the input
+    await user.click(input);
+
+    // Type 'B' to filter and trigger opening
+    await user.type(input, 'B');
+
+    // Verify option 'Banana' is visible in document
+    expect(screen.getByRole('option', { name: 'Banana' })).toBeTruthy();
+    // 'Apple' should not be visible as it doesn't match 'B'
+    expect(screen.queryByRole('option', { name: 'Apple' })).toBeNull();
+
+    // Use ArrowDown to highlight first matching item ('Banana')
+    await user.keyboard('{ArrowDown}');
+
+    // Use Enter to select it
+    await user.keyboard('{Enter}');
+
+    expect(onValueChange).toHaveBeenCalledWith('Banana');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/autocomplete/context.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/context.ts
@@ -1,7 +1,7 @@
-import type { Snippet } from 'svelte';
-import { getContext, setContext } from 'svelte';
+import type { Snippet } from "svelte";
+import { getContext, setContext } from "svelte";
 
-export type AutocompleteSize = 'xs' | 'sm' | 'base' | 'lg';
+export type AutocompleteSize = "xs" | "sm" | "base" | "lg";
 export type AutocompleteValue = string | number | string[];
 
 export type AutocompleteItem = unknown;
@@ -37,16 +37,19 @@ export type AutocompleteGroupContext = {
   get items(): NormalizedAutocompleteItem[];
 };
 
-const AUTOCOMPLETE_CONTEXT = Symbol('kumo-autocomplete');
-const AUTOCOMPLETE_GROUP_CONTEXT = Symbol('kumo-autocomplete-group');
+const AUTOCOMPLETE_CONTEXT = Symbol("kumo-autocomplete");
+const AUTOCOMPLETE_GROUP_CONTEXT = Symbol("kumo-autocomplete-group");
 
 export function setAutocompleteContext(context: AutocompleteContext) {
   setContext(AUTOCOMPLETE_CONTEXT, context);
 }
 
 export function getAutocompleteContext(component: string) {
-  const context = getContext<AutocompleteContext | undefined>(AUTOCOMPLETE_CONTEXT);
-  if (!context) throw new Error(`${component} must be used inside <Autocomplete>.`);
+  const context = getContext<AutocompleteContext | undefined>(
+    AUTOCOMPLETE_CONTEXT,
+  );
+  if (!context)
+    throw new Error(`${component} must be used inside <Autocomplete>.`);
   return context;
 }
 
@@ -55,15 +58,19 @@ export function setAutocompleteGroupContext(context: AutocompleteGroupContext) {
 }
 
 export function getAutocompleteGroupContext() {
-  return getContext<AutocompleteGroupContext | undefined>(AUTOCOMPLETE_GROUP_CONTEXT);
+  return getContext<AutocompleteGroupContext | undefined>(
+    AUTOCOMPLETE_GROUP_CONTEXT,
+  );
 }
 
-export function normalizeAutocompleteItem(item: AutocompleteItem): NormalizedAutocompleteItem {
-  if (typeof item === 'string' || typeof item === 'number') {
+export function normalizeAutocompleteItem(
+  item: AutocompleteItem,
+): NormalizedAutocompleteItem {
+  if (typeof item === "string" || typeof item === "number") {
     return { label: String(item), value: item, raw: item };
   }
 
-  if (item && typeof item === 'object' && 'label' in item && 'value' in item) {
+  if (item && typeof item === "object" && "label" in item && "value" in item) {
     const option = item as {
       label: unknown;
       value: unknown;
@@ -73,17 +80,19 @@ export function normalizeAutocompleteItem(item: AutocompleteItem): NormalizedAut
 
     return {
       label: String(option.label),
-      value: typeof option.value === 'number' ? option.value : String(option.value),
-      disabled: typeof option.disabled === 'boolean' ? option.disabled : undefined,
-      group: typeof option.group === 'string' ? option.group : undefined,
-      raw: item
+      value:
+        typeof option.value === "number" ? option.value : String(option.value),
+      disabled:
+        typeof option.disabled === "boolean" ? option.disabled : undefined,
+      group: typeof option.group === "string" ? option.group : undefined,
+      raw: item,
     };
   }
 
   return {
     label: String(item),
     value: String(item),
-    raw: item
+    raw: item,
   };
 }
 

--- a/packages/kumo-svelte/src/lib/components/autocomplete/context.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/context.ts
@@ -30,6 +30,7 @@ export type AutocompleteContext = {
   resetInputInteraction(): void;
   isSelected(item: NormalizedAutocompleteItem): boolean;
   select(item: NormalizedAutocompleteItem): void;
+  serializeValue(value: unknown): string;
 };
 
 export type AutocompleteGroupContext = {

--- a/packages/kumo-svelte/src/lib/components/autocomplete/index.ts
+++ b/packages/kumo-svelte/src/lib/components/autocomplete/index.ts
@@ -1,13 +1,13 @@
-import Root from './Autocomplete.svelte';
-import InputGroup from './AutocompleteInputGroup.svelte';
-import Content from './AutocompleteContent.svelte';
-import List from './AutocompleteList.svelte';
-import Item from './AutocompleteItem.svelte';
-import Group from './AutocompleteGroup.svelte';
-import GroupLabel from './AutocompleteGroupLabel.svelte';
-import Collection from './AutocompleteCollection.svelte';
-import Separator from './AutocompleteSeparator.svelte';
-import { createKumoFilter } from '../filter';
+import Root from "./Autocomplete.svelte";
+import InputGroup from "./AutocompleteInputGroup.svelte";
+import Content from "./AutocompleteContent.svelte";
+import List from "./AutocompleteList.svelte";
+import Item from "./AutocompleteItem.svelte";
+import Group from "./AutocompleteGroup.svelte";
+import GroupLabel from "./AutocompleteGroupLabel.svelte";
+import Collection from "./AutocompleteCollection.svelte";
+import Separator from "./AutocompleteSeparator.svelte";
+import { createKumoFilter } from "../filter";
 
 export const Autocomplete = Object.assign(Root, {
   InputGroup,
@@ -18,7 +18,7 @@ export const Autocomplete = Object.assign(Root, {
   GroupLabel,
   Collection,
   Separator,
-  useFilter: createKumoFilter
+  useFilter: createKumoFilter,
 });
 
 export {
@@ -30,7 +30,10 @@ export {
   Group as AutocompleteGroup,
   GroupLabel as AutocompleteGroupLabel,
   Collection as AutocompleteCollection,
-  Separator as AutocompleteSeparator
+  Separator as AutocompleteSeparator,
 };
 
-export type { AutocompleteItem as AutocompleteOption, AutocompleteSize } from './context';
+export type {
+  AutocompleteItem as AutocompleteOption,
+  AutocompleteSize,
+} from "./context";

--- a/packages/kumo-svelte/src/lib/components/combobox/Combobox.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/Combobox.svelte
@@ -10,6 +10,7 @@
     type NormalizedComboboxItem
   } from './context';
   import { createKumoFilter } from '../filter';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   type FieldError = string | { message?: string; match?: boolean };
 
@@ -77,6 +78,54 @@
       if (filter) return filter(item.raw, query);
       return contains(item.label, term) || contains(String(item.value), term);
     });
+  });
+
+  const serializedOptions = $derived(
+    normalizedItems.map((item, index) => ({
+      ...item,
+      serializedValue: `kumo-combobox:${index}`
+    }))
+  );
+
+  function serializeSelectedValue(selectionValue: unknown) {
+    const option = serializedOptions.find((entry) => valuesEqual(entry.value, selectionValue));
+    if (option) return option.serializedValue;
+    return typeof selectionValue === 'string' ? selectionValue : undefined;
+  }
+
+  function deserializePrimitiveValue(primitiveValue: string) {
+    const option = serializedOptions.find((entry) => entry.serializedValue === primitiveValue);
+    return option ? option.value : primitiveValue;
+  }
+
+  const primitiveValue = $derived.by(() => {
+    if (multiple) {
+      const arr = Array.isArray(value) ? value : [];
+      return arr.map(serializeSelectedValue).filter((v): v is string => v !== undefined);
+    }
+    const val = serializeSelectedValue(value);
+    return val !== undefined ? val : '';
+  });
+
+  const rootInputValue = $derived(open || multiple ? query : labelFor(value));
+
+  function handleSingleValueChange(nextValue: string | undefined) {
+    const next = nextValue ? deserializePrimitiveValue(nextValue) : null;
+    emit(next);
+    query = '';
+    open = false;
+    onOpenChange?.(false);
+  }
+
+  function handleMultipleValueChange(nextValue: string[]) {
+    emit(nextValue.map(deserializePrimitiveValue));
+    query = '';
+  }
+
+  $effect(() => {
+    if (!open) {
+      query = '';
+    }
   });
 
   function valuesEqual(itemValue: unknown, selectedValue: unknown) {
@@ -208,7 +257,11 @@
     isSelected,
     select,
     remove,
-    labelFor
+    labelFor,
+    serializeValue(itemValue: unknown): string {
+      const option = serializedOptions.find((entry) => valuesEqual(entry.value, itemValue));
+      return option?.serializedValue ?? String(itemValue ?? '');
+    }
   });
 </script>
 
@@ -219,7 +272,29 @@
     class={cn('relative inline-block max-w-full', className)}
     {...rest}
   >
-    {@render children?.()}
+    {#if multiple}
+      <ComboboxPrimitive.Root
+        type="multiple"
+        value={Array.isArray(primitiveValue) ? primitiveValue : []}
+        onValueChange={handleMultipleValueChange}
+        bind:open={open}
+        disabled={disabled}
+        inputValue={rootInputValue}
+      >
+        {@render children?.()}
+      </ComboboxPrimitive.Root>
+    {:else}
+      <ComboboxPrimitive.Root
+        type="single"
+        value={Array.isArray(primitiveValue) ? (primitiveValue[0] ?? '') : primitiveValue}
+        onValueChange={handleSingleValueChange}
+        bind:open={open}
+        disabled={disabled}
+        inputValue={rootInputValue}
+      >
+        {@render children?.()}
+      </ComboboxPrimitive.Root>
+    {/if}
   </div>
 {/snippet}
 

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxContent.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxContent.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from 'svelte';
   import { getComboboxContext } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   type ComboboxContentAlign = 'start' | 'center' | 'end';
   type ComboboxContentSide = 'top' | 'right' | 'bottom' | 'left';
@@ -30,49 +31,28 @@
   }: Props = $props();
   const context = getComboboxContext('Combobox.Content');
 
-  const horizontalAlignClasses: Record<ComboboxContentAlign, string> = {
-    start: 'left-[var(--combobox-align-offset)]',
-    center: 'left-1/2 -translate-x-1/2',
-    end: 'right-[var(--combobox-align-offset)]'
-  };
-
-  const verticalAlignClasses: Record<ComboboxContentAlign, string> = {
-    start: 'top-[var(--combobox-align-offset)]',
-    center: 'top-1/2 -translate-y-1/2',
-    end: 'bottom-[var(--combobox-align-offset)]'
-  };
-
-  const sideClasses: Record<ComboboxContentSide, string> = {
-    top: 'bottom-full mb-[var(--combobox-side-offset)]',
-    right: 'left-full ml-[var(--combobox-side-offset)]',
-    bottom: 'top-full mt-[var(--combobox-side-offset)]',
-    left: 'right-full mr-[var(--combobox-side-offset)]'
-  };
-
-  function toCssUnit(value: Offset) {
-    return typeof value === 'number' ? `${value}px` : value;
+  function toNumberOffset(val: Offset): number {
+    if (typeof val === 'number') return val;
+    const parsed = parseFloat(val);
+    return isNaN(parsed) ? 0 : parsed;
   }
-
-  const positionStyle = $derived(
-    `--combobox-align-offset: ${toCssUnit(alignOffset)}; --combobox-side-offset: ${toCssUnit(sideOffset)};${style ? ` ${style}` : ''}`
-  );
-  const positionClass = $derived.by(() =>
-    side === 'top' || side === 'bottom'
-      ? cn(sideClasses[side], horizontalAlignClasses[align])
-      : cn(sideClasses[side], verticalAlignClasses[align])
-  );
 </script>
 
 {#if context.open}
-  <div
-    class={cn(
-      'absolute z-50 flex max-h-[min(24rem,calc(100vh-8rem))] min-w-full flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line',
-      positionClass,
-      className
-    )}
-    style={positionStyle}
-    {...rest}
-  >
-    {@render children?.()}
-  </div>
+  <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Content
+      class={cn(
+        'z-50 flex max-h-[min(24rem,calc(100vh-8rem))] min-w-[calc(var(--bits-select-anchor-width)+3px)] flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line outline-none',
+        className
+      )}
+      side={side}
+      sideOffset={toNumberOffset(sideOffset)}
+      align={align}
+      alignOffset={toNumberOffset(alignOffset)}
+      style={style}
+      {...rest}
+    >
+      {@render children?.()}
+    </ComboboxPrimitive.Content>
+  </ComboboxPrimitive.Portal>
 {/if}

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxItem.svelte
@@ -3,6 +3,7 @@
   import Check from 'phosphor-svelte/lib/Check';
   import { getComboboxContext, normalizeComboboxItem, type ComboboxItem } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: Snippet;
@@ -18,25 +19,27 @@
     const normalized = normalizeComboboxItem(value);
     return { ...normalized, disabled: disabled ?? normalized.disabled };
   });
-  const selected = $derived(context.isSelected(item));
+  const serializedValue = $derived(context.serializeValue(item.value));
 </script>
 
-<button
-  type="button"
+<ComboboxPrimitive.Item
+  value={serializedValue}
+  label={item.label}
   disabled={item.disabled}
   data-kumo-component="Combobox"
   data-kumo-part="item"
   class={cn(
     'group mx-1.5 grid w-[calc(100%-0.75rem)] grid-cols-[1fr_16px] gap-2 rounded px-2 py-1.5 text-left text-base text-kumo-default outline-none',
-    'cursor-pointer hover:bg-kumo-tint focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',
+    'cursor-pointer data-highlighted:bg-kumo-tint focus-visible:z-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-kumo-brand',
     'disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-kumo-subtle disabled:opacity-60 disabled:hover:bg-transparent',
     className
   )}
-  onclick={() => context.select(item)}
   {...rest}
 >
-  <span class="col-start-1 min-w-0 truncate">{@render children?.()}</span>
-  {#if selected}
-    <Check class="col-start-2 size-4 self-center text-kumo-default" aria-hidden="true" />
-  {/if}
-</button>
+  {#snippet children({ selected })}
+    <span class="col-start-1 min-w-0 truncate">{@render children?.()}</span>
+    {#if selected}
+      <Check class="col-start-2 size-4 self-center text-kumo-default" aria-hidden="true" />
+    {/if}
+  {/snippet}
+</ComboboxPrimitive.Item>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxList.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxList.svelte
@@ -2,6 +2,7 @@
   import type { ItemSnippet } from './context';
   import { getComboboxContext } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: ItemSnippet;
@@ -13,7 +14,7 @@
   const context = getComboboxContext('Combobox.List');
 </script>
 
-<div
+<ComboboxPrimitive.Viewport
   class={cn('min-h-0 flex-1 overflow-y-auto overscroll-contain scroll-pb-2 scroll-pt-2', className)}
   {...rest}
 >
@@ -22,4 +23,4 @@
       {@render children(item.raw)}
     {/each}
   {/if}
-</div>
+</ComboboxPrimitive.Viewport>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTest.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTest.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Combobox from './Combobox.svelte';
+  import ComboboxTriggerInput from './ComboboxTriggerInput.svelte';
+  import ComboboxContent from './ComboboxContent.svelte';
+  import ComboboxList from './ComboboxList.svelte';
+  import ComboboxItem from './ComboboxItem.svelte';
+
+  interface Props {
+    value?: unknown;
+    items?: string[];
+    onValueChange?: (value: unknown) => void;
+  }
+
+  let { value = $bindable(null), items = ['Apple', 'Banana', 'Cherry'], onValueChange }: Props = $props();
+</script>
+
+<Combobox bind:value {items} {onValueChange}>
+  <ComboboxTriggerInput placeholder="Select fruit" />
+  <ComboboxContent>
+    <ComboboxList>
+      {#snippet children(item)}
+        <ComboboxItem value={item}>{item}</ComboboxItem>
+      {/snippet}
+    </ComboboxList>
+  </ComboboxContent>
+</Combobox>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTrigger.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTrigger.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from 'svelte';
   import { getComboboxContext } from './context';
   import { cn } from '$lib/utils/cn';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: Snippet;
@@ -13,14 +14,12 @@
   const context = getComboboxContext('Combobox.Trigger');
 </script>
 
-<button
-  type="button"
+<ComboboxPrimitive.Trigger
   class={cn('inline-flex items-center gap-2', className)}
   disabled={context.disabled}
   data-kumo-component="Combobox"
   data-kumo-part="trigger"
-  onclick={() => (context.open = !context.open)}
   {...rest}
 >
   {@render children?.()}
-</button>
+</ComboboxPrimitive.Trigger>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerInput.svelte
@@ -3,6 +3,7 @@
   import X from 'phosphor-svelte/lib/X';
   import { cn } from '$lib/utils/cn';
   import { embeddedInputStyles, getComboboxContext, iconSizes, inputStyles, type ComboboxSize } from './context';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     class?: string;
@@ -24,7 +25,6 @@
 
   const context = getComboboxContext('Combobox.TriggerInput');
   const resolvedSize = $derived(size ?? context.size);
-  const displayValue = $derived(context.open || context.multiple ? context.query : context.labelFor(context.value));
   const hasValue = $derived(context.multiple ? Array.isArray(context.value) && context.value.length > 0 : Boolean(context.value));
 
   const iconPadding: Record<ComboboxSize, string> = {
@@ -56,7 +56,7 @@
     className
   )}
 >
-  <input
+  <ComboboxPrimitive.Input
     class={cn(
       inputStyles[resolvedSize],
       'w-full border-0 bg-kumo-control text-kumo-default shadow-xs ring ring-kumo-line outline-none',
@@ -66,15 +66,8 @@
         : 'focus:ring-kumo-focus/50 focus:ring-[1.5px]',
       iconPadding[resolvedSize]
     )}
-    value={displayValue}
     {placeholder}
-    disabled={context.disabled}
     aria-invalid={context.invalid || undefined}
-    oninput={(event) => {
-      context.query = (event.currentTarget as HTMLInputElement).value;
-      context.open = true;
-    }}
-    onfocus={() => (context.open = true)}
     {...rest}
   />
 
@@ -89,13 +82,15 @@
       clearRight[resolvedSize]
     )}
     disabled={context.disabled || !hasValue}
-    onclick={() => (context.value = context.multiple ? [] : null)}
+    onclick={() => {
+      context.value = context.multiple ? [] : null;
+      context.query = '';
+    }}
   >
     <X size={iconSizes[resolvedSize]} />
   </button>
 
-  <button
-    type="button"
+  <ComboboxPrimitive.Trigger
     aria-label={showOptionsLabel}
     data-kumo-component="Combobox"
     data-kumo-part="trigger"
@@ -104,8 +99,7 @@
       caretRight[resolvedSize]
     )}
     disabled={context.disabled}
-    onclick={() => (context.open = !context.open)}
   >
     <CaretDown size={iconSizes[resolvedSize]} class="fill-current" />
-  </button>
+  </ComboboxPrimitive.Trigger>
 </div>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerMultipleWithInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerMultipleWithInput.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
   import { getComboboxContext, inputStyles, type ComboboxInputSide, type ComboboxSize } from './context';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     children?: Snippet<[any]>;
@@ -43,16 +44,9 @@
   {...rest}
 >
   {#if inputSide === 'top'}
-    <input
+    <ComboboxPrimitive.Input
       class="w-full border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-muted"
       {placeholder}
-      value={context.query}
-      disabled={context.disabled}
-      oninput={(event) => {
-        context.query = (event.currentTarget as HTMLInputElement).value;
-        context.open = true;
-      }}
-      onfocus={() => (context.open = true)}
     />
   {/if}
   <div class="flex flex-1 flex-wrap items-center gap-1.5">
@@ -60,16 +54,9 @@
       {@render children?.(selected)}
     {/each}
     {#if inputSide === 'right'}
-      <input
+      <ComboboxPrimitive.Input
         class="min-w-[100px] flex-1 border-0 bg-inherit px-2 py-1 outline-none placeholder:text-kumo-muted"
         {placeholder}
-        value={context.query}
-        disabled={context.disabled}
-        oninput={(event) => {
-          context.query = (event.currentTarget as HTMLInputElement).value;
-          context.open = true;
-        }}
-        onfocus={() => (context.open = true)}
       />
     {/if}
   </div>

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerValue.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTriggerValue.svelte
@@ -2,6 +2,7 @@
   import CaretDown from 'phosphor-svelte/lib/CaretDown';
   import { cn } from '$lib/utils/cn';
   import { getComboboxContext, iconSizes, inputStyles, type ComboboxSize } from './context';
+  import { Combobox as ComboboxPrimitive } from 'bits-ui';
 
   export interface Props {
     class?: string;
@@ -30,8 +31,7 @@
   };
 </script>
 
-<button
-  type="button"
+<ComboboxPrimitive.Trigger
   class={cn(
     inputStyles[resolvedSize],
     'relative flex w-full items-center border-0 bg-kumo-control text-left font-normal text-kumo-default shadow-xs ring ring-kumo-line outline-none',
@@ -43,11 +43,10 @@
   disabled={context.disabled}
   data-kumo-component="Combobox"
   data-kumo-part="trigger"
-  onclick={() => (context.open = !context.open)}
   {...rest}
 >
   <span class="min-w-0 flex-1 truncate">{displayValue || placeholder}</span>
   <span class={cn('absolute top-1/2 flex -translate-y-1/2 items-center text-kumo-subtle', iconRight[resolvedSize])}>
     <CaretDown size={iconSizes[resolvedSize]} class="fill-current" />
   </span>
-</button>
+</ComboboxPrimitive.Trigger>

--- a/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
@@ -1,36 +1,36 @@
-import { render, screen } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
-import ComboboxTest from './ComboboxTest.svelte';
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ComboboxTest from "./ComboboxTest.svelte";
 
-describe('Combobox Keyboard Navigation', () => {
-  it('allows navigating and selecting items using Arrow keys and Enter', async () => {
+describe("Combobox Keyboard Navigation", () => {
+  it("allows navigating and selecting items using Arrow keys and Enter", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
 
     render(ComboboxTest, {
       value: null,
-      onValueChange
+      onValueChange,
     });
 
-    const input = screen.getByPlaceholderText('Select fruit');
-    
+    const input = screen.getByPlaceholderText("Select fruit");
+
     // Focus the input
     await user.click(input);
 
     // Click the "Show options" trigger to open it
-    const trigger = screen.getByRole('button', { name: 'Show options' });
+    const trigger = screen.getByRole("button", { name: "Show options" });
     await user.click(trigger);
 
     // Verify option is visible in document
-    expect(screen.getByRole('option', { name: 'Apple' })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Apple" })).toBeTruthy();
 
     // Use ArrowDown to highlight the next item ('Banana')
-    await user.keyboard('{ArrowDown}');
+    await user.keyboard("{ArrowDown}");
 
     // Use Enter to select the highlighted item
-    await user.keyboard('{Enter}');
+    await user.keyboard("{Enter}");
 
-    expect(onValueChange).toHaveBeenCalledWith('Banana');
+    expect(onValueChange).toHaveBeenCalledWith("Banana");
   });
 });

--- a/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import ComboboxTest from './ComboboxTest.svelte';
+
+describe('Combobox Keyboard Navigation', () => {
+  it('allows navigating and selecting items using Arrow keys and Enter', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(ComboboxTest, {
+      value: null,
+      onValueChange
+    });
+
+    const input = screen.getByPlaceholderText('Select fruit');
+    
+    // Focus the input
+    await user.click(input);
+
+    // Click the "Show options" trigger to open it
+    const trigger = screen.getByRole('button', { name: 'Show options' });
+    await user.click(trigger);
+
+    // Verify option is visible in document
+    expect(screen.getByRole('option', { name: 'Apple' })).toBeTruthy();
+
+    // Use ArrowDown to highlight the next item ('Banana')
+    await user.keyboard('{ArrowDown}');
+
+    // Use Enter to select the highlighted item
+    await user.keyboard('{Enter}');
+
+    expect(onValueChange).toHaveBeenCalledWith('Banana');
+  });
+});

--- a/packages/kumo-svelte/src/lib/components/combobox/context.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/context.ts
@@ -34,6 +34,7 @@ export type ComboboxContext = {
   select(item: NormalizedComboboxItem): void;
   remove(item: unknown): void;
   labelFor(value: unknown): string;
+  serializeValue(value: unknown): string;
 };
 
 export type ComboboxGroupContext = {

--- a/packages/kumo-svelte/src/lib/components/combobox/context.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/context.ts
@@ -1,14 +1,16 @@
-import type { Snippet } from 'svelte';
-import { getContext, setContext } from 'svelte';
+import type { Snippet } from "svelte";
+import { getContext, setContext } from "svelte";
 
-export type ComboboxSize = 'xs' | 'sm' | 'base' | 'lg';
-export type ComboboxInputSide = 'right' | 'top';
-export type ComboboxItem = string | {
-  label?: string;
-  value?: unknown;
-  disabled?: boolean;
-  [key: string]: unknown;
-};
+export type ComboboxSize = "xs" | "sm" | "base" | "lg";
+export type ComboboxInputSide = "right" | "top";
+export type ComboboxItem =
+  | string
+  | {
+      label?: string;
+      value?: unknown;
+      disabled?: boolean;
+      [key: string]: unknown;
+    };
 
 export type NormalizedComboboxItem = {
   label: string;
@@ -41,28 +43,28 @@ export type ComboboxGroupContext = {
   get items(): NormalizedComboboxItem[];
 };
 
-const COMBOBOX_CONTEXT = Symbol('kumo-combobox');
-const COMBOBOX_GROUP_CONTEXT = Symbol('kumo-combobox-group');
+const COMBOBOX_CONTEXT = Symbol("kumo-combobox");
+const COMBOBOX_GROUP_CONTEXT = Symbol("kumo-combobox-group");
 
 export const inputStyles: Record<ComboboxSize, string> = {
-  xs: 'h-5 rounded-sm px-1.5 text-xs',
-  sm: 'h-6.5 rounded-md px-2 text-xs',
-  base: 'h-9 rounded-lg px-3 text-base',
-  lg: 'h-10 rounded-lg px-4 text-base'
+  xs: "h-5 rounded-sm px-1.5 text-xs",
+  sm: "h-6.5 rounded-md px-2 text-xs",
+  base: "h-9 rounded-lg px-3 text-base",
+  lg: "h-10 rounded-lg px-4 text-base",
 };
 
 export const embeddedInputStyles: Record<ComboboxSize, string> = {
-  xs: 'h-4 text-xs',
-  sm: 'h-4.5 text-xs',
-  base: 'h-6 text-base',
-  lg: 'h-6 text-base'
+  xs: "h-4 text-xs",
+  sm: "h-4.5 text-xs",
+  base: "h-6 text-base",
+  lg: "h-6 text-base",
 };
 
 export const iconSizes: Record<ComboboxSize, number> = {
   xs: 12,
   sm: 14,
   base: 16,
-  lg: 18
+  lg: 18,
 };
 
 export type ItemSnippet = Snippet<[any]>;
@@ -85,14 +87,16 @@ export function getComboboxGroupContext() {
   return getContext<ComboboxGroupContext | undefined>(COMBOBOX_GROUP_CONTEXT);
 }
 
-export function normalizeComboboxItem(item: ComboboxItem): NormalizedComboboxItem {
-  if (typeof item === 'string') return { label: item, value: item, raw: item };
+export function normalizeComboboxItem(
+  item: ComboboxItem,
+): NormalizedComboboxItem {
+  if (typeof item === "string") return { label: item, value: item, raw: item };
 
   const value = item;
   return {
-    label: String(item.label ?? item.value ?? ''),
+    label: String(item.label ?? item.value ?? ""),
     value,
     disabled: item.disabled,
-    raw: item
+    raw: item,
   };
 }

--- a/packages/kumo-svelte/src/lib/components/combobox/index.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/index.ts
@@ -1,20 +1,20 @@
-import Root from './Combobox.svelte';
-import Content from './ComboboxContent.svelte';
-import TriggerInput from './ComboboxTriggerInput.svelte';
-import TriggerValue from './ComboboxTriggerValue.svelte';
-import TriggerMultipleWithInput from './ComboboxTriggerMultipleWithInput.svelte';
-import Item from './ComboboxItem.svelte';
-import Chip from './ComboboxChip.svelte';
-import Input from './ComboboxInput.svelte';
-import Empty from './ComboboxEmpty.svelte';
-import GroupLabel from './ComboboxGroupLabel.svelte';
-import Group from './ComboboxGroup.svelte';
-import List from './ComboboxList.svelte';
-import Collection from './ComboboxCollection.svelte';
-import Trigger from './ComboboxTrigger.svelte';
-import Value from './ComboboxValue.svelte';
-import Icon from './ComboboxIcon.svelte';
-import { createKumoFilter } from '../filter';
+import Root from "./Combobox.svelte";
+import Content from "./ComboboxContent.svelte";
+import TriggerInput from "./ComboboxTriggerInput.svelte";
+import TriggerValue from "./ComboboxTriggerValue.svelte";
+import TriggerMultipleWithInput from "./ComboboxTriggerMultipleWithInput.svelte";
+import Item from "./ComboboxItem.svelte";
+import Chip from "./ComboboxChip.svelte";
+import Input from "./ComboboxInput.svelte";
+import Empty from "./ComboboxEmpty.svelte";
+import GroupLabel from "./ComboboxGroupLabel.svelte";
+import Group from "./ComboboxGroup.svelte";
+import List from "./ComboboxList.svelte";
+import Collection from "./ComboboxCollection.svelte";
+import Trigger from "./ComboboxTrigger.svelte";
+import Value from "./ComboboxValue.svelte";
+import Icon from "./ComboboxIcon.svelte";
+import { createKumoFilter } from "../filter";
 
 export const Combobox = Object.assign(Root, {
   Content,
@@ -32,7 +32,7 @@ export const Combobox = Object.assign(Root, {
   Trigger,
   Value,
   Icon,
-  useFilter: createKumoFilter
+  useFilter: createKumoFilter,
 });
 
 export {
@@ -51,7 +51,11 @@ export {
   Collection as ComboboxCollection,
   Trigger as ComboboxTrigger,
   Value as ComboboxValue,
-  Icon as ComboboxIcon
+  Icon as ComboboxIcon,
 };
 
-export type { ComboboxInputSide, ComboboxItem as ComboboxOption, ComboboxSize } from './context';
+export type {
+  ComboboxInputSide,
+  ComboboxItem as ComboboxOption,
+  ComboboxSize,
+} from "./context";

--- a/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
@@ -79,6 +79,26 @@ const rows: PropRow[] = [
     "type": "(open: boolean) => void",
     "required": false,
     "description": "Called when open state changes."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Prevents interaction with the field."
+  },
+  {
+    "prop": "size",
+    "type": "'xs' | 'sm' | 'base' | 'lg'",
+    "required": false,
+    "default": "\"base\"",
+    "description": "Size preset."
+  },
+  {
+    "prop": "filter",
+    "type": "((item: AutocompleteItem, query: string) => boolean) | null",
+    "required": false,
+    "description": "Custom filter function. Set to null to disable filtering."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Autocomplete.ts
@@ -1,105 +1,105 @@
-import type { PropRow } from '../prop-types';
+import type { PropRow } from "../prop-types";
 
 const rows: PropRow[] = [
   {
-    "prop": "items",
-    "type": "unknown[]",
-    "required": true,
-    "description": "Array of items to display in the dropdown."
+    prop: "items",
+    type: "unknown[]",
+    required: true,
+    description: "Array of items to display in the dropdown.",
   },
   {
-    "prop": "value",
-    "type": "string | number | string[]",
-    "required": false,
-    "description": "Controlled input value."
+    prop: "value",
+    type: "string | number | string[]",
+    required: false,
+    description: "Controlled input value.",
   },
   {
-    "prop": "open",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Controlled open state."
+    prop: "open",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Controlled open state.",
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
+    prop: "children",
+    type: "Snippet",
+    required: false,
+    description: "Child snippet rendered by the component.",
   },
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    prop: "class",
+    type: "string",
+    required: false,
+    description: "Additional classes merged onto the root element.",
   },
   {
-    "prop": "label",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Visible label content."
+    prop: "label",
+    type: "string | Snippet",
+    required: false,
+    description: "Visible label content.",
   },
   {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
+    prop: "required",
+    type: "boolean",
+    required: false,
+    description: "Marks the field as required.",
   },
   {
-    "prop": "labelTooltip",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Optional help content for the label."
+    prop: "labelTooltip",
+    type: "string | Snippet",
+    required: false,
+    description: "Optional help content for the label.",
   },
   {
-    "prop": "description",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Supporting description text."
+    prop: "description",
+    type: "string | Snippet",
+    required: false,
+    description: "Supporting description text.",
   },
   {
-    "prop": "error",
-    "type": "FieldError",
-    "required": false,
-    "description": "Validation error message or matcher."
+    prop: "error",
+    type: "FieldError",
+    required: false,
+    description: "Validation error message or matcher.",
   },
   {
-    "prop": "defaultValue",
-    "type": "string | number | string[]",
-    "required": false,
-    "description": "Uncontrolled default input value."
+    prop: "defaultValue",
+    type: "string | number | string[]",
+    required: false,
+    description: "Uncontrolled default input value.",
   },
   {
-    "prop": "onValueChange",
-    "type": "(value: string | number | string[]) => void",
-    "required": false,
-    "description": "Called when the value changes."
+    prop: "onValueChange",
+    type: "(value: string | number | string[]) => void",
+    required: false,
+    description: "Called when the value changes.",
   },
   {
-    "prop": "onOpenChange",
-    "type": "(open: boolean) => void",
-    "required": false,
-    "description": "Called when open state changes."
+    prop: "onOpenChange",
+    type: "(open: boolean) => void",
+    required: false,
+    description: "Called when open state changes.",
   },
   {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Prevents interaction with the field."
+    prop: "disabled",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Prevents interaction with the field.",
   },
   {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
+    prop: "size",
+    type: "'xs' | 'sm' | 'base' | 'lg'",
+    required: false,
+    default: '"base"',
+    description: "Size preset.",
   },
   {
-    "prop": "filter",
-    "type": "((item: AutocompleteItem, query: string) => boolean) | null",
-    "required": false,
-    "description": "Custom filter function. Set to null to disable filtering."
-  }
+    prop: "filter",
+    type: "((item: AutocompleteItem, query: string) => boolean) | null",
+    required: false,
+    description: "Custom filter function. Set to null to disable filtering.",
+  },
 ];
 
 export default rows;

--- a/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
@@ -1,111 +1,111 @@
-import type { PropRow } from '../prop-types';
+import type { PropRow } from "../prop-types";
 
 const rows: PropRow[] = [
   {
-    "prop": "size",
-    "type": "'xs' | 'sm' | 'base' | 'lg'",
-    "required": false,
-    "default": "\"base\"",
-    "description": "Size preset."
+    prop: "size",
+    type: "'xs' | 'sm' | 'base' | 'lg'",
+    required: false,
+    default: '"base"',
+    description: "Size preset.",
   },
   {
-    "prop": "items",
-    "type": "unknown[]",
-    "required": true,
-    "description": "Array of items to display in the dropdown."
+    prop: "items",
+    type: "unknown[]",
+    required: true,
+    description: "Array of items to display in the dropdown.",
   },
   {
-    "prop": "value",
-    "type": "unknown",
-    "required": false,
-    "description": "Controlled value."
+    prop: "value",
+    type: "unknown",
+    required: false,
+    description: "Controlled value.",
   },
   {
-    "prop": "children",
-    "type": "Snippet",
-    "required": false,
-    "description": "Child snippet rendered by the component."
+    prop: "children",
+    type: "Snippet",
+    required: false,
+    description: "Child snippet rendered by the component.",
   },
   {
-    "prop": "class",
-    "type": "string",
-    "required": false,
-    "description": "Additional classes merged onto the root element."
+    prop: "class",
+    type: "string",
+    required: false,
+    description: "Additional classes merged onto the root element.",
   },
   {
-    "prop": "label",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Visible label content."
+    prop: "label",
+    type: "string | Snippet",
+    required: false,
+    description: "Visible label content.",
   },
   {
-    "prop": "required",
-    "type": "boolean",
-    "required": false,
-    "description": "Marks the field as required."
+    prop: "required",
+    type: "boolean",
+    required: false,
+    description: "Marks the field as required.",
   },
   {
-    "prop": "labelTooltip",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Optional help content for the label."
+    prop: "labelTooltip",
+    type: "string | Snippet",
+    required: false,
+    description: "Optional help content for the label.",
   },
   {
-    "prop": "description",
-    "type": "string | Snippet",
-    "required": false,
-    "description": "Supporting description text."
+    prop: "description",
+    type: "string | Snippet",
+    required: false,
+    description: "Supporting description text.",
   },
   {
-    "prop": "error",
-    "type": "FieldError",
-    "required": false,
-    "description": "Validation error message or matcher."
+    prop: "error",
+    type: "FieldError",
+    required: false,
+    description: "Validation error message or matcher.",
   },
   {
-    "prop": "onValueChange",
-    "type": "(value: unknown) => void",
-    "required": false,
-    "description": "Called when the value changes."
+    prop: "onValueChange",
+    type: "(value: unknown) => void",
+    required: false,
+    description: "Called when the value changes.",
   },
   {
-    "prop": "multiple",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Enables multiple selection."
+    prop: "multiple",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Enables multiple selection.",
   },
   {
-    "prop": "onOpenChange",
-    "type": "(open: boolean) => void",
-    "required": false,
-    "description": "Called when open state changes."
+    prop: "onOpenChange",
+    type: "(open: boolean) => void",
+    required: false,
+    description: "Called when open state changes.",
   },
   {
-    "prop": "disabled",
-    "type": "boolean",
-    "required": false,
-    "default": "false",
-    "description": "Prevents interaction with the field."
+    prop: "disabled",
+    type: "boolean",
+    required: false,
+    default: "false",
+    description: "Prevents interaction with the field.",
   },
   {
-    "prop": "defaultValue",
-    "type": "unknown",
-    "required": false,
-    "description": "Initial value."
+    prop: "defaultValue",
+    type: "unknown",
+    required: false,
+    description: "Initial value.",
   },
   {
-    "prop": "filter",
-    "type": "((item: ComboboxItem, query: string) => boolean) | null",
-    "required": false,
-    "description": "Custom filter function. Set to null to disable filtering."
+    prop: "filter",
+    type: "((item: ComboboxItem, query: string) => boolean) | null",
+    required: false,
+    description: "Custom filter function. Set to null to disable filtering.",
   },
   {
-    "prop": "isItemEqualToValue",
-    "type": "(item: unknown, value: unknown) => boolean",
-    "required": false,
-    "description": "Custom value equality matcher function."
-  }
+    prop: "isItemEqualToValue",
+    type: "(item: unknown, value: unknown) => boolean",
+    required: false,
+    description: "Custom value equality matcher function.",
+  },
 ];
 
 export default rows;

--- a/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Combobox.ts
@@ -80,6 +80,31 @@ const rows: PropRow[] = [
     "type": "(open: boolean) => void",
     "required": false,
     "description": "Called when open state changes."
+  },
+  {
+    "prop": "disabled",
+    "type": "boolean",
+    "required": false,
+    "default": "false",
+    "description": "Prevents interaction with the field."
+  },
+  {
+    "prop": "defaultValue",
+    "type": "unknown",
+    "required": false,
+    "description": "Initial value."
+  },
+  {
+    "prop": "filter",
+    "type": "((item: ComboboxItem, query: string) => boolean) | null",
+    "required": false,
+    "description": "Custom filter function. Set to null to disable filtering."
+  },
+  {
+    "prop": "isItemEqualToValue",
+    "type": "(item: unknown, value: unknown) => boolean",
+    "required": false,
+    "description": "Custom value equality matcher function."
   }
 ];
 

--- a/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
+++ b/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
@@ -17,13 +17,7 @@ sourceFile: "components/autocomplete"
   <ComponentExample demo="AutocompleteDemo" />
 </ComponentSection>
 
-<ComponentSection>
-
-## Contribution
-
-The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for this component were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
-
-</ComponentSection>
+The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for Autocomplete were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
 
 <!-- Installation -->
 

--- a/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
+++ b/packages/kumo-svelte/src/routes/components/autocomplete/+page.md
@@ -17,6 +17,14 @@ sourceFile: "components/autocomplete"
   <ComponentExample demo="AutocompleteDemo" />
 </ComponentSection>
 
+<ComponentSection>
+
+## Contribution
+
+The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for this component were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
+
+</ComponentSection>
+
 <!-- Installation -->
 
 <ComponentSection>
@@ -26,13 +34,13 @@ sourceFile: "components/autocomplete"
 ### Barrel
 
 ```typescript
-import { Autocomplete } from 'kumo-svelte';
+import { Autocomplete } from "kumo-svelte";
 ```
 
 ### Granular
 
 ```typescript
-import { Autocomplete } from 'kumo-svelte/components/autocomplete';
+import { Autocomplete } from "kumo-svelte/components/autocomplete";
 ```
 
 </ComponentSection>
@@ -43,10 +51,9 @@ import { Autocomplete } from 'kumo-svelte/components/autocomplete';
 
 ## When to use
 
-
 Use `Autocomplete` when the input value can be free-form text and suggestions
-  are optional hints. Use `Combobox` instead when the selected value must come
-  from the predefined list.
+are optional hints. Use `Combobox` instead when the selected value must come
+from the predefined list.
 
 </ComponentSection>
 
@@ -55,7 +62,6 @@ Use `Autocomplete` when the input value can be free-form text and suggestions
 <ComponentSection>
 
 ## Controlled
-
 
 Pass `value` and `onValueChange` for controlled usage.
 
@@ -68,7 +74,6 @@ Pass `value` and `onValueChange` for controlled usage.
 
 ## With Field
 
-
 Add `label`, `description`, and `required` to enable the built-in Field wrapper.
 
 <ComponentExample demo="AutocompleteWithFieldDemo" />
@@ -79,7 +84,6 @@ Add `label`, `description`, and `required` to enable the built-in Field wrapper.
 <ComponentSection>
 
 ## Error State
-
 
 Display validation errors with the `error` prop.
 
@@ -92,7 +96,6 @@ Display validation errors with the `error` prop.
 
 ## Grouped
 
-
 Group items into categories using `Autocomplete.Group` and `Autocomplete.GroupLabel`.
 
 <ComponentExample demo="AutocompleteGroupedDemo" />
@@ -104,9 +107,8 @@ Group items into categories using `Autocomplete.Group` and `Autocomplete.GroupLa
 
 ## Sizes
 
-
 The `size` prop on `Autocomplete.InputGroup` supports four variants matching the
-  Input component: `xs`, `sm`, `base` (default), and `lg`.
+Input component: `xs`, `sm`, `base` (default), and `lg`.
 
 <ComponentExample demo="AutocompleteSizesDemo" />
 </ComponentSection>
@@ -161,13 +163,11 @@ pass `filter={null}`:
 
 ### Autocomplete
 
-
 Root component. Wraps all sub-components and manages state.
 
 <PropsTable component="Autocomplete" />
 
 ### Autocomplete.InputGroup
-
 
 Autocomplete text input with Input component styling.
 
@@ -175,13 +175,11 @@ Autocomplete text input with Input component styling.
 
 ### Autocomplete.Content
 
-
 Dropdown popup container.
 
 <PropsTable component="Autocomplete.Content" />
 
 ### Autocomplete.List
-
 
 Scrollable list container with render prop.
 
@@ -189,13 +187,11 @@ Scrollable list container with render prop.
 
 ### Autocomplete.Item
 
-
 Individual suggestion item in the list.
 
 <PropsTable component="Autocomplete.Item" />
 
 ### Autocomplete.Group
-
 
 Groups items under a heading.
 
@@ -203,20 +199,17 @@ Groups items under a heading.
 
 ### Autocomplete.GroupLabel
 
-
 Heading label for a group.
 
 <PropsTable component="Autocomplete.GroupLabel" />
 
 ### Autocomplete.Collection
 
-
 Item container within a group.
 
 <PropsTable component="Autocomplete.Collection" />
 
 ### Autocomplete.Separator
-
 
 Horizontal divider between items.
 

--- a/packages/kumo-svelte/src/routes/components/combobox/+page.md
+++ b/packages/kumo-svelte/src/routes/components/combobox/+page.md
@@ -17,13 +17,7 @@ baseUIComponent: "combobox"
   <ComponentExample demo="ComboboxDemo" />
 </ComponentSection>
 
-<ComponentSection>
-
-## Contribution
-
-The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for this component were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
-
-</ComponentSection>
+The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for Combobox were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
 
 <!-- Installation -->
 

--- a/packages/kumo-svelte/src/routes/components/combobox/+page.md
+++ b/packages/kumo-svelte/src/routes/components/combobox/+page.md
@@ -17,6 +17,14 @@ baseUIComponent: "combobox"
   <ComponentExample demo="ComboboxDemo" />
 </ComponentSection>
 
+<ComponentSection>
+
+## Contribution
+
+The Bits UI primitive integration, keyboard-navigation tests, and prop documentation for this component were contributed by [Teddy (@uhteddy)](https://github.com/uhteddy).
+
+</ComponentSection>
+
 <!-- Installation -->
 
 <ComponentSection>
@@ -26,13 +34,13 @@ baseUIComponent: "combobox"
 ### Barrel
 
 ```typescript
-import { Combobox } from 'kumo-svelte';
+import { Combobox } from "kumo-svelte";
 ```
 
 ### Granular
 
 ```typescript
-import { Combobox } from 'kumo-svelte/components/combobox';
+import { Combobox } from "kumo-svelte/components/combobox";
 ```
 
 </ComponentSection>
@@ -74,12 +82,10 @@ import { Combobox } from 'kumo-svelte/components/combobox';
 
 ### Sizes
 
-
 The Combobox supports four size variants that match the Input component: `xs`,
-  `sm`, `base` (default), and `lg`.
+`sm`, `base` (default), and `lg`.
 
 <ComponentExample demo="ComboboxSizesDemo" />
-
 
 Size also applies to `TriggerValue` (searchable inside variant):
 
@@ -90,9 +96,8 @@ Size also applies to `TriggerValue` (searchable inside variant):
 
 ### Searchable Item (Inside)
 
-
 A searchable select component inside popup that allows users to filter and
-    select.
+select.
 
   <ComponentExample demo="ComboboxSearchableInsideDemo" />
 </ComponentSection>
@@ -101,9 +106,8 @@ A searchable select component inside popup that allows users to filter and
 
 ### Searchable Select with Placeholder
 
-
 Use `TriggerValue` with a `placeholder` prop to create a searchable Select-style field.
-    The placeholder is displayed until a value is selected.
+The placeholder is displayed until a value is selected.
 
   <ComponentExample demo="ComboboxSearchableSelectDemo" />
 </ComponentSection>
@@ -111,7 +115,6 @@ Use `TriggerValue` with a `placeholder` prop to create a searchable Select-style
 <ComponentSection>
 
 ### Custom Trigger
-
 
 Use <code>Combobox.Trigger</code> with a <code>render</code> prop to replace the default input-like trigger with your own element. Pair with <code>Combobox.Value</code> to display the selected value. Useful for account switchers, sidebar navigation, or anywhere the default chrome doesn't fit.
 
@@ -123,7 +126,6 @@ Use <code>Combobox.Trigger</code> with a <code>render</code> prop to replace the
 
 ### Grouped
 
-
 Group items into categories using the Group and GroupLabel components.
 
   <ComponentExample demo="ComboboxGroupedDemo" />
@@ -132,7 +134,6 @@ Group items into categories using the Group and GroupLabel components.
 <ComponentSection>
 
 ### Multiple
-
 
 Allow users to select multiple options from the list.
 
@@ -143,7 +144,6 @@ Allow users to select multiple options from the list.
 
 ### With Field
 
-
 Add label and description using the built-in Field wrapper.
 
   <ComponentExample demo="ComboboxWithFieldDemo" />
@@ -152,7 +152,6 @@ Add label and description using the built-in Field wrapper.
 <ComponentSection>
 
 ### Disabled
-
 
 Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` and `TriggerValue`.
 
@@ -163,7 +162,6 @@ Pass the `disabled` prop to prevent interaction. Works with both `TriggerInput` 
 
 ### Disabled Items
 
-
 Pass the `disabled` prop to an individual `Combobox.Item` to make it non-selectable. Disabled rows are rendered with a muted style and skipped during keyboard navigation selection.
 
   <ComponentExample demo="ComboboxDisabledItemsDemo" />
@@ -172,7 +170,6 @@ Pass the `disabled` prop to an individual `Combobox.Item` to make it non-selecta
 <ComponentSection>
 
 ### Error State
-
 
 Display validation errors with the error prop.
 
@@ -223,12 +220,9 @@ pass `filter={null}`:
 
 ## Customizing Dropdown Height
 
-
 By default, <code class="text-surface">Combobox.Content</code> has a max height of <code class="text-surface">24rem</code> (384px) or the available viewport space, whichever is smaller. The dropdown scrolls automatically when content exceeds this height.
 
-
 To customize the max height, pass a class to <code class="text-surface">Combobox.Content</code>:
-
 
 ```svelte
 // Shorter dropdown (200px)
@@ -250,20 +244,17 @@ To customize the max height, pass a class to <code class="text-surface">Combobox
 
 ### Combobox
 
-
 Root component for the searchable select.
 
 <PropsTable component="Combobox" />
 
 ### Combobox.Content
 
-
 Dropdown container for the list.
 
 <PropsTable component="Combobox.Content" />
 
 ### Combobox.Item
-
 
 Individual selectable option.
 


### PR DESCRIPTION
## Summary

Ports the focused changes from [uhteddy/kumo-svelte](https://github.com/uhteddy/kumo-svelte) into `maxffarrell/kumo-svelte`.

- Integrates `bits-ui` Combobox primitives for Combobox and Autocomplete input, trigger, item, viewport, and portal behavior.
- Adds keyboard-navigation coverage and improves disabled, multiple-value, serialization, focus, ARIA, and popup positioning behavior.
- Updates generated component metadata and prop documentation.
- Credits Teddy (@uhteddy) in the README, both component docs, and changeset.

## Why

The fork changes are directly parity-relevant: they align these components with the repository's Bits UI foundation and close behavior/accessibility gaps rather than introducing unrelated changes.

## Validation

- `pnpm --filter kumo-svelte test -- packages/kumo-svelte/src/lib/components/autocomplete/autocomplete.test.ts packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts`
  - 18 test files passed; 61 tests passed; 3 skipped.
- `pnpm --filter kumo-svelte check`
  - 630 files checked; 0 errors; 0 warnings.
- `pnpm --filter kumo-svelte build:package`
  - Passed.
- `git diff --check` and Prettier check passed.
- Pre-push changeset validation passed.

## Attribution

The implementation and focused tests are preserved from Teddy's authored commits, and the documentation/README explicitly credits [Teddy (@uhteddy)](https://github.com/uhteddy).