### PR TITLE
Port Cloudflare Kumo 2.13.0 through 2.13.1

### DIFF
--- a/.changeset/bright-clouds-align.md
+++ b/.changeset/bright-clouds-align.md
@@ -1,0 +1,10 @@
+---
+"kumo-svelte": minor
+---
+
+Port the applicable Cloudflare Kumo 2.13.0 through 2.13.1 changes to Svelte:
+
+- add unknown-total pagination and `Toolbar.Link`
+- expose Select popup placement controls and align its surfaces with Input
+- position dialogs near the viewport top
+- update Table, Text, InputGroup, Combobox, Tabs demo, and Tooltip styling for upstream parity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,17 +38,21 @@ jobs:
       # consider a publish-only script.
       - name: Create Version PR or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        # v2 is required for @changesets/cli v3. The v1 action relies on the
+        # Changesets v2 publish output and can publish successfully without
+        # detecting the package, pushing its tag, or creating its release.
+        uses: changesets/action@v2
         with:
-          version: pnpm run version
-          publish: pnpm run release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-script: pnpm run version
+          publish-script: pnpm run release
+          create-github-releases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       # Publish pkg-pr-new preview for Version Packages PR
       # (GITHUB_TOKEN PRs don't trigger workflows, so we do it here)
       - name: Publish package preview
-        if: ${{ steps.changesets.outputs.pullRequestNumber }}
+        if: ${{ steps.changesets.outputs.pr-number }}
         continue-on-error: true
         run: pnpm dlx pkg-pr-new publish --pnpm --compact --no-template ./packages/kumo-svelte

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -3934,6 +3934,11 @@
           "optional": true,
           "description": "Total number of items across all pages."
         },
+        "hasNextPage": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Whether another page exists when the total count is unknown."
+        },
         "class": {
           "type": "string",
           "optional": true,
@@ -4639,6 +4644,71 @@
           "type": "HTMLElement | string",
           "optional": true,
           "description": "Container element for the portal."
+        },
+        "side": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "top",
+            "right",
+            "bottom",
+            "left"
+          ],
+          "default": "bottom",
+          "description": "Preferred popup side; collision handling may flip it."
+        },
+        "sideOffset": {
+          "type": "number",
+          "optional": true,
+          "default": "4",
+          "description": "Distance between the trigger and popup."
+        },
+        "align": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "start",
+            "center",
+            "end"
+          ],
+          "default": "start",
+          "description": "Popup alignment along the trigger edge."
+        },
+        "alignOffset": {
+          "type": "number",
+          "optional": true,
+          "default": "0",
+          "description": "Additional offset along the alignment axis."
+        },
+        "customAnchor": {
+          "type": "HTMLElement | string",
+          "optional": true,
+          "description": "Custom floating-position anchor."
+        },
+        "strategy": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "absolute",
+            "fixed"
+          ],
+          "description": "CSS positioning strategy for the popup."
+        },
+        "avoidCollisions": {
+          "type": "boolean",
+          "optional": true,
+          "description": "Whether the popup should adjust to avoid viewport collisions."
+        },
+        "collisionPadding": {
+          "type": "enum",
+          "optional": true,
+          "values": [
+            "top",
+            "right",
+            "bottom",
+            "left"
+          ],
+          "description": "Padding between the popup and its collision boundary."
         }
       },
       "colors": [
@@ -6256,6 +6326,46 @@
               "type": "string",
               "optional": true,
               "description": "Additional classes merged onto the toolbar input group."
+            }
+          }
+        },
+        "Link": {
+          "description": "Toolbar.Link",
+          "props": {
+            "children": {
+              "type": "Snippet",
+              "optional": true,
+              "description": "Optional visible link label."
+            },
+            "href": {
+              "type": "string",
+              "optional": true,
+              "description": "Navigation destination."
+            },
+            "icon": {
+              "type": "Component",
+              "optional": true,
+              "description": "Optional icon component rendered before the label."
+            },
+            "shape": {
+              "type": "enum",
+              "optional": true,
+              "values": [
+                "base",
+                "square",
+                "circle"
+              ],
+              "description": "Link shape. Icon-only toolbar links default to square."
+            },
+            "external": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Opens the link in a new tab with safe rel attributes."
+            },
+            "disabled": {
+              "type": "boolean",
+              "optional": true,
+              "description": "Disables navigation and exposes disabled semantics."
             }
           }
         }

