### PR TITLE
Port applicable Kumo 2.9.2 fixes

### DIFF
--- a/.changeset/kumo-2-9-2-tabs.md
+++ b/.changeset/kumo-2-9-2-tabs.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Port the Kumo 2.9.2 Tabs fixes: flatten overflow carets, limit overflow controls to segmented Tabs, and focus the caret target.

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
@@ -377,7 +377,7 @@
           !isSegmented && 'w-8'
         )}
       >
-        <span class={cn('flex items-center justify-center rounded-full bg-kumo-elevated text-kumo-subtle shadow-sm ring ring-kumo-line transition-colors hover:bg-kumo-base hover:text-kumo-default', isSm ? 'size-5' : 'size-6', control.side === 'start' ? 'ml-1' : 'mr-1')}>
+        <span class={cn('flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default', isSm ? 'size-5' : 'size-6', control.side === 'start' ? 'ml-1' : 'mr-1')}>
           <svg viewBox="0 0 16 16" fill="none" class="size-3.5" aria-hidden="true">
             <path d={control.side === 'start' ? 'M9.25 4.25L5.75 8L9.25 11.75' : 'M6.75 4.25L10.25 8L6.75 11.75'} stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
           </svg>

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
@@ -355,35 +355,36 @@
       ></div>
     </TabsPrimitive.List>
 
