### PR TITLE
fix: pop in Tabs indicator at measured size instead of growing from 0

### DIFF
--- a/.changeset/tabs-indicator-pop-in.md
+++ b/.changeset/tabs-indicator-pop-in.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Fix Tabs indicator (segmented pill and underline) growing from 0x0 on initial mount. The indicator stays hidden until the active tab is measured, then pops in at the correct size and position via the existing scale/opacity transition instead of animating its size up from zero.

--- a/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
+++ b/packages/kumo-svelte/src/lib/components/tabs/Tabs.svelte
@@ -106,6 +106,7 @@
   let activeTop = $state(0);
   let activeWidth = $state(0);
   let activeHeight = $state(0);
+  let indicatorMeasured = $state(false);
   let indicatorRendered = $state(false);
   let dragState: { pointerId: number; startX: number; scrollLeft: number; dragging: boolean } | null = null;
   let shouldSuppressClick = false;
@@ -139,6 +140,7 @@
 
     const activeTab = listEl.querySelector<HTMLElement>('[data-state="active"], [aria-selected="true"]');
     if (!activeTab) {
+      indicatorMeasured = false;
       indicatorRendered = false;
       return;
     }
@@ -149,7 +151,20 @@
     activeTop = tabRect.top - listRect.top;
     activeWidth = tabRect.width;
     activeHeight = tabRect.height;
-    indicatorRendered = true;
+
+    if (!indicatorMeasured) {
+      // First measurement: unhide the indicator at its real size while it is
+      // still in the pre-render state (scale-90 / opacity-0 via
+      // data-rendered=false), then flip data-rendered on a later frame so it
+      // pops in at the correct size and position instead of transitioning its
+      // size up from 0x0.
+      indicatorMeasured = true;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          indicatorRendered = true;
+        });
+      });
+    }
   }
 
   async function syncMeasurements() {
@@ -342,6 +357,7 @@
       {/each}
       <div
         aria-hidden="true"
+        hidden={!indicatorMeasured}
         data-rendered={indicatorRendered}
         class={cn(
           'absolute z-1 left-0 transition-all duration-200 data-[rendered=false]:scale-90 data-[rendered=false]:opacity-0',


### PR DESCRIPTION
Fixes the Tabs indicator being painted at `0×0` and visibly growing from 0 on mount (hard reload). The issue is tracked upstream at https://github.com/cloudflare/kumo/issues/714 — the same dead `data-[rendered=false]` styles exist in `cloudflare/kumo`'s `tabs.tsx`.

The indicator is kept hidden until the first measurement lands, mirroring Base UI's `hidden: !displayIndicator`. On first measurement it is unhidden at the real size while still in the pre-render state (`data-rendered=false` → `scale-90 opacity-0`), then `data-rendered` is flipped on a later frame (double `requestAnimationFrame`) so the existing `transition-all` animates only opacity/scale — the pill pops in at the correct size and position instead of animating its size from 0. Subsequent measurements (tab switches, resize, scroll) keep the normal sliding transition.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: hard-reloaded the Tabs docs page (`/components/tabs`) — the indicator pops in fully formed at the measured size, and switching tabs still animates normally.
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you checked whether this PR needs a changeset?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
