### PR TITLE
Port SkeletonLine styles into @layer base so class height overrides work

### DIFF
--- a/.changeset/skeleton-line-layer-base.md
+++ b/.changeset/skeleton-line-layer-base.md
@@ -1,0 +1,5 @@
+---
+"kumo-svelte": patch
+---
+
+Port the upstream SkeletonLine fix: move the `.skeleton-line` styles into `@layer base` so Tailwind utility classes (e.g. `h-6`) can override the default `0.5rem` height.

--- a/packages/kumo-svelte/src/lib/components/loader/SkeletonLine.svelte
+++ b/packages/kumo-svelte/src/lib/components/loader/SkeletonLine.svelte
@@ -62,31 +62,33 @@
     }
   }
 
-  :global(.skeleton-line) {
-    position: relative;
-    overflow: hidden;
-    border-radius: 2px;
-    height: 0.5rem;
-    width: var(--skeleton-width);
-    background-color: #f3f4f6;
-  }
+  @layer base {
+    :global(.skeleton-line) {
+      position: relative;
+      overflow: hidden;
+      border-radius: 2px;
+      height: 0.5rem;
+      width: var(--skeleton-width);
+      background-color: #f3f4f6;
+    }
 
-  :global(.skeleton-line::after) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    animation: shimmer var(--shimmer-duration, 1.5s) var(--shimmer-delay, 0s) infinite ease-in-out;
-    content: '';
-    background: linear-gradient(90deg, rgb(0 0 0 / 0%) 0%, rgb(0 0 0 / 8%) 50%, rgb(0 0 0 / 0%) 100%);
-  }
+    :global(.skeleton-line::after) {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      animation: shimmer var(--shimmer-duration, 1.5s) var(--shimmer-delay, 0s) infinite ease-in-out;
+      content: '';
+      background: linear-gradient(90deg, rgb(0 0 0 / 0%) 0%, rgb(0 0 0 / 8%) 50%, rgb(0 0 0 / 0%) 100%);
+    }
 
-  :global([data-mode='dark'] .skeleton-line) {
-    background-color: rgb(255 255 255 / 6%);
-  }
+    :global([data-mode='dark'] .skeleton-line) {
+      background-color: rgb(255 255 255 / 6%);
+    }
 
-  :global([data-mode='dark'] .skeleton-line::after) {
-    background: linear-gradient(90deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 5%) 50%, rgb(255 255 255 / 0%) 100%);
+    :global([data-mode='dark'] .skeleton-line::after) {
+      background: linear-gradient(90deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 5%) 50%, rgb(255 255 255 / 0%) 100%);
+    }
   }
 </style>


### PR DESCRIPTION
Fixes the documented **Custom Height** usage of `SkeletonLine` — `class`-based height overrides (e.g. `<SkeletonLine class="h-6" />`) currently render at the default `0.5rem` height because the component's unlayered `.skeleton-line` styles override Tailwind utility classes. Verified on the live docs: `h-2`/`h-4`/`h-6`/`h-8` all compute to 8px.

Ports upstream `cloudflare/kumo` commit `db75c51` (https://github.com/cloudflare/kumo/pull/336): move the `.skeleton-line` rules into `@layer base` so utilities can override the default height. The docs demo and Custom Height section for this were already ported; this is the missing CSS half of the upstream change.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: confirmed in the docs dev server that `class="h-2"` computes to 8px, `h-4` → 16px, `h-6` → 24px, `h-8` → 32px, and the shimmer animation still runs (Svelte rewrites the scoped `shimmer` keyframe reference inside `@layer base`; verified in the compiled output). Also confirmed the cascade fix in a consuming app where `skeleton-line h-5` previously computed to 8px.
  - [ ] Additional testing not necessary because: <!-- explain why -->

<!--
Have you checked whether this PR needs a changeset?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