-    {#each [
-      { side: 'start', visible: canScrollStart, label: labels.scrollStart ?? 'Scroll tabs left' },
-      { side: 'end', visible: canScrollEnd, label: labels.scrollEnd ?? 'Scroll tabs right' }
-    ] as control}
-      <button
-        type="button"
-        data-kumo-component="Tabs"
-        data-kumo-part="overflow-control"
-        data-side={control.side}
-        aria-label={control.label}
-        aria-hidden={!control.visible}
-        tabindex={control.visible ? 0 : -1}
-        onclick={() => scrollTabs(control.side as 'start' | 'end')}
-        class={cn(
-          'absolute inset-y-0 z-3 flex items-center border-0 bg-transparent p-0 transition-opacity duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand',
-          control.side === 'start' ? 'left-0 justify-start bg-linear-to-r' : 'right-0 justify-end bg-linear-to-l',
-          control.visible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
-          isSegmented ? 'from-kumo-recessed via-kumo-recessed/95 to-transparent' : 'from-kumo-base via-kumo-base/95 to-transparent',
-          isSegmented && (isSm ? 'w-8 rounded-md' : 'w-10 rounded-lg'),
-          !isSegmented && 'w-8'
-        )}
-      >
-        <span class={cn('flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default', isSm ? 'size-5' : 'size-6', control.side === 'start' ? 'ml-1' : 'mr-1')}>
-          <svg viewBox="0 0 16 16" fill="none" class="size-3.5" aria-hidden="true">
-            <path d={control.side === 'start' ? 'M9.25 4.25L5.75 8L9.25 11.75' : 'M6.75 4.25L10.25 8L6.75 11.75'} stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-          </svg>
-        </span>
-      </button>
-    {/each}
+    {#if isSegmented}
+      {#each [
+        { side: 'start', visible: canScrollStart, label: labels.scrollStart ?? 'Scroll tabs left' },
+        { side: 'end', visible: canScrollEnd, label: labels.scrollEnd ?? 'Scroll tabs right' }
+      ] as control}
+        <button
+          type="button"
+          data-kumo-component="Tabs"
+          data-kumo-part="overflow-control"
+          data-side={control.side}
+          aria-label={control.label}
+          aria-hidden={!control.visible}
+          tabindex={control.visible ? 0 : -1}
+          onclick={() => scrollTabs(control.side as 'start' | 'end')}
+          class={cn(
+            'absolute inset-y-0 z-3 flex items-center border-0 bg-transparent p-0 transition-opacity duration-150 focus:outline-none focus-visible:[&>span]:ring-2 focus-visible:[&>span]:ring-kumo-brand',
+            control.side === 'start' ? 'left-0 justify-start bg-linear-to-r' : 'right-0 justify-end bg-linear-to-l',
+            control.visible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+            'from-kumo-recessed via-kumo-recessed/95 to-transparent',
+            isSm ? 'w-8 rounded-md' : 'w-10 rounded-lg'
+          )}
+        >
+          <span class={cn('flex items-center justify-center text-kumo-subtle transition-colors hover:text-kumo-default', isSm ? 'size-5 rounded-sm' : 'size-6 rounded-md', control.side === 'start' ? 'ml-1' : 'mr-1')}>
+            <svg viewBox="0 0 16 16" fill="none" class="size-3.5" aria-hidden="true">
+              <path d={control.side === 'start' ? 'M9.25 4.25L5.75 8L9.25 11.75' : 'M6.75 4.25L10.25 8L6.75 11.75'} stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+            </svg>
+          </span>
+        </button>
+      {/each}
+    {/if}
 
     {#each normalizedItems as tab (tab.value)}
       {#if tab.content}

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.test.ts
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import Tabs from './Tabs.svelte';
 
 describe('Tabs', () => {
-  it('keeps underline tabs horizontally scrollable for overflow controls', () => {
+  it('keeps underline tabs horizontally scrollable without overflow controls', () => {
     render(Tabs, {
       variant: 'underline',
       value: 'overview',
@@ -16,5 +16,16 @@ describe('Tabs', () => {
     const list = screen.getByRole('tablist');
     expect(list.className).toContain('overflow-x-auto');
     expect(list.className).toContain('overflow-y-hidden');
+    expect(document.querySelectorAll('[data-kumo-part="overflow-control"]')).toHaveLength(0);
+  });
+
+  it('renders overflow controls for segmented tabs', () => {
+    render(Tabs, {
+      variant: 'segmented',
+      value: 'overview',
+      items: [{ value: 'overview', label: 'Overview' }]
+    });
+
+    expect(document.querySelectorAll('[data-kumo-part="overflow-control"]')).toHaveLength(2);
   });
 });

--- a/packages/kumo-svelte/src/lib/docs/ThemeToggle.svelte
+++ b/packages/kumo-svelte/src/lib/docs/ThemeToggle.svelte
@@ -1,39 +1,80 @@
 <script lang="ts">
+  import DesktopIcon from 'phosphor-svelte/lib/DesktopIcon';
   import MoonIcon from 'phosphor-svelte/lib/MoonIcon';
   import SunIcon from 'phosphor-svelte/lib/SunIcon';
-  import { onMount } from 'svelte';
+  import { onMount, type Component } from 'svelte';
   import { Button } from '$lib/components/button';
+  import { DropdownMenu } from '$lib/components/dropdown-menu';
 
-  let theme = $state<'light' | 'dark'>('light');
+  type ThemePreference = 'light' | 'dark' | 'system';
+
+  const themeOptions: Array<{ value: ThemePreference; label: string; icon: Component }> = [
+    { value: 'light', label: 'Light', icon: SunIcon },
+    { value: 'dark', label: 'Dark', icon: MoonIcon },
+    { value: 'system', label: 'System', icon: DesktopIcon }
+  ];
+
+  function isThemePreference(value: string | null): value is ThemePreference {
+    return value === 'light' || value === 'dark' || value === 'system';
+  }
+
+  let theme = $state<ThemePreference>('system');
   let mounted = $state(false);
 
   onMount(() => {
     mounted = true;
     const stored = localStorage.getItem('theme');
-    if (stored === 'dark' || stored === 'light') {
-      theme = stored;
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      theme = 'dark';
-    }
+    theme = isThemePreference(stored) ? stored : 'system';
+
+    const handleThemeChange = (event: Event) => {
+      const nextTheme = (event as CustomEvent<{ theme?: string }>).detail?.theme ?? null;
+      if (isThemePreference(nextTheme)) theme = nextTheme;
+    };
+
+    window.addEventListener('kumo:theme-change', handleThemeChange);
+    return () => window.removeEventListener('kumo:theme-change', handleThemeChange);
   });
 
-  function toggleTheme() {
-    const next = theme === 'light' ? 'dark' : 'light';
-    theme = next;
-    localStorage.setItem('theme', next);
-    document.documentElement.setAttribute('data-mode', next);
+  function selectTheme(nextTheme: string) {
+    if (!isThemePreference(nextTheme)) return;
+
+    const resolvedTheme =
+      nextTheme === 'system'
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'
+        : nextTheme;
+
+    theme = nextTheme;
+    localStorage.setItem('theme', nextTheme);
+    document.documentElement.setAttribute('data-mode', resolvedTheme);
+    window.dispatchEvent(
+      new CustomEvent('kumo:theme-change', { detail: { theme: nextTheme, resolvedTheme } })
+    );
   }
 </script>
 
-<Button
-  variant="ghost"
-  shape="square"
-  aria-label={mounted ? `Switch to ${theme === 'light' ? 'dark' : 'light'} mode` : 'Toggle theme'}
-  onclick={toggleTheme}
->
-  {#if mounted && theme === 'dark'}
-    <SunIcon size={20} />
-  {:else}
-    <MoonIcon size={20} />
-  {/if}
-</Button>
+<DropdownMenu>
+  <DropdownMenu.Trigger>
+    <Button variant="ghost" shape="square" aria-label={mounted ? `Select theme, current theme is ${theme}` : 'Select theme'}>
+      {#if !mounted || theme === 'system'}
+        <DesktopIcon size={20} />
+      {:else if theme === 'dark'}
+        <MoonIcon size={20} />
+      {:else}
+        <SunIcon size={20} />
+      {/if}
+    </Button>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content align="end">
+    <DropdownMenu.Label>Theme</DropdownMenu.Label>
+    <DropdownMenu.RadioGroup bind:value={theme} onValueChange={selectTheme}>
+      {#each themeOptions as option}
+        <DropdownMenu.RadioItem value={option.value} icon={option.icon}>
+          {option.label}
+          <DropdownMenu.RadioItemIndicator />
+        </DropdownMenu.RadioItem>
+      {/each}
+    </DropdownMenu.RadioGroup>
+  </DropdownMenu.Content>
+</DropdownMenu>

--- a/packages/kumo-svelte/src/routes/+layout.svelte
+++ b/packages/kumo-svelte/src/routes/+layout.svelte
@@ -17,11 +17,52 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=optional" />
   <script>
     (function () {
-      const stored = localStorage.getItem('theme');
-      if (stored) {
-        document.documentElement.setAttribute('data-mode', stored);
-      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.setAttribute('data-mode', 'dark');
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+      function resolveTheme(theme) {
+        return theme === 'system' ? (systemTheme.matches ? 'dark' : 'light') : theme;
+      }
+
+      function setTheme(theme) {
+        const resolvedTheme = resolveTheme(theme);
+        localStorage.setItem('theme', theme);
+        document.documentElement.setAttribute('data-mode', resolvedTheme);
+        window.dispatchEvent(
+          new CustomEvent('kumo:theme-change', { detail: { theme, resolvedTheme } })
+        );
+      }
+
+      function applyStoredTheme() {
+        const stored = localStorage.getItem('theme');
+        const theme = ['light', 'dark', 'system'].includes(stored) ? stored : 'system';
+        document.documentElement.setAttribute('data-mode', resolveTheme(theme));
+      }
+
+      applyStoredTheme();
+
+      if (!window.__kumoThemeInit) {
+        window.__kumoThemeInit = true;
+        systemTheme.addEventListener('change', () => {
+          const stored = localStorage.getItem('theme');
+          if (!stored || stored === 'system') setTheme('system');
+        });
+
+        document.addEventListener('keydown', (event) => {
+          if (event.defaultPrevented || event.repeat) return;
+          if (event.metaKey || event.ctrlKey || event.altKey) return;
+          if (event.key?.toLowerCase() !== 'd') return;
+
+          const target = event.target;
+          if (
+            target instanceof HTMLElement &&
+            (target.isContentEditable || target.closest('input, textarea, select, [contenteditable]'))
+          ) return;
+
+          event.preventDefault();
+          const current = localStorage.getItem('theme');
+          const nextTheme = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+          setTheme(nextTheme);
+        });
       }
     })();
   </script>

--- a/packages/kumo-svelte/src/routes/colors/+page.md
+++ b/packages/kumo-svelte/src/routes/colors/+page.md
@@ -4,7 +4,6 @@ description: "Kumo uses semantic color tokens that automatically adapt to light 
 ---
 
 <script>
-  import { Badge } from 'kumo-svelte';
   import Callout from '$lib/docs/Callout.svelte';
   import ComponentExample from '$lib/docs/ComponentExample.svelte';
   import ComponentSection from '$lib/docs/ComponentSection.svelte';
@@ -322,11 +321,11 @@ Use the solid token on icons, status dots, borders and rings. Banners and badges
     </thead>
     <tbody>
       <tr>
-        <td><code>kumo-hairline</code><span class="not-prose ml-2 inline-flex align-middle"><Badge variant="blue">New</Badge></span></td>
+        <td><code>kumo-hairline</code></td>
         <td>A border/ring color to distinguish between flat surfaces where no shadow is present (i.e. <code>LayerCard</code>).</td>
       </tr>
       <tr>
-        <td><code>kumo-hairline</code></td>
+        <td><code>kumo-line</code></td>
         <td>A thicker border/ring color that defines the edge of an elevated surface alongside a shadow.</td>
       </tr>
     </tbody>

--- a/packages/kumo-svelte/src/routes/components/tabs/+page.md
+++ b/packages/kumo-svelte/src/routes/components/tabs/+page.md
@@ -99,6 +99,12 @@ Tabs automatically scroll horizontally when there are many items.
 
 <ComponentExample demo="TabsManyDemo" />
 
+### Horizontal Overflow
+
+When segmented tabs overflow their container, scroll buttons appear at the
+clipped edge. Use them, horizontal scrolling, or mouse drag to reveal off-screen
+tabs.
+
 </ComponentSection>
 
 <!-- API Reference -->


### PR DESCRIPTION
## Summary

Port the applicable `@cloudflare/kumo@2.9.2` changes into Svelte, one commit at a time in upstream order:

- fix the duplicate `kumo-hairline` docs reference and restore `kumo-line`
- add the `light` / `dark` / `system` theme selector with OS-theme change handling and keyboard cycling
- flatten the Tabs overflow caret
- limit Tabs overflow controls to segmented Tabs and focus the caret target

The upstream screenshot-worker navigation hardening has no Svelte counterpart in this repository and was intentionally skipped.

## Validation

- `CI=true pnpm --filter kumo-svelte check` — 0 errors, 0 warnings
- `CI=true pnpm --filter kumo-svelte test` — 65 passed
- `CI=true pnpm --filter kumo-svelte build:package` — passed
- Final diff against `main` — 7 files, 166 additions, 62 deletions

Upstream source range: `@cloudflare/kumo@2.9.1..@cloudflare/kumo@2.9.2`.