--- a/packages/kumo-svelte/ai/component-registry.json
+++ b/packages/kumo-svelte/ai/component-registry.json
@@ -4713,7 +4713,7 @@
       },
       "colors": [
         "bg-kumo-base",
-        "bg-kumo-elevated",
+        "bg-kumo-control",
         "bg-kumo-hairline",
         "bg-kumo-tint",
         "border-kumo-line",

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxInput.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxInput.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <input
-  class={cn(inputStyles[context.size], 'mx-1.5 w-[calc(100%-0.75rem)] shrink-0 first:mb-2 border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none placeholder:text-kumo-muted focus:ring-kumo-focus/50 focus:ring-[1.5px]', className)}
+  class={cn(inputStyles[context.size], 'mx-0 -mt-1.5 w-full shrink-0 rounded-b-none first:mb-2 border-0 bg-kumo-control text-kumo-default ring ring-kumo-line outline-none placeholder:text-kumo-muted focus:ring-kumo-focus/50 focus:ring-[1.5px]', className)}
   value={context.query}
   {placeholder}
   disabled={context.disabled}

--- a/packages/kumo-svelte/src/lib/components/combobox/ComboboxTest.svelte
+++ b/packages/kumo-svelte/src/lib/components/combobox/ComboboxTest.svelte
@@ -4,6 +4,7 @@
   import ComboboxContent from './ComboboxContent.svelte';
   import ComboboxList from './ComboboxList.svelte';
   import ComboboxItem from './ComboboxItem.svelte';
+  import ComboboxInput from './ComboboxInput.svelte';
 
   interface Props {
     value?: unknown;
@@ -25,6 +26,7 @@
     hideWhenDetached={false}
     updatePositionStrategy="optimized"
   >
+    <ComboboxInput placeholder="Search fruit" />
     <ComboboxList>
       {#snippet children(item)}
         <ComboboxItem value={item}>{item}</ComboboxItem>

--- a/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
+++ b/packages/kumo-svelte/src/lib/components/combobox/combobox.test.ts
@@ -4,6 +4,17 @@ import { describe, expect, it, vi } from "vitest";
 import ComboboxTest from "./ComboboxTest.svelte";
 
 describe("Combobox Keyboard Navigation", () => {
+  it("aligns popup input with the content edges", async () => {
+    const user = userEvent.setup();
+    render(ComboboxTest);
+    await user.click(screen.getByRole("button", { name: "Show options" }));
+
+    const input = screen.getByPlaceholderText("Search fruit");
+    expect(input.className).toContain("mx-0");
+    expect(input.className).toContain("-mt-1.5");
+    expect(input.className).toContain("rounded-b-none");
+  });
+
   it("allows navigating and selecting items using Arrow keys and Enter", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.svelte
@@ -1,12 +1,12 @@
 <script module lang="ts">
-  export { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
+  export { dialogVariants, KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
 </script>
 
 <script lang="ts">
   import { AlertDialog, Dialog as DialogPrimitive } from 'bits-ui';
   import type { Snippet } from 'svelte';
   import { cn } from '$lib/utils/cn';
-  import { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
+  import { dialogVariants, KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
 
   export const KUMO_DIALOG_STYLING = {
     dimensions: {
@@ -104,11 +104,7 @@
     'fixed inset-0 bg-kumo-recessed opacity-80 transition-all duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0';
 
   let contentClasses = $derived(
-    cn(
-      'shadow-m ring ring-kumo-line fixed top-1/2 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0',
-      KUMO_DIALOG_VARIANTS.size[size].classes,
-      className
-    )
+    cn(dialogVariants({ size }), className)
   );
 
   const contentStyle = $derived(

--- a/packages/kumo-svelte/src/lib/components/dialog/Dialog.variants.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/Dialog.variants.ts
@@ -34,3 +34,15 @@ export const KUMO_DIALOG_DEFAULT_VARIANTS = {
   size: 'base',
   role: 'dialog'
 } as const;
+
+export type KumoDialogSize = keyof typeof KUMO_DIALOG_VARIANTS.size;
+
+export function dialogVariants({
+  size = KUMO_DIALOG_DEFAULT_VARIANTS.size
+}: { size?: KumoDialogSize } = {}) {
+  return cn(
+    'shadow-m ring ring-kumo-line fixed top-8 left-1/2 w-full max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-xl bg-kumo-base text-kumo-default duration-150 data-ending-style:scale-90 data-ending-style:opacity-0 data-starting-style:scale-90 data-starting-style:opacity-0 sm:top-16',
+    KUMO_DIALOG_VARIANTS.size[size].classes
+  );
+}
+import { cn } from '$lib/utils/cn';

--- a/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/dialog.test.ts
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { expectNoA11yViolations } from "../../../../tests/a11y";
 import DialogTestHost from "./DialogTestHost.svelte";
-import { KUMO_DIALOG_VARIANTS } from "./Dialog.variants";
+import { dialogVariants, KUMO_DIALOG_VARIANTS } from "./Dialog.variants";
 
 describe("Dialog", () => {
   it("renders the trigger with Kumo data attributes", () => {
@@ -71,6 +71,14 @@ describe("Dialog", () => {
 });
 
 describe("Dialog variants", () => {
+  it("positions dialogs closer to the top of the viewport", () => {
+    const classes = dialogVariants().split(" ");
+    expect(classes).toContain("top-8");
+    expect(classes).toContain("sm:top-16");
+    expect(classes).not.toContain("top-1/2");
+    expect(classes).not.toContain("-translate-y-1/2");
+  });
+
   it("uses fixed width classes for size variants", () => {
     for (const [size, expectedClass] of [
       ["sm", "sm:w-72"],

--- a/packages/kumo-svelte/src/lib/components/dialog/index.ts
+++ b/packages/kumo-svelte/src/lib/components/dialog/index.ts
@@ -1,2 +1,3 @@
 export { default as Dialog } from './Dialog.svelte';
-export { KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
+export { dialogVariants, KUMO_DIALOG_DEFAULT_VARIANTS, KUMO_DIALOG_VARIANTS } from './Dialog.variants';
+export type { KumoDialogSize } from './Dialog.variants';

--- a/packages/kumo-svelte/src/lib/components/input-group/context.ts
+++ b/packages/kumo-svelte/src/lib/components/input-group/context.ts
@@ -60,7 +60,7 @@ export const INPUT_GROUP_SIZE: Record<InputGroupSize, InputGroupSizeTokens> = {
     addonOuterStart: 'pl-2.5',
     addonOuterEnd: 'pr-2.5',
     addonButtonOuterStart: 'pl-1.5',
-    addonButtonOuterEnd: 'pr-1.5',
+    addonButtonOuterEnd: 'pr-0.5',
     suffixPad: 'pr-4',
     fontSize: 'text-base',
     addonIconSize: '[&>svg]:size-5',

--- a/packages/kumo-svelte/src/lib/components/input-group/input-group.test.ts
+++ b/packages/kumo-svelte/src/lib/components/input-group/input-group.test.ts
@@ -3,8 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { expectNoA11yViolations } from '../../../../tests/a11y';
 import InputGroupTestHost from './InputGroupTestHost.svelte';
+import { INPUT_GROUP_SIZE } from './context';
 
 describe('InputGroup', () => {
+  it('uses compact end spacing for a button in a large group', () => {
+    expect(INPUT_GROUP_SIZE.lg.addonButtonOuterEnd).toBe('pr-0.5');
+  });
+
   it('renders input inside group', () => {
     render(InputGroupTestHost);
     expect(screen.getByRole('textbox', { name: 'Search' })).toBeTruthy();

--- a/packages/kumo-svelte/src/lib/components/pagination/Pagination.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/Pagination.svelte
@@ -50,6 +50,8 @@
     setPage?: (page: number) => void;
     perPage?: number;
     totalCount?: number;
+    /** Whether another page exists when no total count or page count is available. */
+    hasNextPage?: boolean;
     pages?: number;
     controls?: Controls;
     text?: (props: InfoTextProps) => unknown;
@@ -64,6 +66,7 @@
     setPage: setPageProp,
     perPage,
     totalCount,
+    hasNextPage,
     pages,
     controls = KUMO_PAGINATION_DEFAULT_VARIANTS.controls,
     text,
@@ -100,6 +103,9 @@
     },
     get totalCount() {
       return effectiveTotalCount;
+    },
+    get hasNextPage() {
+      return hasNextPage;
     },
     get maxPage() {
       return maxPage;

--- a/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
+++ b/packages/kumo-svelte/src/lib/components/pagination/PaginationControls.svelte
@@ -20,6 +20,12 @@
 
   let { controls = 'full', pageSelector = 'input', class: className, ...rest }: Props = $props();
   const context = getPaginationContext();
+  const hasKnownTotal = $derived(context.totalCount !== undefined);
+  const isUnknownTotal = $derived(!hasKnownTotal && context.hasNextPage !== undefined);
+  const showFullControls = $derived(controls === 'full' && !isUnknownTotal);
+  const isNextDisabled = $derived(
+    hasKnownTotal ? context.page === context.maxPage : context.hasNextPage !== true
+  );
   const pageOptions = $derived(
     Array.from({ length: context.maxPage }, (_, index) => {
       const page = index + 1;
@@ -28,7 +34,9 @@
   );
 
   function commitPage(nextPage: number) {
-    const clamped = clamp(nextPage, 1, context.maxPage);
+    const clamped = hasKnownTotal
+      ? clamp(nextPage, 1, context.maxPage)
+      : Math.max(nextPage, 1);
     context.setPage(clamped);
     context.setEditingPage(clamped);
   }
@@ -42,7 +50,7 @@
 <div data-slot="pagination-controls" class={cn('grow flex flex-col items-end', className)} {...rest}>
   <nav aria-label={context.labels.navigation}>
     <InputGroup focusMode="individual">
-      {#if controls === 'full'}
+      {#if showFullControls}
         <InputGroupButton
           variant="secondary"
           aria-label={context.labels.firstPage}
@@ -60,7 +68,7 @@
       >
         <CaretLeft class="size-4" />
       </InputGroupButton>
-      {#if controls === 'full'}
+      {#if showFullControls}
         {#if pageSelector === 'dropdown'}
           <Select
             aria-label={context.labels.pageNumber}
@@ -95,12 +103,12 @@
       <InputGroupButton
         variant="secondary"
         aria-label={context.labels.nextPage}
-        disabled={context.page === context.maxPage}
+        disabled={isNextDisabled}
         onclick={() => commitPage(context.page + 1)}
       >
         <CaretRight class="size-4" />
       </InputGroupButton>
-      {#if controls === 'full'}
+      {#if showFullControls}
         <InputGroupButton
           variant="secondary"
           aria-label={context.labels.lastPage}

--- a/packages/kumo-svelte/src/lib/components/pagination/context.ts
+++ b/packages/kumo-svelte/src/lib/components/pagination/context.ts
@@ -24,6 +24,7 @@ export interface PaginationContextValue {
   page: number;
   perPage?: number;
   totalCount?: number;
+  hasNextPage?: boolean;
   maxPage: number;
   pageShowingRange: string;
   setPage: (page: number) => void;

--- a/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
+++ b/packages/kumo-svelte/src/lib/components/pagination/pagination.test.ts
@@ -55,6 +55,29 @@ describe('Pagination', () => {
     expect(onPageChange).toHaveBeenCalledWith(3);
   });
 
+  it('supports sequential pagination when the total is unknown', async () => {
+    const user = userEvent.setup();
+    const setPage = vi.fn();
+
+    render(Pagination, {
+      page: 3,
+      hasNextPage: true,
+      setPage,
+      text: ({ page }) => `Page ${page}`
+    });
+
+    expect(screen.queryByRole('button', { name: 'First page' })).toBeNull();
+    expect(screen.queryByRole('textbox', { name: 'Page number' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Last page' })).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(setPage).toHaveBeenCalledWith(4);
+  });
+
+  it('disables next when an unknown-total list has no following page', () => {
+    render(Pagination, { page: 3, hasNextPage: false });
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+  });
+
   it('updates the page from the dropdown selector', async () => {
     const user = userEvent.setup();
     const setPage = vi.fn();

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -214,7 +214,7 @@
   <SelectPrimitive.Trigger
       child={trigger ? customTriggerChild : undefined}
       class={cn(
-        'inline-flex w-full items-center justify-between gap-2 bg-kumo-base text-left font-normal text-kumo-default shadow-xs outline-none ring ring-kumo-line transition focus:opacity-100 focus:ring-2 focus:ring-kumo-focus/50 focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 *:in-focus:opacity-100',
+        'inline-flex w-full items-center justify-between gap-2 bg-kumo-control text-left font-normal text-kumo-default shadow-xs outline-none ring ring-kumo-line transition focus:opacity-100 focus:ring-2 focus:ring-kumo-focus/50 focus-visible:ring-inset disabled:cursor-not-allowed disabled:bg-kumo-control/50 disabled:opacity-50 data-[state=open]:bg-kumo-control *:in-focus:opacity-100',
         sizes[size],
         !value || (Array.isArray(value) && value.length === 0) ? 'text-kumo-placeholder' : undefined,
         errorMessage ? 'ring-kumo-danger! focus:ring-kumo-danger/50!' : undefined,

--- a/packages/kumo-svelte/src/lib/components/select/Select.svelte
+++ b/packages/kumo-svelte/src/lib/components/select/Select.svelte
@@ -19,6 +19,7 @@
 
   type ItemDescriptor = string | { label: string; disabled?: boolean };
   type Items = Record<string, ItemDescriptor> | Option[];
+  type ContentProps = SelectPrimitive.ContentProps;
 
   interface Props {
     class?: string;
@@ -45,6 +46,19 @@
     renderValue?: (value: Value) => unknown;
     onValueChange?: (value: Value) => void;
     container?: HTMLElement | string;
+    /** Preferred popup side. Collision handling may flip it when space is limited. */
+    side?: ContentProps['side'];
+    sideOffset?: ContentProps['sideOffset'];
+    align?: ContentProps['align'];
+    alignOffset?: ContentProps['alignOffset'];
+    customAnchor?: ContentProps['customAnchor'];
+    strategy?: ContentProps['strategy'];
+    avoidCollisions?: ContentProps['avoidCollisions'];
+    collisionBoundary?: ContentProps['collisionBoundary'];
+    collisionPadding?: ContentProps['collisionPadding'];
+    sticky?: ContentProps['sticky'];
+    hideWhenDetached?: ContentProps['hideWhenDetached'];
+    updatePositionStrategy?: ContentProps['updatePositionStrategy'];
     [key: string]: unknown;
   }
 
@@ -73,6 +87,18 @@
     renderValue,
     onValueChange,
     container,
+    side = 'bottom',
+    sideOffset = 4,
+    align = 'start',
+    alignOffset = 0,
+    customAnchor,
+    strategy,
+    avoidCollisions,
+    collisionBoundary,
+    collisionPadding,
+    sticky,
+    hideWhenDetached,
+    updatePositionStrategy,
     ...rest
   }: Props = $props();
 
@@ -224,11 +250,22 @@
     <SelectPrimitive.Portal to={container}>
       <SelectPrimitive.Content
         class={cn(
-          'z-50 flex max-h-[var(--bits-select-content-available-height)] min-w-[calc(var(--bits-select-anchor-width)+3px)] flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line outline-none',
+          'z-50 flex max-h-[var(--bits-select-content-available-height)] max-w-[var(--bits-select-content-available-width)] min-w-[var(--bits-select-anchor-width)] flex-col overflow-hidden rounded-lg bg-kumo-base py-1.5 text-base text-kumo-default shadow-lg ring ring-kumo-line outline-none',
           contentClass
         )}
         preventScroll
-        sideOffset={4}
+        {side}
+        {sideOffset}
+        {align}
+        {alignOffset}
+        {customAnchor}
+        {strategy}
+        {avoidCollisions}
+        {collisionBoundary}
+        {collisionPadding}
+        {sticky}
+        {hideWhenDetached}
+        {updatePositionStrategy}
       >
         <SelectPrimitive.Viewport class={cn('min-h-0 flex-1 overflow-y-auto overscroll-none scroll-pb-2 scroll-pt-2', viewportClass)}>
           {#if children}

--- a/packages/kumo-svelte/src/lib/components/select/select-variants.ts
+++ b/packages/kumo-svelte/src/lib/components/select/select-variants.ts
@@ -31,7 +31,7 @@ export const KUMO_SELECT_STYLING = {
     height: 36,
     paddingX: 12,
     borderRadius: 8,
-    background: 'bg-kumo-elevated',
+    background: 'bg-kumo-control',
     text: 'text-color-surface',
     ring: 'color-border',
     fontSize: 16,
@@ -46,7 +46,7 @@ export const KUMO_SELECT_STYLING = {
     check: { name: 'ph-check', size: 20 }
   },
   popup: {
-    background: 'bg-kumo-elevated',
+    background: 'bg-kumo-base',
     ring: 'border-kumo-line',
     borderRadius: 8,
     padding: 6
@@ -68,7 +68,7 @@ export function selectVariants({
   const buttonSize = KUMO_SELECT_VARIANTS.size[size].classes;
   return cn(
     'group flex w-full items-center select-none border-0 shadow-xs focus:outline-none focus:ring-kumo-focus/50 focus-visible:ring-2 focus-visible:ring-kumo-brand cursor-pointer disabled:cursor-not-allowed disabled:text-kumo-subtle',
-    'bg-kumo-base !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-base/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-base',
+    'bg-kumo-control !text-kumo-default ring not-disabled:hover:bg-kumo-tint disabled:bg-kumo-control/50 disabled:!text-kumo-default/70 ring-kumo-line data-[state=open]:bg-kumo-control',
     buttonSize,
     'justify-between font-normal',
     'focus:opacity-100 focus:ring-kumo-focus/50 focus-visible:ring-inset *:in-focus:opacity-100'

--- a/packages/kumo-svelte/src/lib/components/select/select.test.ts
+++ b/packages/kumo-svelte/src/lib/components/select/select.test.ts
@@ -40,6 +40,15 @@ describe("Select", () => {
   });
 
   describe("variant fidelity", () => {
+    it("uses the Input control surface when closed, open, or disabled", () => {
+      render(Select, { "aria-label": "Fruit", options: fruits, disabled: true });
+      const cls = screen.getByRole("button", { name: "Fruit" }).className;
+      expect(cls).toContain("bg-kumo-control");
+      expect(cls).toContain("data-[state=open]:bg-kumo-control");
+      expect(cls).toContain("disabled:bg-kumo-control/50");
+      expect(cls).not.toContain("data-[state=open]:bg-kumo-base");
+    });
+
     it("accepts popup positioning props without forwarding them to the trigger", () => {
       render(Select, {
         "aria-label": "Fruit",

--- a/packages/kumo-svelte/src/lib/components/select/select.test.ts
+++ b/packages/kumo-svelte/src/lib/components/select/select.test.ts
@@ -1,169 +1,190 @@
-import { render, screen } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
-import { expectNoA11yViolations } from '../../../../tests/a11y';
-import Select from './Select.svelte';
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { expectNoA11yViolations } from "../../../../tests/a11y";
+import Select from "./Select.svelte";
 
 const fruits = [
-  { label: 'Apple', value: 'apple' },
-  { label: 'Banana', value: 'banana' },
-  { label: 'Cherry', value: 'cherry' }
+  { label: "Apple", value: "apple" },
+  { label: "Banana", value: "banana" },
+  { label: "Cherry", value: "cherry" },
 ];
 
-describe('Select', () => {
-  it('renders trigger with Kumo data attributes', () => {
+describe("Select", () => {
+  it("renders trigger with Kumo data attributes", () => {
     render(Select, {
-      'aria-label': 'Favorite fruit',
-      options: fruits
+      "aria-label": "Favorite fruit",
+      options: fruits,
     });
 
-    const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
-    expect(trigger.getAttribute('data-kumo-component')).toBe('Select');
-    expect(trigger.getAttribute('data-kumo-part')).toBe('trigger');
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    const trigger = screen.getByRole("button", { name: "Favorite fruit" });
+    expect(trigger.getAttribute("data-kumo-component")).toBe("Select");
+    expect(trigger.getAttribute("data-kumo-part")).toBe("trigger");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it('displays labels for non-string option values', () => {
+  it("displays labels for non-string option values", () => {
     render(Select, {
-      'aria-label': 'Rows per page',
+      "aria-label": "Rows per page",
       value: 50,
       options: [
-        { label: '25 rows', value: 25 },
-        { label: '50 rows', value: 50 },
-        { label: '100 rows', value: 100 }
-      ]
+        { label: "25 rows", value: 25 },
+        { label: "50 rows", value: 50 },
+        { label: "100 rows", value: 100 },
+      ],
     });
 
-    expect(screen.getByRole('button', { name: 'Rows per page' }).textContent).toContain('50 rows');
+    expect(
+      screen.getByRole("button", { name: "Rows per page" }).textContent,
+    ).toContain("50 rows");
   });
 
-  describe('variant fidelity', () => {
-    it('applies selectVariants with button secondary base classes', () => {
-      render(Select, { 'aria-label': 'Fruit', options: fruits });
-      const cls = screen.getByRole('button', { name: 'Fruit' }).className;
-      expect(cls).toContain('justify-between');
-      expect(cls).toContain('font-normal');
-      expect(cls).toContain('ring-kumo-line');
-      expect(cls).not.toContain('ring-kumo-hairline');
+  describe("variant fidelity", () => {
+    it("accepts popup positioning props without forwarding them to the trigger", () => {
+      render(Select, {
+        "aria-label": "Fruit",
+        options: fruits,
+        side: "top",
+        sideOffset: 12,
+        align: "end",
+        alignOffset: 2,
+        strategy: "fixed",
+      });
+      const trigger = screen.getByRole("button", { name: "Fruit" });
+      expect(trigger).not.toHaveAttribute("side");
+      expect(trigger).not.toHaveAttribute("align");
     });
 
-    it('applies error ring classes on trigger', () => {
+    it("applies selectVariants with button secondary base classes", () => {
+      render(Select, { "aria-label": "Fruit", options: fruits });
+      const cls = screen.getByRole("button", { name: "Fruit" }).className;
+      expect(cls).toContain("justify-between");
+      expect(cls).toContain("font-normal");
+      expect(cls).toContain("ring-kumo-line");
+      expect(cls).not.toContain("ring-kumo-hairline");
+    });
+
+    it("applies error ring classes on trigger", () => {
       render(Select, {
-        'aria-label': 'Fruit',
+        "aria-label": "Fruit",
         options: fruits,
-        error: 'Required'
+        error: "Required",
       });
-      const cls = screen.getByRole('button', { name: 'Fruit' }).className;
+      const cls = screen.getByRole("button", { name: "Fruit" }).className;
       // cn/tailwind-merge canonicalizes the important modifier to a trailing `!`.
-      expect(cls).toContain('ring-kumo-danger');
-      expect(cls).toContain('focus:ring-kumo-danger/50');
+      expect(cls).toContain("ring-kumo-danger");
+      expect(cls).toContain("focus:ring-kumo-danger/50");
     });
 
-    it('applies disabled opacity classes on trigger', () => {
+    it("applies disabled opacity classes on trigger", () => {
       render(Select, {
-        'aria-label': 'Fruit',
+        "aria-label": "Fruit",
         options: fruits,
-        disabled: true
+        disabled: true,
       });
-      const cls = screen.getByRole('button', { name: 'Fruit' }).className;
-      expect(cls).toContain('cursor-not-allowed');
-      expect(cls).toContain('opacity-50');
+      const cls = screen.getByRole("button", { name: "Fruit" }).className;
+      expect(cls).toContain("cursor-not-allowed");
+      expect(cls).toContain("opacity-50");
     });
 
-    it('applies size classes via selectVariants', () => {
-      render(Select, { 'aria-label': 'Fruit', options: fruits, size: 'lg' });
-      expect(screen.getByRole('button', { name: 'Fruit' }).className).toContain('h-10');
+    it("applies size classes via selectVariants", () => {
+      render(Select, { "aria-label": "Fruit", options: fruits, size: "lg" });
+      expect(screen.getByRole("button", { name: "Fruit" }).className).toContain(
+        "h-10",
+      );
     });
   });
 
-  describe('interaction', () => {
-    it('opens on trigger click and updates aria-expanded', async () => {
+  describe("interaction", () => {
+    it("opens on trigger click and updates aria-expanded", async () => {
       const user = userEvent.setup();
-      render(Select, { 'aria-label': 'Favorite fruit', options: fruits });
+      render(Select, { "aria-label": "Favorite fruit", options: fruits });
 
-      const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
-      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      const trigger = screen.getByRole("button", { name: "Favorite fruit" });
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
 
       await user.click(trigger);
 
-      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      expect(trigger.getAttribute("aria-expanded")).toBe("true");
       // Open listbox content is covered by VRT (happy-dom does not mount portaled content).
     });
 
-    it('selects an option via keyboard and updates displayed value', async () => {
+    it("selects an option via keyboard and updates displayed value", async () => {
       const user = userEvent.setup();
-      let current = 'apple';
+      let current = "apple";
       const onValueChange = vi.fn((next: unknown) => {
         current = next as string;
       });
 
       const { rerender } = render(Select, {
-        'aria-label': 'Favorite fruit',
+        "aria-label": "Favorite fruit",
         options: fruits,
         value: current,
-        onValueChange
+        onValueChange,
       });
 
-      const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
+      const trigger = screen.getByRole("button", { name: "Favorite fruit" });
       trigger.focus();
-      await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+      await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
 
-      expect(onValueChange).toHaveBeenCalledWith('banana');
+      expect(onValueChange).toHaveBeenCalledWith("banana");
       await rerender({
-        value: 'banana',
+        value: "banana",
         onValueChange,
         options: fruits,
-        'aria-label': 'Favorite fruit'
+        "aria-label": "Favorite fruit",
       });
-      expect(screen.getByRole('button', { name: 'Favorite fruit' }).textContent).toContain('Banana');
+      expect(
+        screen.getByRole("button", { name: "Favorite fruit" }).textContent,
+      ).toContain("Banana");
     });
 
-    it('supports keyboard navigation with ArrowDown and Enter', async () => {
+    it("supports keyboard navigation with ArrowDown and Enter", async () => {
       const user = userEvent.setup();
       const onValueChange = vi.fn();
       render(Select, {
-        'aria-label': 'Favorite fruit',
+        "aria-label": "Favorite fruit",
         options: fruits,
-        onValueChange
+        onValueChange,
       });
 
-      const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
+      const trigger = screen.getByRole("button", { name: "Favorite fruit" });
       trigger.focus();
-      await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+      await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
 
       expect(onValueChange).toHaveBeenCalled();
     });
 
-    it('stays closed when disabled', () => {
+    it("stays closed when disabled", () => {
       render(Select, {
-        'aria-label': 'Favorite fruit',
+        "aria-label": "Favorite fruit",
         options: fruits,
-        disabled: true
+        disabled: true,
       });
 
-      const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
+      const trigger = screen.getByRole("button", { name: "Favorite fruit" });
       expect(trigger).toBeDisabled();
-      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
     });
 
-    it('activates via keyboard on trigger', async () => {
+    it("activates via keyboard on trigger", async () => {
       const user = userEvent.setup();
-      render(Select, { 'aria-label': 'Favorite fruit', options: fruits });
+      render(Select, { "aria-label": "Favorite fruit", options: fruits });
 
-      const trigger = screen.getByRole('button', { name: 'Favorite fruit' });
+      const trigger = screen.getByRole("button", { name: "Favorite fruit" });
       trigger.focus();
       expect(document.activeElement).toBe(trigger);
 
-      await user.keyboard('{Enter}');
-      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      await user.keyboard("{Enter}");
+      expect(trigger.getAttribute("aria-expanded")).toBe("true");
     });
   });
 
-  describe('accessibility', () => {
-    it('has no axe violations when closed', async () => {
+  describe("accessibility", () => {
+    it("has no axe violations when closed", async () => {
       const { container } = render(Select, {
-        'aria-label': 'Favorite fruit',
-        options: fruits
+        "aria-label": "Favorite fruit",
+        options: fruits,
       });
       await expectNoA11yViolations(container);
     });

--- a/packages/kumo-svelte/src/lib/components/table/Table.svelte
+++ b/packages/kumo-svelte/src/lib/components/table/Table.svelte
@@ -15,7 +15,7 @@
     variant: {
       default: {
         classes:
-          'even:bg-kumo-tint [--kumo-table-row-bg:var(--color-kumo-base)] even:[--kumo-table-row-bg:var(--color-kumo-tint)]',
+          'even:bg-kumo-elevated [--kumo-table-row-bg:var(--color-kumo-base)] even:[--kumo-table-row-bg:var(--color-kumo-elevated)]',
         description: 'Default row variant'
       },
       selected: {

--- a/packages/kumo-svelte/src/lib/components/table/table.test.ts
+++ b/packages/kumo-svelte/src/lib/components/table/table.test.ts
@@ -36,6 +36,18 @@ describe("Table", () => {
     );
   });
 
+  it("elevates even rows without changing selected row styling", () => {
+    expect(KUMO_TABLE_VARIANTS.variant.default.classes).toContain(
+      "even:bg-kumo-elevated",
+    );
+    expect(KUMO_TABLE_VARIANTS.variant.default.classes).toContain(
+      "even:[--kumo-table-row-bg:var(--color-kumo-elevated)]",
+    );
+    expect(KUMO_TABLE_VARIANTS.variant.selected.classes).not.toContain(
+      "even:bg-kumo-elevated",
+    );
+  });
+
   it("applies sticky column classes on head and cell", () => {
     render(TableTestHost, { variant: "sticky" });
     const head = screen.getByTestId("sticky-head");

--- a/packages/kumo-svelte/src/lib/components/text/Text.svelte
+++ b/packages/kumo-svelte/src/lib/components/text/Text.svelte
@@ -50,19 +50,19 @@
     },
     size: {
       xs: {
-        classes: 'text-xs',
+        classes: 'text-xs/[inherit]',
         description: 'Extra small text'
       },
       sm: {
-        classes: 'text-sm',
+        classes: 'text-sm/[inherit]',
         description: 'Small text'
       },
       base: {
-        classes: 'text-base',
+        classes: 'text-base/[inherit]',
         description: 'Default text size'
       },
       lg: {
-        classes: 'text-lg',
+        classes: 'text-lg/[inherit]',
         description: 'Large text'
       }
     }

--- a/packages/kumo-svelte/src/lib/components/text/text.test.ts
+++ b/packages/kumo-svelte/src/lib/components/text/text.test.ts
@@ -1,8 +1,20 @@
 import { render } from "@testing-library/svelte";
 import { describe, expect, it, vi } from "vitest";
-import Text from "./Text.svelte";
+import Text, { textVariants } from "./Text.svelte";
 
 describe("Text", () => {
+  it("inherits line height for non-heading sizes", () => {
+    for (const [size, expected] of [
+      ["xs", "text-xs/[inherit]"],
+      ["sm", "text-sm/[inherit]"],
+      ["base", "text-base/[inherit]"],
+      ["lg", "text-lg/[inherit]"],
+    ] as const) {
+      expect(textVariants({ variant: "body", size })).toContain(expected);
+    }
+    expect(textVariants({ variant: "mono" })).toContain("text-sm/[inherit]");
+  });
+
   it("renders the new heading variant as a span by default", () => {
     const { container } = render(Text, { variant: "heading" });
     const heading = container.querySelector("span")!;

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarLink.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarLink.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { Component, Snippet } from 'svelte';
+  import LinkButton from '$lib/components/button/LinkButton.svelte';
+  import { getToolbarContext, toolbarControlClassName } from './context';
+
+  export interface Props {
+    children?: Snippet;
+    class?: string;
+    icon?: Component;
+    href?: string;
+    external?: boolean;
+    linksExternal?: boolean;
+    shape?: 'base' | 'square' | 'circle';
+    size?: never;
+    variant?: never;
+    disabled?: boolean;
+    title?: string | number;
+    'aria-label'?: string;
+    'aria-labelledby'?: string;
+    [key: string]: unknown;
+  }
+
+  let {
+    children,
+    class: className,
+    icon,
+    shape,
+    size: _ignoredSize,
+    variant: _ignoredVariant,
+    ...rest
+  }: Props = $props();
+  const toolbar = getToolbarContext();
+  const size = $derived(toolbar?.size ?? 'base');
+  const resolvedShape = $derived(shape ?? (!children && icon ? 'square' : 'base'));
+</script>
+
+<LinkButton
+  class={toolbarControlClassName(className)}
+  {icon}
+  shape={resolvedShape}
+  {size}
+  variant="ghost"
+  componentName="Toolbar.Link"
+  data-kumo-toolbar-control=""
+  {...rest}
+>
+  {@render children?.()}
+</LinkButton>

--- a/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/toolbar/ToolbarTestHost.svelte
@@ -22,6 +22,12 @@
 </Toolbar>
 
 <Toolbar>
+  <Toolbar.Button>Before link</Toolbar.Button>
+  <Toolbar.Link href="#docs" external>Documentation</Toolbar.Link>
+  <Toolbar.Button>After link</Toolbar.Button>
+</Toolbar>
+
+<Toolbar>
   <Toolbar.InputGroup aria-label="Search DNS records">
     <InputGroup.Input placeholder="Search DNS records" />
   </Toolbar.InputGroup>

--- a/packages/kumo-svelte/src/lib/components/toolbar/index.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/index.ts
@@ -1,16 +1,19 @@
 import Root from './Toolbar.svelte';
 import Button from './ToolbarButton.svelte';
+import Link from './ToolbarLink.svelte';
 import Input from './ToolbarInput.svelte';
 import InputGroup from './ToolbarInputGroup.svelte';
 
 const Toolbar = Object.assign(Root, {
   Root,
   Button,
+  Link,
   Input,
   InputGroup
 }) as typeof Root & {
   Root: typeof Root;
   Button: typeof Button;
+  Link: typeof Link;
   Input: typeof Input;
   InputGroup: typeof InputGroup;
 };
@@ -19,6 +22,7 @@ export {
   Toolbar,
   Root as ToolbarRoot,
   Button as ToolbarButton,
+  Link as ToolbarLink,
   Input as ToolbarInput,
   InputGroup as ToolbarInputGroup
 };
@@ -30,5 +34,6 @@ export {
 } from './context';
 export type { Props as ToolbarProps } from './Toolbar.svelte';
 export type { Props as ToolbarButtonProps } from './ToolbarButton.svelte';
+export type { Props as ToolbarLinkProps } from './ToolbarLink.svelte';
 export type { Props as ToolbarInputProps } from './ToolbarInput.svelte';
 export type { Props as ToolbarInputGroupProps } from './ToolbarInputGroup.svelte';

--- a/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
+++ b/packages/kumo-svelte/src/lib/components/toolbar/toolbar.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   Toolbar,
   ToolbarButton,
+  ToolbarLink,
   ToolbarInput,
   ToolbarInputGroup,
   ToolbarRoot
@@ -15,12 +16,28 @@ describe('Toolbar exports', () => {
     expect(Toolbar).toBeDefined();
     expect(Toolbar.Root).toBe(ToolbarRoot);
     expect(Toolbar.Button).toBe(ToolbarButton);
+    expect(Toolbar.Link).toBe(ToolbarLink);
     expect(Toolbar.Input).toBe(ToolbarInput);
     expect(Toolbar.InputGroup).toBe(ToolbarInputGroup);
   });
 });
 
 describe('Toolbar', () => {
+  it('renders links and includes them in arrow-key focus movement', async () => {
+    render(ToolbarTestHost);
+    const before = screen.getByRole('button', { name: 'Before link' });
+    const link = screen.getByRole('link', { name: 'Documentation' });
+    const after = screen.getByRole('button', { name: 'After link' });
+
+    expect(link.getAttribute('data-kumo-component')).toBe('Toolbar.Link');
+    expect(link).toHaveAttribute('target', '_blank');
+    before.focus();
+    await fireEvent.keyDown(before, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(link);
+    await fireEvent.keyDown(link, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(after);
+  });
+
   it('applies toolbar size and item styles through Toolbar.Input', () => {
     render(ToolbarTestHost);
 

--- a/packages/kumo-svelte/src/lib/components/tooltip/Tooltip.svelte
+++ b/packages/kumo-svelte/src/lib/components/tooltip/Tooltip.svelte
@@ -95,7 +95,7 @@
   <span
     {...props}
     class={cn(
-      'inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 leading-[0] shadow-none',
+      'inline-flex h-auto min-h-0 items-center border-none bg-transparent p-0 shadow-none',
       'm-0 cursor-default'
     )}
   >

--- a/packages/kumo-svelte/src/lib/components/tooltip/TooltipTestHost.svelte
+++ b/packages/kumo-svelte/src/lib/components/tooltip/TooltipTestHost.svelte
@@ -2,6 +2,7 @@
   import { Button } from '$lib/components/button';
   import { TooltipProvider } from '$lib/components/tooltip';
   import Tooltip from './Tooltip.svelte';
+  import { Text } from '$lib/components/text';
 </script>
 
 <TooltipProvider>
@@ -9,5 +10,8 @@
     {#snippet trigger(props)}
       <Button {...props}>Hover for help</Button>
     {/snippet}
+  </Tooltip>
+  <Tooltip content="Nested text" delay={0}>
+    <Text as="span" size="sm">Trigger label</Text>
   </Tooltip>
 </TooltipProvider>

--- a/packages/kumo-svelte/src/lib/components/tooltip/tooltip.test.ts
+++ b/packages/kumo-svelte/src/lib/components/tooltip/tooltip.test.ts
@@ -5,6 +5,13 @@ import { expectNoA11yViolations } from '../../../../tests/a11y';
 import TooltipTestHost from './TooltipTestHost.svelte';
 
 describe('Tooltip', () => {
+  it('does not override the line height of nested text', () => {
+    render(TooltipTestHost);
+    const trigger = screen.getByText('Trigger label').closest('[data-tooltip-trigger]');
+    expect(trigger).not.toBeNull();
+    expect(trigger?.className).not.toMatch(/\bleading-/);
+  });
+
   it('renders the trigger when closed', () => {
     render(TooltipTestHost);
 

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationUnknownTotalDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/PaginationUnknownTotalDemo.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Pagination } from 'kumo-svelte/components/pagination';
+
+  let page = $state(1);
+  const hasNextPage = $derived(page < 3);
+</script>
+
+<Pagination
+  bind:page
+  {hasNextPage}
+  text={({ page }) => `Page ${page}`}
+/>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/SelectPlacementDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/SelectPlacementDemo.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { Select } from 'kumo-svelte/components/select';
+
+  const planets = {
+    mercury: 'Mercury',
+    venus: 'Venus',
+    earth: 'Earth',
+    mars: 'Mars',
+    jupiter: 'Jupiter',
+    saturn: 'Saturn',
+    uranus: 'Uranus'
+  };
+</script>
+
+<div class="grid gap-4 sm:grid-cols-2">
+  <Select label="side=bottom (default)" class="w-[200px]" value="earth" items={planets} />
+  <Select label="side=top" side="top" class="w-[200px]" value="earth" items={planets} />
+  <Select label="align=end" align="end" class="w-[200px]" value="earth" items={planets} />
+  <Select label="sideOffset=12" sideOffset={12} class="w-[200px]" value="earth" items={planets} />
+</div>

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TabsDefaultDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TabsDefaultDemo.svelte
@@ -8,7 +8,7 @@
   ];
 </script>
 
-<div class="flex flex-col gap-6">
+<div class="flex flex-col items-start gap-6">
   <div>
     <p class="mb-2 text-sm text-kumo-subtle">Segmented (default)</p>
     <Tabs variant="segmented" {items} value="tab1" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/TabsSmDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/TabsSmDemo.svelte
@@ -8,7 +8,7 @@
   ];
 </script>
 
-<div class="flex flex-col gap-6">
+<div class="flex flex-col items-start gap-6">
   <div>
     <p class="mb-2 text-sm text-kumo-subtle">Segmented sm</p>
     <Tabs variant="segmented" size="sm" {items} value="tab1" />

--- a/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarLinksDemo.svelte
+++ b/packages/kumo-svelte/src/lib/docs/demo-snippets/ToolbarLinksDemo.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import BookOpen from 'phosphor-svelte/lib/BookOpen';
+  import DownloadSimple from 'phosphor-svelte/lib/DownloadSimple';
+  import { Toolbar } from 'kumo-svelte/components/toolbar';
+</script>
+
+<Toolbar>
+  <Toolbar.Link href="/components/button" icon={BookOpen}>Button documentation</Toolbar.Link>
+  <Toolbar.Button icon={DownloadSimple}>Download</Toolbar.Button>
+</Toolbar>

--- a/packages/kumo-svelte/src/lib/docs/props-data/Pagination.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Pagination.ts
@@ -27,6 +27,12 @@ const rows: PropRow[] = [
     "description": "Total number of items across all pages."
   },
   {
+    "prop": "hasNextPage",
+    "type": "boolean",
+    "required": false,
+    "description": "Whether another page exists when the total count is unknown."
+  },
+  {
     "prop": "class",
     "type": "string",
     "required": false,

--- a/packages/kumo-svelte/src/lib/docs/props-data/Select.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Select.ts
@@ -128,6 +128,58 @@ const rows: PropRow[] = [
     "type": "HTMLElement | string",
     "required": false,
     "description": "Container element for the portal."
+  },
+  {
+    "prop": "side",
+    "type": "'top' | 'right' | 'bottom' | 'left'",
+    "required": false,
+    "default": "\"bottom\"",
+    "description": "Preferred popup side; collision handling may flip it."
+  },
+  {
+    "prop": "sideOffset",
+    "type": "number",
+    "required": false,
+    "default": "4",
+    "description": "Distance between the trigger and popup."
+  },
+  {
+    "prop": "align",
+    "type": "'start' | 'center' | 'end'",
+    "required": false,
+    "default": "\"start\"",
+    "description": "Popup alignment along the trigger edge."
+  },
+  {
+    "prop": "alignOffset",
+    "type": "number",
+    "required": false,
+    "default": "0",
+    "description": "Additional offset along the alignment axis."
+  },
+  {
+    "prop": "customAnchor",
+    "type": "HTMLElement | string",
+    "required": false,
+    "description": "Custom floating-position anchor."
+  },
+  {
+    "prop": "strategy",
+    "type": "'absolute' | 'fixed'",
+    "required": false,
+    "description": "CSS positioning strategy for the popup."
+  },
+  {
+    "prop": "avoidCollisions",
+    "type": "boolean",
+    "required": false,
+    "description": "Whether the popup should adjust to avoid viewport collisions."
+  },
+  {
+    "prop": "collisionPadding",
+    "type": "number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>",
+    "required": false,
+    "description": "Padding between the popup and its collision boundary."
   }
 ];
 

--- a/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Link.ts
+++ b/packages/kumo-svelte/src/lib/docs/props-data/Toolbar__Link.ts
@@ -1,0 +1,32 @@
+export default [
+  {
+    prop: 'children',
+    type: 'Snippet',
+    description: 'Optional visible link label.'
+  },
+  {
+    prop: 'href',
+    type: 'string',
+    description: 'Navigation destination.'
+  },
+  {
+    prop: 'icon',
+    type: 'Component',
+    description: 'Optional icon component rendered before the label.'
+  },
+  {
+    prop: 'shape',
+    type: '"base" | "square" | "circle"',
+    description: 'Link shape. Icon-only toolbar links default to square.'
+  },
+  {
+    prop: 'external',
+    type: 'boolean',
+    description: 'Opens the link in a new tab with safe rel attributes.'
+  },
+  {
+    prop: 'disabled',
+    type: 'boolean',
+    description: 'Disables navigation and exposes disabled semantics.'
+  }
+];

--- a/packages/kumo-svelte/src/lib/index.ts
+++ b/packages/kumo-svelte/src/lib/index.ts
@@ -213,12 +213,14 @@ export {
   KUMO_TOOLBAR_VARIANTS,
   Toolbar,
   ToolbarButton,
+  ToolbarLink,
   ToolbarInput,
   ToolbarInputGroup,
   ToolbarRoot,
 } from "./components/toolbar";
 export type {
   ToolbarButtonProps,
+  ToolbarLinkProps,
   ToolbarInputGroupProps,
   ToolbarInputProps,
   ToolbarProps,

--- a/packages/kumo-svelte/src/routes/components/pagination/+page.md
+++ b/packages/kumo-svelte/src/routes/components/pagination/+page.md
@@ -75,6 +75,23 @@ Use `controls="simple"` for a minimal pagination with only previous and next
 
 <ComponentExample demo="PaginationSimpleDemo" />
 
+### Unknown Totals
+
+Use `hasNextPage` when the data source does not return a total count. This is
+common for cursor-based APIs, where calculating the total can be expensive or
+unavailable. Pagination then shows only the sequential Previous and Next
+controls, and disables Next when `hasNextPage` is false.
+
+```svelte
+<Pagination
+  bind:page
+  hasNextPage={data.hasMore}
+  text={({ page }) => `Page ${page}`}
+/>
+```
+
+<ComponentExample demo="PaginationUnknownTotalDemo" />
+
 ### Mid-Page State
 
 

--- a/packages/kumo-svelte/src/routes/components/select/+page.md
+++ b/packages/kumo-svelte/src/routes/components/select/+page.md
@@ -26,13 +26,13 @@ baseUIComponent: "select"
 ### Barrel
 
 ```typescript
-import { Select } from 'kumo-svelte';
+import { Select } from "kumo-svelte";
 ```
 
 ### Granular
 
 ```typescript
-import { Select } from 'kumo-svelte/components/select';
+import { Select } from "kumo-svelte/components/select";
 ```
 
 </ComponentSection>
@@ -67,9 +67,7 @@ import { Select } from 'kumo-svelte/components/select';
 
 ### Basic
 
-
 A select with a visible label. When you provide the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">label</code> prop, the select automatically renders inside a Field wrapper with the label displayed above it.
-
 
   <ComponentExample demo="SelectBasicDemo" />
 </ComponentSection>
@@ -80,12 +78,23 @@ A select with a visible label. When you provide the <code class="rounded bg-kumo
 
 ### Sizes
 
-
 Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code> prop
-    to match Input sizing (xs, sm, base, lg).
-
+to match Input sizing (xs, sm, base, lg).
 
   <ComponentExample demo="SelectSizesDemo" />
+</ComponentSection>
+
+<!-- Placement -->
+
+<ComponentSection>
+
+### Placement
+
+The popup prefers `side="bottom"` and flips automatically when that side runs
+out of room. Use `side`, `align`, `sideOffset`, and `alignOffset` to pin it
+explicitly while retaining collision handling.
+
+  <ComponentExample demo="SelectPlacementDemo" />
 </ComponentSection>
 
 <!-- Without Visible Label -->
@@ -94,10 +103,8 @@ Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">size</code> pr
 
 ### Without Visible Label
 
-
 When a visible label isn't needed (e.g., in compact UIs or when context is clear),
-    use `aria-label` for accessibility.
-
+use `aria-label` for accessibility.
 
   <ComponentExample demo="SelectWithoutLabelDemo" />
 </ComponentSection>
@@ -108,9 +115,7 @@ When a visible label isn't needed (e.g., in compact UIs or when context is clear
 
 ### With Description and Error
 
-
 Select integrates with the Field wrapper to show description text and validation errors.
-
 
   <ComponentExample demo="SelectWithFieldDemo" />
 </ComponentSection>
@@ -121,12 +126,10 @@ Select integrates with the Field wrapper to show description text and validation
 
 ### Placeholder
 
-
 Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> prop
-    to show text when no value is selected. When using <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to
-    customize the display of selected values, the placeholder is shown instead of
-    calling <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> when the value is <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">null</code>.
-
+to show text when no value is selected. When using <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to
+customize the display of selected values, the placeholder is shown instead of
+calling <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> when the value is <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">null</code>.
 
 ```svelte
 <script lang="ts">
@@ -156,10 +159,8 @@ Use the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</c
 
 ### Label with Tooltip
 
-
 Add a tooltip icon next to the label for additional context using <code
       class="rounded bg-kumo-control px-1 py-0.5 text-sm">labelTooltip</code>.
-
 
   <ComponentExample demo="SelectWithTooltipDemo" />
 </ComponentSection>
@@ -170,17 +171,13 @@ Add a tooltip icon next to the label for additional context using <code
 
 ### Custom Rendering
 
-
 Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how the selected value
-    appears in the trigger button. This is useful when working with complex object
-    data structures instead of simple string values.
-
+appears in the trigger button. This is useful when working with complex object
+data structures instead of simple string values.
 
 <ComponentExample demo="SelectCustomRenderingDemo" />
 
-
 The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> function is only called when a value is selected. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> to define what to show when no value is selected.
-
 
 ```svelte
 <script lang="ts">
@@ -214,11 +211,9 @@ The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code>
 
 ### Loading
 
-
 A select component with loading state. The loading state is passed to
-    the component via the <code
+the component via the <code
       class="rounded bg-kumo-control px-1 py-0.5 text-sm">loading</code> prop.
-
 
   <ComponentExample demo="SelectLoadingDemo" />
 </ComponentSection>
@@ -229,11 +224,9 @@ A select component with loading state. The loading state is passed to
 
 ### Multiple Selection
 
-
 Enable multiple selection with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">multiple</code> prop.
-    The value becomes an array of selected items. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> for the empty state
-    and <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how selections are displayed.
-
+The value becomes an array of selected items. Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">placeholder</code> for the empty state
+and <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">renderValue</code> to customize how selections are displayed.
 
 ```svelte
 <script lang="ts">
@@ -269,10 +262,8 @@ Enable multiple selection with the <code class="rounded bg-kumo-control px-1 py-
 
 ### Disabled Options
 
-
 Options can be disabled with the <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> prop.
-    Disabled options are greyed out and cannot be selected.
-
+Disabled options are greyed out and cannot be selected.
 
   <ComponentExample demo="SelectDisabledOptionsDemo" />
 </ComponentSection>
@@ -283,11 +274,9 @@ Options can be disabled with the <code class="rounded bg-kumo-control px-1 py-0.
 
 ### Disabled Items (via items prop)
 
-
 The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code> object-map prop
-    accepts descriptor objects with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> alongside
-    plain string values.
-
+accepts descriptor objects with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">disabled</code> alongside
+plain string values.
 
   <ComponentExample demo="SelectDisabledItemsDemo" />
 </ComponentSection>
@@ -298,12 +287,10 @@ The <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">items</code> objec
 
 ### Grouped Options
 
-
 Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>,{" "}
-    <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code>, and{" "}
-    <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Separator</code> to
-    organize options under labeled headers with visual dividers.
-
+<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.GroupLabel</code>, and{" "}
+<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Separator</code> to
+organize options under labeled headers with visual dividers.
 
   <ComponentExample demo="SelectGroupedDemo" />
 </ComponentSection>
@@ -314,10 +301,8 @@ Use <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code
 
 ### Groups with Disabled Options
 
-
 Combine groups, separators, and disabled options with info tooltips to
-    clearly separate available and unavailable choices.
-
+clearly separate available and unavailable choices.
 
   <ComponentExample demo="SelectGroupedWithDisabledDemo" />
 </ComponentSection>
@@ -328,10 +313,8 @@ Combine groups, separators, and disabled options with info tooltips to
 
 ### Long List (Scrolling Test)
 
-
 A select component with many options to test popup scrolling behavior.
-    The popup should scroll smoothly without bounce/overscroll issues.
-
+The popup should scroll smoothly without bounce/overscroll issues.
 
   <ComponentExample demo="SelectLongListDemo" />
 </ComponentSection>
@@ -352,26 +335,21 @@ A select component with many options to test popup scrolling behavior.
 
 ### Select.Group
 
-
 Groups related options together with an accessible{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
-  Use with{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
-    Select.GroupLabel
-  </code>{" "}
-  to provide a visible heading.
-
+<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="group"</code>.
+Use with{" "}
+<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">
+Select.GroupLabel
+</code>{" "}
+to provide a visible heading.
 
 ### Select.GroupLabel
 
-
 A visible heading for a{" "}
-  <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
-  Automatically associated with its parent group for accessibility.
-
+<code class="rounded bg-kumo-control px-1 py-0.5 text-sm">Select.Group</code>.
+Automatically associated with its parent group for accessibility.
 
 ### Select.Separator
-
 
 A visual divider line between option groups. Renders with <code class="rounded bg-kumo-control px-1 py-0.5 text-sm">role="separator"</code>.
 

--- a/packages/kumo-svelte/src/routes/components/toolbar/+page.md
+++ b/packages/kumo-svelte/src/routes/components/toolbar/+page.md
@@ -37,7 +37,7 @@ import { Toolbar } from "kumo-svelte/components/toolbar";
 ## Usage
 
 Use `Toolbar` when multiple controls should read as one compact toolbar or
-filter card. Use `Toolbar.Button`, `Toolbar.Input`, and `Toolbar.InputGroup` to
+filter card. Use `Toolbar.Button`, `Toolbar.Link`, `Toolbar.Input`, and `Toolbar.InputGroup` to
 opt supported controls into toolbar sizing, button styling, borders, and radii.
 Compose Select and Combobox triggers with those controls through Svelte child
 snippets.
@@ -68,6 +68,7 @@ snippets.
 - Every `Toolbar.*` control uses the `base` size by default.
 - The Toolbar `size` prop remains available for compatibility but is deprecated; omit it for the base size.
 - `Toolbar.Button` always renders with quiet toolbar button styling.
+- `Toolbar.Link` renders a `LinkButton` with quiet toolbar styling and participates in arrow-key navigation.
 - `Toolbar.InputGroup` passes props directly to `InputGroup` with the toolbar `size`.
 - Render `Toolbar.Button` from Select's `trigger` snippet to compose a select trigger.
 - Render `Toolbar.Input` from `Combobox.TriggerInput`'s `child` snippet for an editable combobox.
@@ -124,6 +125,13 @@ consistent.
 
 <ComponentExample demo="ToolbarActionsDemo" />
 
+### Links
+
+Use `Toolbar.Link` for navigation actions. It accepts LinkButton props except
+for `size` and `variant`, which are controlled by the Toolbar.
+
+<ComponentExample demo="ToolbarLinksDemo" />
+
 ### Accessible Labels
 
 Use `aria-label` or `aria-labelledby` for compact toolbar controls that do not
@@ -145,6 +153,10 @@ already at the relevant text boundary.
 ### Toolbar.Button
 
 <PropsTable component="Toolbar.Button" />
+
+### Toolbar.Link
+
+<PropsTable component="Toolbar.Link" />
 
 ### Toolbar.Input
 


### PR DESCRIPTION
Upstream parity port; no linked issue.

## Summary

- port every applicable `@cloudflare/kumo@2.12.0..@cloudflare/kumo@2.13.1` component and docs change as an individual commit
- add unknown-total Pagination and `Toolbar.Link`, plus Select placement controls
- align Dialog, Table, Text, Select, InputGroup, Combobox, Tabs demo, and Tooltip behavior/styling
- migrate `changesets/action` from v1 to v2 so `@changesets/cli` v3 publication output is detected and Git tags/GitHub Releases are created
- keep npm trusted publishing on OIDC while authenticating GitHub Release creation with the ephemeral workflow `GITHUB_TOKEN`

## Upstream audit

Ported product commits: `8f0a1f0`, `8482c50`, `d004940`, `7526a6a`, `4066307`, `f74936f`, `20b7880`, `1ede8bf`, `b094a5a`, `b7f6cd2`, and `7d5241d`. Upstream version, Wrangler, Bonk, and React-specific bundle-reporting commits were audited but are not applicable to the Svelte package.

## Validation

- 715 Svelte files: 0 errors, 0 warnings
- Vitest: 57 files, 428 tests passed
- Oxlint passed
- package build and production docs build passed
- changeset and PR-description validators passed
- browser-verified all affected docs routes; Select popup measured 4px below its trigger with equal width; warmed Toolbar/Table loads had no console or page errors

---

- Reviews
  - [ ] bonk has reviewed the change
  - [ ] automated review not possible because: <!-- explain why -->
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: <!-- describe testing -->
  - [ ] Additional testing not necessary because: <!-- explain why -->